### PR TITLE
Patch for missing exception handling when using netifaces in rosgraph/network.py

### DIFF
--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -215,7 +215,7 @@ def get_local_addresses():
             try:
                 v4addrs.extend([addr['addr'] for iface in ifaces if socket.AF_INET in netifaces.ifaddresses(iface) for addr in netifaces.ifaddresses(iface)[socket.AF_INET]])
                 v6addrs.extend([addr['addr'] for iface in ifaces if socket.AF_INET6 in netifaces.ifaddresses(iface) for addr in netifaces.ifaddresses(iface)[socket.AF_INET6]])
-            except: pass
+            except ValueError: pass
 
         if use_ipv6():
             return v6addrs + v4addrs

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -209,8 +209,14 @@ def get_local_addresses():
         # unix-only branch
         import netifaces
         ifaces = netifaces.interfaces()
-        v4addrs = [addr['addr'] for iface in ifaces if socket.AF_INET in netifaces.ifaddresses(iface) for addr in netifaces.ifaddresses(iface)[socket.AF_INET]]
-        v6addrs = [addr['addr'] for iface in ifaces if socket.AF_INET6 in netifaces.ifaddresses(iface) for addr in netifaces.ifaddresses(iface)[socket.AF_INET6]]
+        v4addrs = []
+        v6addrs = []
+        for iface in ifaces:
+            try:
+                v4addrs.extend([addr['addr'] for iface in ifaces if socket.AF_INET in netifaces.ifaddresses(iface) for addr in netifaces.ifaddresses(iface)[socket.AF_INET]])
+                v6addrs.extend([addr['addr'] for iface in ifaces if socket.AF_INET6 in netifaces.ifaddresses(iface) for addr in netifaces.ifaddresses(iface)[socket.AF_INET6]])
+            except: pass
+
         if use_ipv6():
             return v6addrs + v4addrs
         else:

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -213,8 +213,10 @@ def get_local_addresses():
         v6addrs = []
         for iface in ifaces:
             try:
-                v4addrs.extend([addr['addr'] for iface in ifaces if socket.AF_INET in netifaces.ifaddresses(iface) for addr in netifaces.ifaddresses(iface)[socket.AF_INET]])
-                v6addrs.extend([addr['addr'] for iface in ifaces if socket.AF_INET6 in netifaces.ifaddresses(iface) for addr in netifaces.ifaddresses(iface)[socket.AF_INET6]])
+                if socket.AF_INET in netifaces.ifaddresses(iface):
+                    v4addrs.extend([addr['addr'] for addr in netifaces.ifaddresses(iface)[socket.AF_INET]])
+                if socket.AF_INET6 in netifaces.ifaddresses(iface):
+                    v6addrs.extend([addr['addr'] for addr in netifaces.ifaddresses(iface)[socket.AF_INET6]])
             except ValueError: pass
 
         if use_ipv6():


### PR DESCRIPTION
We encountered a small bug when using the current ros_comm version in groovy. When netifaces.ifaddresses(...) is used on one of our CAN bus network interfaces, it throws an unhandled exception. This might actually be the driver's fault, but we cannot do anything about it right now. 

This occurred when roscore was launched, and it meant we couldn't launch anything on our robot. I tracked the source of the problem to a recent addition in rosgraph/network.py, and I simply added some exception handling/ignoring. Similar exception handling was done with netifaces in a different condition a few lines ahead of that addition. Unfortunately, I cannot test the change with many different configurations.
