### PR TITLE
Use roslaunch arg resolution in rosparam text

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -207,7 +207,7 @@ class XmlLoader(loader.Loader):
             
             # load is the default command            
             cmd = cmd or 'load'
-            self.load_rosparam(context, ros_config, cmd, param, file, _get_text(tag), verbose=verbose)
+            self.load_rosparam(context, ros_config, cmd, param, file, self.resolve_args(_get_text(tag), context), verbose=verbose)
 
         except ValueError as e:
             raise loader.LoadException("error loading <rosparam> tag: \n\t"+str(e)+"\nXML is %s"%tag.toxml())


### PR DESCRIPTION
Would be very useful to do things like

```
rosparam param="app_lists">$(arg app_lists)</rosparam>
```

or even use `$(find ...)` embedded in the raw yaml. This works for `<param.../>` where the value is a tag attribute.  Obvious advantage with rosparam is to be able to parse lists and dictionaries. Over the last three years I keep running into this and seem to be finding more situations where it's desirable now I'm using args alot more.

The fix here is a simple one-liner. It works, but is there intentionally a reason this wasn't implemented?
