### PR TITLE
Adding substitution_args support for rosparam tags (yaml-based rosparam)

### DIFF
--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -376,6 +376,9 @@ class Loader(object):
             if file_:
                 with open(file_, 'r') as f:
                     text = f.read()
+
+            # Apply substitution args
+            text = self.resolve_args(text, context)
                     
             # parse YAML text
             # - lazy import

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -355,10 +355,14 @@ class TestXmlLoader(unittest.TestCase):
     def test_node_rosparam_sub_args(self):
         mock = self._load(os.path.join(self.xml_dir, 'test-rosparam-sub-args.xml'))
 
-        # verify that 'param' attribute is not required
+        # verify that subtitutions are happening properly
         with_sub = [p for p in mock.params if p.key == '/with_sub'][0]
         without_sub =  [p for p in mock.params if p.key == '/without_sub'][0]
         self.assertEquals(with_sub.value, without_sub.value)
+
+        # verify that normal BASH-like environment variables aren't replaced
+        shouldnt_sub =  [p for p in mock.params if p.key == '/shouldnt_sub'][0]
+        self.assertEquals(shouldnt_sub.value, '$ROS_ROOT')
 
     def test_node_rosparam(self):
         from roslaunch.core import PHASE_SETUP

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -350,6 +350,16 @@ class TestXmlLoader(unittest.TestCase):
             except roslaunch.xmlloader.XmlParseException, e:
                 pass
 
+        tests = []
+
+    def test_node_rosparam_sub_args(self):
+        mock = self._load(os.path.join(self.xml_dir, 'test-rosparam-sub-args.xml'))
+
+        # verify that 'param' attribute is not required
+        with_sub = [p for p in mock.params if p.key == '/with_sub'][0]
+        without_sub =  [p for p in mock.params if p.key == '/without_sub'][0]
+        self.assertEquals(with_sub.value, without_sub.value)
+
     def test_node_rosparam(self):
         from roslaunch.core import PHASE_SETUP
 

--- a/tools/roslaunch/test/xml/test-rosparam-sub-args.xml
+++ b/tools/roslaunch/test/xml/test-rosparam-sub-args.xml
@@ -1,0 +1,11 @@
+<launch>
+
+  <!-- Test chckes if with_sub == without_sub -->
+  <arg name="my_arg" value="my_value"/>
+  <rosparam>
+    with_sub: $(arg my_arg)
+    without_sub: my_value
+  </rosparam>
+
+</launch>
+

--- a/tools/roslaunch/test/xml/test-rosparam-sub-args.xml
+++ b/tools/roslaunch/test/xml/test-rosparam-sub-args.xml
@@ -7,5 +7,9 @@
     without_sub: my_value
   </rosparam>
 
+  <rosparam>
+    shouldnt_sub: $ROS_ROOT
+  </rosparam>
+
 </launch>
 


### PR DESCRIPTION
Also added a simple unit test.

The substitution happens to the raw text, before it goes into the YAML parser.

This is the feature requested here: https://github.com/ros/ros_comm/issues/101
