### PR TITLE
Pass along LOG4CXX include dirs and libraries

### DIFF
--- a/tools/rosconsole/CMakeLists.txt
+++ b/tools/rosconsole/CMakeLists.txt
@@ -1,14 +1,27 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosconsole)
+
 find_package(catkin REQUIRED COMPONENTS cpp_common rostime rosunit)
+
+find_package(Log4cxx QUIET)
+if(NOT LOG4CXX_LIBRARIES)
+  # backup plan, hope it is in the system path
+  find_library(LOG4CXX_LIBRARIES log4cxx)
+endif()
+if(NOT LOG4CXX_LIBRARIES)
+  message(FATAL_ERROR "Couldn't find log4cxx library")
+endif()
+
+find_package(Boost COMPONENTS regex thread)
+
+include(cmake/rosconsole-extras.cmake)
+
 catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES rosconsole
+  INCLUDE_DIRS include ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}
+  LIBRARIES rosconsole ${Boost_LIBRARIES} ${LOG4CXX_LIBRARIES}
   CATKIN_DEPENDS cpp_common rostime
   CFG_EXTRAS rosconsole-extras.cmake
 )
-
-include(cmake/rosconsole-extras.cmake)
 
 # See ticket: https://code.ros.org/trac/ros/ticket/3626
 # On mac use g++-4.2
@@ -23,20 +36,9 @@ ENDIF(${CMAKE_SYSTEM} MATCHES "Darwin-11.*")
 
 include_directories(${catkin_INCLUDE_DIRS})
 
-find_package(Boost COMPONENTS regex thread)
-
-include_directories(include ${Boost_INCLUDE_DIR})
+include_directories(include ${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS})
 
 add_library(rosconsole src/rosconsole/rosconsole.cpp)
-
-find_package(Log4cxx QUIET)
-if(NOT LOG4CXX_LIBRARIES)
-  # backup plan, hope it is in the system path
-  find_library(LOG4CXX_LIBRARIES log4cxx)
-endif()
-if(NOT LOG4CXX_LIBRARIES)
-  message(FATAL_ERROR "Couldn't find log4cxx library")
-endif()
 
 target_link_libraries(rosconsole ${catkin_LIBRARIES} ${LOG4CXX_LIBRARIES} ${Boost_LIBRARIES})
 


### PR DESCRIPTION
When building `roscpp` on OS X I get:

```
==> Processing catkin package: 'roscpp'
==> Building with env: '/Users/william/ros_catkin_ws/install_isolated/env_cached.sh'
Makefile exists, skipping explicit cmake invocation...
==> make cmake_check_build_system in '/Users/william/ros_catkin_ws/build_isolated/roscpp'
==> make -j4 in '/Users/william/ros_catkin_ws/build_isolated/roscpp'
Scanning dependencies of target roscpp_genpy
Scanning dependencies of target roscpp_genlisp
[  6%] [  8%] [  6%] [ 11%] Built target roscpp_gencpp
Generating Python code from SRV roscpp/Empty
Generating Lisp code from roscpp/Logger.msg
Generating Python from MSG roscpp/Logger
[ 15%] [ 15%] [ 16%] Generating Lisp code from roscpp/Empty.srv
Generating Python code from SRV roscpp/GetLoggers
Generating Python code from SRV roscpp/SetLoggerLevel
[ 18%] [ 20%] [ 21%] Generating Lisp code from roscpp/GetLoggers.srv
Generating Python msg __init__.py for roscpp
Generating Lisp code from roscpp/SetLoggerLevel.srv
[ 23%] [ 23%] Built target roscpp_genlisp
Generating Python srv __init__.py for roscpp
[ 23%] Built target roscpp_genpy
[ 26%] [ 26%] [ 28%] [ 30%] Building CXX object CMakeFiles/roscpp.dir/src/libros/names.cpp.o
Building CXX object CMakeFiles/roscpp.dir/src/libros/topic.cpp.o
Building CXX object CMakeFiles/roscpp.dir/src/libros/topic_manager.cpp.o
Building CXX object CMakeFiles/roscpp.dir/src/libros/poll_manager.cpp.o
[ 31%] Building CXX object CMakeFiles/roscpp.dir/src/libros/publication.cpp.o
[ 33%] Building CXX object CMakeFiles/roscpp.dir/src/libros/intraprocess_subscriber_link.cpp.o
[ 35%] Building CXX object CMakeFiles/roscpp.dir/src/libros/intraprocess_publisher_link.cpp.o
[ 36%] Building CXX object CMakeFiles/roscpp.dir/src/libros/callback_queue.cpp.o
[ 38%] Building CXX object CMakeFiles/roscpp.dir/src/libros/service_server_link.cpp.o
[ 40%] Building CXX object CMakeFiles/roscpp.dir/src/libros/service_client.cpp.o
[ 41%] Building CXX object CMakeFiles/roscpp.dir/src/libros/node_handle.cpp.o
[ 43%] Building CXX object CMakeFiles/roscpp.dir/src/libros/connection_manager.cpp.o
[ 45%] Building CXX object CMakeFiles/roscpp.dir/src/libros/file_log.cpp.o
[ 46%] Building CXX object CMakeFiles/roscpp.dir/src/libros/transport/transport_udp.cpp.o
[ 48%] Building CXX object CMakeFiles/roscpp.dir/src/libros/transport/transport_tcp.cpp.o
[ 50%] Building CXX object CMakeFiles/roscpp.dir/src/libros/subscriber_link.cpp.o
[ 51%] Building CXX object CMakeFiles/roscpp.dir/src/libros/service_client_link.cpp.o
[ 53%] Building CXX object CMakeFiles/roscpp.dir/src/libros/transport_publisher_link.cpp.o
[ 55%] Building CXX object CMakeFiles/roscpp.dir/src/libros/transport_subscriber_link.cpp.o
[ 56%] Building CXX object CMakeFiles/roscpp.dir/src/libros/service_manager.cpp.o
[ 58%] Building CXX object CMakeFiles/roscpp.dir/src/libros/rosout_appender.cpp.o
[ 60%] Building CXX object CMakeFiles/roscpp.dir/src/libros/init.cpp.o
[ 61%] Building CXX object CMakeFiles/roscpp.dir/src/libros/subscription.cpp.o
[ 63%] Building CXX object CMakeFiles/roscpp.dir/src/libros/subscription_queue.cpp.o
[ 65%] Building CXX object CMakeFiles/roscpp.dir/src/libros/spinner.cpp.o
[ 66%] Building CXX object CMakeFiles/roscpp.dir/src/libros/internal_timer_manager.cpp.o
[ 68%] [ 70%] Building CXX object CMakeFiles/roscpp.dir/src/libros/message_deserializer.cpp.o
Building CXX object CMakeFiles/roscpp.dir/src/libros/header.cpp.o
[ 71%] Building CXX object CMakeFiles/roscpp.dir/src/libros/poll_set.cpp.o
[ 73%] Building CXX object CMakeFiles/roscpp.dir/src/libros/service.cpp.o
[ 75%] Building CXX object CMakeFiles/roscpp.dir/src/libros/this_node.cpp.o
Linking CXX shared library /Users/william/ros_catkin_ws/devel_isolated/roscpp/lib/libroscpp.dylib
Undefined symbols for architecture x86_64:
  "log4cxx::AppenderSkeleton::clearFilters()", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::AppenderSkeleton::doAppend(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&)", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::AppenderSkeleton::addFilter(log4cxx::helpers::ObjectPtrT<log4cxx::spi::Filter> const&)", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::AppenderSkeleton::setOption(std::string const&, std::string const&)", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::AppenderSkeleton::AppenderSkeleton()", referenced from:
      ros::ROSOutAppender::ROSOutAppender() in rosout_appender.cpp.o
      ros::ROSOutAppender::ROSOutAppender() in rosout_appender.cpp.o
  "log4cxx::spi::OptionHandler::getStaticClass()", referenced from:
      log4cxx::AppenderSkeleton::cast(log4cxx::helpers::Class const&) const in rosout_appender.cpp.o
  "log4cxx::Level::getInfo()", referenced from:
      ros::ROSOutAppender::append(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&) in rosout_appender.cpp.o
      ros::setLoggerLevel(roscpp::SetLoggerLevelRequest_<std::allocator<void> >&, roscpp::SetLoggerLevelResponse_<std::allocator<void> >&) in init.cpp.o
  "log4cxx::Level::getWarn()", referenced from:
      ros::ROSOutAppender::append(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&) in rosout_appender.cpp.o
      ros::setLoggerLevel(roscpp::SetLoggerLevelRequest_<std::allocator<void> >&, roscpp::SetLoggerLevelResponse_<std::allocator<void> >&) in init.cpp.o
  "log4cxx::Level::getDebug()", referenced from:
      ros::ROSOutAppender::append(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&) in rosout_appender.cpp.o
      ros::setLoggerLevel(roscpp::SetLoggerLevelRequest_<std::allocator<void> >&, roscpp::SetLoggerLevelResponse_<std::allocator<void> >&) in init.cpp.o
  "log4cxx::Level::getError()", referenced from:
      ros::ROSOutAppender::append(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&) in rosout_appender.cpp.o
      ros::setLoggerLevel(roscpp::SetLoggerLevelRequest_<std::allocator<void> >&, roscpp::SetLoggerLevelResponse_<std::allocator<void> >&) in init.cpp.o
  "log4cxx::Level::getFatal()", referenced from:
      ros::ROSOutAppender::append(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&) in rosout_appender.cpp.o
      ros::setLoggerLevel(roscpp::SetLoggerLevelRequest_<std::allocator<void> >&, roscpp::SetLoggerLevelResponse_<std::allocator<void> >&) in init.cpp.o
  "log4cxx::Logger::getRootLogger()", referenced from:
      ros::shutdown() in init.cpp.o
  "log4cxx::Logger::getLogger(char const*)", referenced from:
      ros::shutdown() in init.cpp.o
      ros::getLoggers(roscpp::GetLoggersRequest_<std::allocator<void> >&, roscpp::GetLoggersResponse_<std::allocator<void> >&) in init.cpp.o
      ros::start() in init.cpp.o
  "log4cxx::Logger::getLogger(std::string const&)", referenced from:
      ros::setLoggerLevel(roscpp::SetLoggerLevelRequest_<std::allocator<void> >&, roscpp::SetLoggerLevelResponse_<std::allocator<void> >&) in init.cpp.o
  "log4cxx::helpers::ObjectImpl::ObjectImpl()", referenced from:
      ros::ROSOutAppender::ROSOutAppender() in rosout_appender.cpp.o
  "log4cxx::helpers::ObjectImpl::~ObjectImpl()", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::helpers::ObjectImpl::~ObjectImpl()", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::helpers::ObjectImpl::~ObjectImpl()", referenced from:
      ros::ROSOutAppender::ROSOutAppender() in rosout_appender.cpp.o
      ros::ROSOutAppender::~ROSOutAppender() in rosout_appender.cpp.o
      log4cxx::AppenderSkeleton::~AppenderSkeleton() in rosout_appender.cpp.o
  "log4cxx::helpers::ObjectPtrBase::exchange(void**, void*)", referenced from:
      log4cxx::helpers::ObjectPtrT<log4cxx::Layout>::exchange(log4cxx::Layout const*) in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<ros::ROSOutAppender>::exchange(ros::ROSOutAppender const*) in init.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::Level>::exchange(log4cxx::Level const*) in init.cpp.o
  "log4cxx::helpers::ObjectPtrBase::checkNull(int const&)", referenced from:
      log4cxx::helpers::ObjectPtrT<ros::ROSOutAppender>::operator=(int const&) in init.cpp.o
  "log4cxx::helpers::ObjectPtrBase::ObjectPtrBase()", referenced from:
      log4cxx::helpers::ObjectPtrT<log4cxx::Logger>::ObjectPtrT() in file_log.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::Layout>::ObjectPtrT(log4cxx::helpers::ObjectPtrT<log4cxx::Layout> const&) in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::spi::Filter>::ObjectPtrT(log4cxx::helpers::ObjectPtrT<log4cxx::spi::Filter> const&) in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::Appender>::ObjectPtrT(log4cxx::helpers::ObjectPtrBase&) in init.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::Level>::ObjectPtrT() in init.cpp.o
      log4cxx::helpers::ObjectPtrT<ros::ROSOutAppender>::ObjectPtrT() in init.cpp.o
  "log4cxx::helpers::ObjectPtrBase::~ObjectPtrBase()", referenced from:
      log4cxx::helpers::ObjectPtrT<log4cxx::Logger>::~ObjectPtrT() in file_log.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::Level>::~ObjectPtrT() in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::Layout>::ObjectPtrT(log4cxx::helpers::ObjectPtrT<log4cxx::Layout> const&) in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::Layout>::~ObjectPtrT() in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::spi::Filter>::ObjectPtrT(log4cxx::helpers::ObjectPtrT<log4cxx::spi::Filter> const&) in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::spi::Filter>::~ObjectPtrT() in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::spi::ErrorHandler>::~ObjectPtrT() in rosout_appender.cpp.o
      ...
  "log4cxx::helpers::Pool::~Pool()", referenced from:
      log4cxx::AppenderSkeleton::~AppenderSkeleton() in rosout_appender.cpp.o
  "log4cxx::helpers::Mutex::~Mutex()", referenced from:
      log4cxx::AppenderSkeleton::~AppenderSkeleton() in rosout_appender.cpp.o
  "log4cxx::helpers::Object::getStaticClass()", referenced from:
      log4cxx::AppenderSkeleton::cast(log4cxx::helpers::Class const&) const in rosout_appender.cpp.o
  "log4cxx::Appender::getStaticClass()", referenced from:
      log4cxx::AppenderSkeleton::cast(log4cxx::helpers::Class const&) const in rosout_appender.cpp.o
      log4cxx::helpers::ObjectPtrT<log4cxx::Appender>::ObjectPtrT(log4cxx::helpers::ObjectPtrBase&) in init.cpp.o
  "log4cxx::AppenderSkeleton::releaseRef() const", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::AppenderSkeleton::addRef() const", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::AppenderSkeleton::getClass() const", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::spi::LocationInfo::getFileName() const", referenced from:
      ros::ROSOutAppender::append(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&) in rosout_appender.cpp.o
  "log4cxx::spi::LocationInfo::getLineNumber() const", referenced from:
      ros::ROSOutAppender::append(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&) in rosout_appender.cpp.o
  "log4cxx::spi::LocationInfo::getMethodName() const", referenced from:
      ros::ROSOutAppender::append(log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&, log4cxx::helpers::Pool&) in rosout_appender.cpp.o
  "log4cxx::spi::OptionHandler::getClass() const", referenced from:
      construction vtable for log4cxx::spi::OptionHandler-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::Level::toString() const", referenced from:
      ros::getLoggers(roscpp::GetLoggersRequest_<std::allocator<void> >&, roscpp::GetLoggersResponse_<std::allocator<void> >&) in init.cpp.o
  "log4cxx::Logger::getLoggerRepository() const", referenced from:
      ros::shutdown() in init.cpp.o
      ros::getLoggers(roscpp::GetLoggersRequest_<std::allocator<void> >&, roscpp::GetLoggersResponse_<std::allocator<void> >&) in init.cpp.o
  "log4cxx::helpers::ObjectImpl::releaseRef() const", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::helpers::ObjectImpl::addRef() const", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::helpers::Object::getClass() const", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "log4cxx::Appender::getClass() const", referenced from:
      construction vtable for log4cxx::Appender-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "typeinfo for log4cxx::AppenderSkeleton", referenced from:
      typeinfo for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "typeinfo for log4cxx::spi::OptionHandler", referenced from:
      construction vtable for log4cxx::spi::OptionHandler-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "typeinfo for log4cxx::helpers::ObjectImpl", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "typeinfo for log4cxx::helpers::ObjectPtrBase", referenced from:
      typeinfo for log4cxx::helpers::ObjectPtrT<log4cxx::Logger> in file_log.cpp.o
      typeinfo for log4cxx::helpers::ObjectPtrT<log4cxx::Level> in rosout_appender.cpp.o
      typeinfo for log4cxx::helpers::ObjectPtrT<log4cxx::Layout> in rosout_appender.cpp.o
      typeinfo for log4cxx::helpers::ObjectPtrT<log4cxx::spi::Filter> in rosout_appender.cpp.o
      typeinfo for log4cxx::helpers::ObjectPtrT<log4cxx::spi::ErrorHandler> in rosout_appender.cpp.o
      typeinfo for log4cxx::helpers::ObjectPtrT<log4cxx::Appender> in init.cpp.o
      typeinfo for log4cxx::helpers::ObjectPtrT<log4cxx::Level> in init.cpp.o
      ...
  "typeinfo for log4cxx::Appender", referenced from:
      construction vtable for log4cxx::Appender-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "VTT for log4cxx::AppenderSkeleton", referenced from:
      log4cxx::AppenderSkeleton::~AppenderSkeleton() in rosout_appender.cpp.o
  "VTT for log4cxx::spi::OptionHandler", referenced from:
      log4cxx::spi::OptionHandler::~OptionHandler() in rosout_appender.cpp.o
  "VTT for log4cxx::Appender", referenced from:
      log4cxx::Appender::~Appender() in rosout_appender.cpp.o
  "vtable for log4cxx::helpers::Object", referenced from:
      log4cxx::helpers::Object::Object() in rosout_appender.cpp.o
  NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
  "non-virtual thunk to log4cxx::helpers::ObjectImpl::~ObjectImpl()", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "non-virtual thunk to log4cxx::helpers::ObjectImpl::~ObjectImpl()", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "non-virtual thunk to log4cxx::AppenderSkeleton::addRef() const", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "non-virtual thunk to log4cxx::helpers::ObjectImpl::addRef() const", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "non-virtual thunk to log4cxx::AppenderSkeleton::releaseRef() const", referenced from:
      vtable for ros::ROSOutAppender in rosout_appender.cpp.o
      construction vtable for log4cxx::AppenderSkeleton-in-ros::ROSOutAppender in rosout_appender.cpp.o
  "non-virtual thunk to log4cxx::helpers::ObjectImpl::releaseRef() const", referenced from:
      construction vtable for log4cxx::helpers::ObjectImpl-in-ros::ROSOutAppender in rosout_appender.cpp.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [/Users/william/ros_catkin_ws/devel_isolated/roscpp/lib/libroscpp.dylib] Error 1
make[1]: *** [CMakeFiles/roscpp.dir/all] Error 2
make: *** [all] Error 2

<== Failed to process package 'roscpp': 
  Command '/Users/william/ros_catkin_ws/install_isolated/env_cached.sh make -j4' returned non-zero exit status 2
Command failed, exiting.
```

This comes from rosconsole not passing along LOG4CXX link flags.
