### PR TITLE
Fix for Python threading error message bug.

### DIFF
--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -37,6 +37,13 @@ import logging
 import sys
 import traceback
 
+##### monkey-patch to suppress threading error message in python 2.7.3
+##### See http://stackoverflow.com/questions/13193278/understand-python-threading-bug
+if sys.version_info[:3] == (2, 7, 3):
+    import threading
+    threading._DummyThread._Thread__stop = lambda x: 42
+#####
+
 import rospkg
 
 from . import core as roslaunch_core


### PR DESCRIPTION
This is a small patch to roslaunch/**init**.py which suppresses the message:

Exception AttributeError: AttributeError("'_DummyThread' object has no attribute '_Thread__block'",) in <module 'threading' from '/usr/lib/python2.7/threading.pyc'> ignored

which Python 2.7.3 prints when using roslaunch.

See http://stackoverflow.com/questions/13193278/understand-python-threading-bug for details on the bug and this fix.

I know the "right" thing to do is wait for the Python people or the Ubuntu people to do another release, since it is already fixed in the Python source upstream, but who knows how long that will be.  In the meantime the error message happens so frequently that it makes it hard to see where our real errors occur.
