### PR TITLE
keyword template is unnecessary in signal_.template addCallback()

### DIFF
--- a/utilities/message_filters/include/message_filters/synchronizer.h
+++ b/utilities/message_filters/include/message_filters/synchronizer.h
@@ -301,25 +301,25 @@ public:
   template<class C>
   Connection registerCallback(C& callback)
   {
-    return signal_.template addCallback(callback);
+    return signal_.addCallback(callback);
   }
 
   template<class C>
   Connection registerCallback(const C& callback)
   {
-    return signal_.template addCallback(callback);
+    return signal_.addCallback(callback);
   }
 
   template<class C, typename T>
   Connection registerCallback(const C& callback, T* t)
   {
-    return signal_.template addCallback(callback, t);
+    return signal_.addCallback(callback, t);
   }
 
   template<class C, typename T>
   Connection registerCallback(C& callback, T* t)
   {
-    return signal_.template addCallback(callback, t);
+    return signal_.addCallback(callback, t);
   }
 
   void setName(const std::string& name) { name_ = name; }


### PR DESCRIPTION
the Intel compiler was very picky about this and failed compiling 
