### PR TITLE
revamped roslaunch $(find) stuff

### DIFF
--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -308,6 +308,8 @@ def resolve_args(arg_str, context=None, resolve_anon=True):
         'optenv': _optenv,
         'anon': _anon,
         'arg': _arg,
+        'find-executable': _find_executable,
+        'find-resource': _find_resource,
     }
     resolved = _resolve_args(arg_str, context, resolve_anon, commands)
     # than resolve 'find' as it requires the subsequent path to be expanded already
@@ -318,7 +320,7 @@ def resolve_args(arg_str, context=None, resolve_anon=True):
     return resolved
 
 def _resolve_args(arg_str, context, resolve_anon, commands):
-    valid = ['find', 'env', 'optenv', 'anon', 'arg']
+    valid = ['find', 'find-executable', 'find-resource', 'env', 'optenv', 'anon', 'arg']
     resolved = arg_str
     for a in _collect_args(arg_str):
         splits = [s for s in a.split(' ') if s]


### PR DESCRIPTION
- modified roslaunch $(find PKG) to consider path after it for resolve strategy
- add separate commands:
  - $(find-executable PKG PATH)
  - $(find-share PKG PATH)
  - $(find-share-devel PKG)
  - $(find-share-source PKG)

Update - the following commands have been removed again:
- $(find-share-devel PKG)
- $(find-share-source PKG)

Update - the following command has been renamed:
- $(find-share PKG PATH) -> $(find-resource PKG PATH)

Update:
- Since #233 has been merged which only affects the $(find) command, I have updated this pull request to only contain:
  - $(find-executable PKG PATH)
  - $(find-resource PKG PATH)
