### PR TITLE
Implemented Publisher::isLatched, which until now was dangling.

### DIFF
--- a/clients/cpp/roscpp/src/libros/publisher.cpp
+++ b/clients/cpp/roscpp/src/libros/publisher.cpp
@@ -26,6 +26,7 @@
  */
 
 #include "ros/publisher.h"
+#include "ros/publication.h"
 #include "ros/node_handle.h"
 #include "ros/topic_manager.h"
 
@@ -126,6 +127,23 @@ uint32_t Publisher::getNumSubscribers() const
   }
 
   return 0;
+}
+
+bool Publisher::isLatched() const {
+  PublicationPtr publication_ptr;
+  if (impl_ && impl_->isValid()) {
+    publication_ptr =
+      TopicManager::instance()->lookupPublication(impl_->topic_);
+  } else {
+    ROS_ASSERT_MSG(false, "Call to isLatched() on an invalid Publisher");
+    throw ros::Exception("Call to isLatched() on an invalid Publisher");
+  }
+  if (publication_ptr) {
+    return publication_ptr->isLatched();
+  } else {
+    ROS_ASSERT_MSG(false, "Call to isLatched() on an invalid Publisher");
+    throw ros::Exception("Call to isLatched() on an invalid Publisher");
+  }
 }
 
 } // namespace ros


### PR DESCRIPTION
Implemented Publisher::isLatched, which until now was dangling.

See: https://code.ros.org/trac/ros/ticket/4038

This is the example which exposes the bug:

https://github.com/wjwwood/ros_comm/zipball/is_latched_bug

The pull request fixes the problem, but I have not added tests, nor have I run the ros_comm tests, yet.

Thanks to Michael Carroll for reporting this.
