### PR TITLE
incorrect braces in ros::console::vformatToBuffer() causing a memory leak

### DIFF
--- a/tools/rosconsole/src/rosconsole/rosconsole.cpp
+++ b/tools/rosconsole/src/rosconsole/rosconsole.cpp
@@ -510,8 +510,8 @@ void vformatToBuffer(boost::shared_array<char>& buffer, size_t& buffer_size, con
 #else
     vsnprintf(buffer.get(), buffer_size, fmt, arg_copy);
 #endif
-    va_end(arg_copy);
   }
+  va_end(arg_copy);
 }
 
 void formatToBuffer(boost::shared_array<char>& buffer, size_t& buffer_size, const char* fmt, ...)


### PR DESCRIPTION
The vformatToBuffer() function in rosconsole, that parses the format string for the variadic version of the print function, makes a copy of the argument list to be able to resize the buffer and reevaluate for the case the buffer was too small.

I am not very familiar with cstdarg, but I guess the va_end command should come after the closing brace of the if block in [rosconsole.cpp:513](https://github.com/ros/ros_comm/blob/d339a40fca5eda54bcf27b4353e0f9d62c3763d2/tools/rosconsole/src/rosconsole/rosconsole.cpp#L513), so that the memory allocated during the va_copy call gets freed in every case.

As this function is called for every log line that uses the variadic rosconsole macros this bug might cause a severe memory leak, at least for logging intensive applications.
