### PR TITLE
Allow configuration of xml-rpc and tcpros ports

### DIFF
--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -194,7 +194,7 @@ def _init_node_params(argv, node_name):
 
 _init_node_args = None
 
-def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=False, disable_rosout=False, disable_signals=False):
+def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=False, disable_rosout=False, disable_signals=False, port=0, tcpros_port=0):
     """
     Register client node with the master under the specified name.
     This MUST be called from the main Python thread unless
@@ -246,6 +246,14 @@ def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=
     @param disable_rosout: for internal testing only: suppress
         auto-publication of rosout
     @type  disable_rostime: bool
+
+    @param port: If provided, it will use this port number for the client
+        XMLRPC node. 
+    @type  port: int
+
+    @param tcpros_port: If provided, the TCPROS server will listen for
+        connections on this port
+    @type  tcpros_port: int
 
     @raise ROSInitException: if initialization/registration fails
     @raise ValueError: if parameters are invalid (e.g. name contains a namespace or is otherwise illegal)
@@ -308,7 +316,7 @@ def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=
     logger.info("init_node, name[%s], pid[%s]", resolved_node_name, os.getpid())
             
     # node initialization blocks until registration with master
-    node = rospy.impl.init.start_node(os.environ, resolved_node_name) 
+    node = rospy.impl.init.start_node(os.environ, resolved_node_name, port=port, tcpros_port=tcpros_port) 
     rospy.core.set_node_uri(node.uri)
     rospy.core.add_shutdown_hook(node.shutdown)    
     

--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -194,7 +194,7 @@ def _init_node_params(argv, node_name):
 
 _init_node_args = None
 
-def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=False, disable_rosout=False, disable_signals=False, port=0, tcpros_port=0):
+def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=False, disable_rosout=False, disable_signals=False, xmlrpc_port=0, tcpros_port=0):
     """
     Register client node with the master under the specified name.
     This MUST be called from the main Python thread unless
@@ -247,9 +247,9 @@ def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=
         auto-publication of rosout
     @type  disable_rostime: bool
 
-    @param port: If provided, it will use this port number for the client
+    @param xmlrpc_port: If provided, it will use this port number for the client
         XMLRPC node. 
-    @type  port: int
+    @type  xmlrpc_port: int
 
     @param tcpros_port: If provided, the TCPROS server will listen for
         connections on this port
@@ -316,7 +316,7 @@ def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=
     logger.info("init_node, name[%s], pid[%s]", resolved_node_name, os.getpid())
             
     # node initialization blocks until registration with master
-    node = rospy.impl.init.start_node(os.environ, resolved_node_name, port=port, tcpros_port=tcpros_port) 
+    node = rospy.impl.init.start_node(os.environ, resolved_node_name, port=xmlrpc_port, tcpros_port=tcpros_port) 
     rospy.core.set_node_uri(node.uri)
     rospy.core.add_shutdown_hook(node.shutdown)    
     

--- a/clients/rospy/src/rospy/impl/init.py
+++ b/clients/rospy/src/rospy/impl/init.py
@@ -68,7 +68,7 @@ def _node_run_error(e):
     rospyerr(traceback.format_exc())
     signal_shutdown('error in XML-RPC server: %s'%(e))
 
-def start_node(environ, resolved_name, master_uri=None, port=None):
+def start_node(environ, resolved_name, master_uri=None, port=0, tcpros_port=0):
     """
     Load ROS slave node, initialize from environment variables
     @param environ: environment variables
@@ -79,11 +79,13 @@ def start_node(environ, resolved_name, master_uri=None, port=None):
     @type  master_uri: str
     @param port: override ROS_PORT: port of slave xml-rpc node
     @type  port: int
+    @param tcpros_port: override the port of the TCP server
+    @type  tcpros_port: int
     @return: node server instance
     @rtype rosgraph.xmlrpc.XmlRpcNode
     @raise ROSInitException: if node has already been started
     """
-    init_tcpros()
+    init_tcpros(tcpros_port)
     if not master_uri:
         master_uri = rosgraph.get_master_uri()
     if not master_uri:

--- a/clients/rospy/src/rospy/impl/tcpros.py
+++ b/clients/rospy/src/rospy/impl/tcpros.py
@@ -49,8 +49,12 @@ from rospy.impl.tcpros_pubsub import TCPROSHandler
 
 _handler = TCPROSHandler()
 
-def init_tcpros():
-    server = init_tcpros_server()
+def init_tcpros(port=0):
+    """
+    @param tcpros_port: override the port of the TCP server
+    @type  tcpros_port: int
+    """
+    server = init_tcpros_server(port)
     server.topic_connection_handler = _handler.topic_connection_handler
     server.service_connection_handler = rospy.impl.tcpros_service.service_connection_handler
 


### PR DESCRIPTION
This update to rospy surfaces the 'port' variables for the slave xml-rpc node and the tcpros server as optional parameters to rospy.init_node.

You can use them by initializing rospy as follows:

```
rospy.init_node(NODE_NAME,port=1234,tcpros_port=5678)
```

This enables the possibility of running a ROS node behind a firewall without the need of a VPN - only these two ports need to be configured as forwards in the firewall
