### PR TITLE
Replacing '%' in ipv6 address by '/' to avoid syntax conflict

### DIFF
--- a/utilities/roswtf/src/roswtf/network.py
+++ b/utilities/roswtf/src/roswtf/network.py
@@ -52,8 +52,14 @@ def ip_check(ctx):
     global_ips = [ ip for ip in resolved_ips if not ip.startswith('127.') and not ip == '::1']
 
     remote_ips = list(set(global_ips) - set(local_addrs))
-    if remote_ips:
-        return "Local hostname [%s] resolves to [%s], which does not appear to be a local IP address %s."%(socket.gethostname(), ','.join(remote_ips), str(local_addrs))
+
+    # replace '%' symbol in ipv6 address by '/' to avoid syntax conflict
+    refined_ips = list()
+    for val in remote_ips:
+        refined_ips.append(val.replace('%', '/'))
+        
+    if refined_ips:
+        return "Local hostname [%s] resolves to [%s], which does not appear to be a local IP address %s."%(socket.gethostname(), ','.join(refined_ips), str(local_addrs))
 
 # suggestion by mquigley based on laptop dhcp issues    
 def ros_hostname_check(ctx):


### PR DESCRIPTION
In Windows, roswtf throws the error while checking local network configuration. It comes from  the expression of IPv6. The IPv6 uses a zone index to provide routing information. The zone index is appended to the address, separated by '%'. This notation causes syntax conflict with Python when roswtf deals with it.

This syntax conflict happens when roswtf appends IP address to the context to just show it to user after checking all. The new is to avoid this conflict through replacing '%' in IP addresses by '/'.

PS. For URI, ISOC is finding solution to avoid conflict like here:

http://tools.ietf.org/html/draft-fenner-literal-zone-02
