### PR TITLE
Add the --duration and --split flags to the python wrapper for rosbag.

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -108,10 +108,8 @@ def record_cmd(argv):
         if not options.duration and not options.size:
             parser.error("Split specified without giving a maximum duration or size")
         cmd.extend(["--split"])
-        if options.duration:
-            cmd.extend(["--duration", options.duration])
-        if options.size:
-            cmd.extend(["--size", str(options.size)])
+    if options.duration:    cmd.extend(["--duration", options.duration])
+    if options.size:        cmd.extend(["--size", str(options.size)])
     if options.node:
         cmd.extend(["--node", options.node])
 


### PR DESCRIPTION
Changing so that duration and size flags are recognized through the python command line.

Modification taken from https://code.ros.org/trac/ros/ticket/3810

Quote:
[moved from  https://code.ros.org/trac/ros-pkg/ticket/5335]

Currently rosbag record doesn't support --duration argument (it ignores it).

It would be useful to have such feature, in particular to record multiple topics for a given time, since -l (number of messages) is not useful in such case (it records the same number of messages for each topic).

This affects to ros-electric, as well as previous version (at least, diamondback).
