### PR TITLE
Fix crash for bag migration

### DIFF
--- a/tools/rosbag/src/rosbag/migration.py
+++ b/tools/rosbag/src/rosbag/migration.py
@@ -763,7 +763,7 @@ class MessageMigrator(object):
                     rulechain.chain[otherind].location, r.location, r.old_type, r.location)
                 return
             else:
-                if rulechain.rename and (r.order >= rulechain.chain[-1]):
+                if rulechain.rename and (r.order >= rulechain.rename.order):
                     print >> sys.stderr, "WARNING: Update rule [%s] has order number larger than rename rule [%s]. Ignoring"%(
                         r.location, rulechain.rename.location)
                     return


### PR DESCRIPTION
This appears to be a copy and paste error. You should check the
rename rule order and not the last element of the list.
