### PR TITLE
roslaunch fix

### DIFF
--- a/tools/rosservice/CMakeLists.txt
+++ b/tools/rosservice/CMakeLists.txt
@@ -4,3 +4,6 @@ find_package(catkin)
 catkin_package()
 
 catkin_python_setup()
+
+install(PROGRAMS scripts/rosservice
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
This should fix the inability to use rosservice from within a launch file.

Wholly untested, off the top of my head change, but it should at least clearly illustrate the problem for you.
