### PR TITLE
Fixes a compile error on OS X due the symbol MSG_NOSIGNAL not being defined on OS X.

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -51,6 +51,13 @@ extern "C" {
 
 #endif // MAKEDEPEND
 
+// MSG_NOSIGNAL does not exists on OS X
+#if defined(__APPLE__) || defined(__MACH__)
+# ifndef MSG_NOSIGNAL
+#   define MSG_NOSIGNAL SO_NOSIGPIPE
+# endif
+#endif
+
 
 using namespace XmlRpc;
 


### PR DESCRIPTION
Fixes a compile error on OS X due the symbol MSG_NOSIGNAL not being defined on OS X.

When I try to compile ros_comm on OS X 10.7.4 I get:

```
Scanning dependencies of target xmlrpcpp
[ 10%] Building CXX object ros_comm/utilities/xmlrpcpp/CMakeFiles/xmlrpcpp.dir/src/XmlRpcClient.cpp.o
[ 10%] Building CXX object ros_comm/utilities/xmlrpcpp/CMakeFiles/xmlrpcpp.dir/src/XmlRpcDispatch.cpp.o
[ 10%] Building CXX object ros_comm/utilities/xmlrpcpp/CMakeFiles/xmlrpcpp.dir/src/XmlRpcServer.cpp.o
[ 10%] Building CXX object ros_comm/utilities/xmlrpcpp/CMakeFiles/xmlrpcpp.dir/src/XmlRpcServerConnection.cpp.o
[ 10%] Building CXX object ros_comm/utilities/xmlrpcpp/CMakeFiles/xmlrpcpp.dir/src/XmlRpcServerMethod.cpp.o
[ 10%] Building CXX object ros_comm/utilities/xmlrpcpp/CMakeFiles/xmlrpcpp.dir/src/XmlRpcSocket.cpp.o
/Users/william/ros-underlay/ros_comm/utilities/xmlrpcpp/src/XmlRpcSocket.cpp:268:36: error: use of undeclared identifier 'MSG_NOSIGNAL'
    int n = send(fd, sp, nToWrite, MSG_NOSIGNAL);
                                   ^
1 error generated.
make[2]: *** [ros_comm/utilities/xmlrpcpp/CMakeFiles/xmlrpcpp.dir/src/XmlRpcSocket.cpp.o] Error 1
make[1]: *** [ros_comm/utilities/xmlrpcpp/CMakeFiles/xmlrpcpp.dir/all] Error 2
make: *** [all] Error 2
```

This pull request fixes the problem by defining the symbol MSG_NOSIGNAL on OS X to an appropriate alternative define.  See: http://lists.apple.com/archives/macnetworkprog/2002/Dec/msg00091.html
