### PR TITLE
Remove redundant fctl code - now implemented in python

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -45,7 +45,6 @@ The common entry point for most libraries is the L{XmlRpcNode} class.
 import logging
 import select
 import socket
-import fcntl
 
 try:
     import _thread
@@ -109,14 +108,6 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
             self.server_bind()
             self.server_activate()
             logger.info('bound to ' + str(self.socket.getsockname()[0:2]))
-            # TODO IPV6: check Windows compatibility
-            # [Bug #1222790] If possible, set close-on-exec flag; if a
-            # method spawns a subprocess, the subprocess shouldn't have
-            # the listening socket open.
-            if fcntl is not None and hasattr(fcntl, 'FD_CLOEXEC'):
-                flags = fcntl.fcntl(self.fileno(), fcntl.F_GETFD)
-                flags |= fcntl.FD_CLOEXEC
-                fcntl.fcntl(self.fileno(), fcntl.F_SETFD, flags)
         else:
             SimpleXMLRPCServer.__init__(self, addr, SilenceableXMLRPCRequestHandler, log_requests)
 


### PR DESCRIPTION
Had to write an alternative handler because windows doesn't have fcntl. In the result of checking about this, found this is now redundant as it been integrated into python already.
- Bug report on python-bugs: http://bugs.python.org/issue1222790
- Integrated in python: http://hg.python.org/cpython/rev/81c944c3d13a/
- Already in ubuntu precise's python 2.7: `/usr/lib/python2.7/SimpleXMLRPCServer.py`

I'm not sure if the windows python implementation has a similar problem - will look into it later when testing.
