### PR TITLE
Refine license description of xmlrpcpp to LGPL-2.1

### DIFF
--- a/utilities/xmlrpcpp/package.xml
+++ b/utilities/xmlrpcpp/package.xml
@@ -8,7 +8,7 @@
     own fork.
   </description>
   <maintainer email="dthomas@willowgarage.com">Dirk Thomas</maintainer>
-  <license>LGPL</license>
+  <license>LGPL-2.1</license>
 
   <url>http://xmlrpcpp.sourceforge.net</url>
   <author>Chris Morley</author>


### PR DESCRIPTION
For industrial applications, it is critical that the version of the LGPL license is provided. The XmlRpc++ implementation is licensed LGPL version 2.1.
