### PR TITLE
CRITICAL BUG: proper escaping for ROS_PACKAGE_NAME definition

### DIFF
--- a/tools/rosconsole/cmake/rosconsole-extras.cmake
+++ b/tools/rosconsole/cmake/rosconsole-extras.cmake
@@ -1,4 +1,4 @@
 # ros_comm/tools/rosconsole/cmake/rosconsole-extras.cmake
 
 # add ROS_PACKAGE_NAME define required by the named logging macros
-add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")
+add_definitions(-DROS_PACKAGE_NAME="\\"${PROJECT_NAME}\\"")


### PR DESCRIPTION
Without this, sometimes this ends up as (for a packange named `foo_pkg`):
`-DROS_PACKAGE_NAME="foo_pkg"`

Which breaks everything, since on the command line this needs to be the following so that the quotes end up in the variable:
`-DROS_PACKAGE_NAME=\"foo_pkg\"`

See this cmake thread here: http://www.cmake.org/pipermail/cmake/2007-June/014611.html

It looks like the [old rosbuild method](http://www.ros.org/wiki/rosbuild#ROS_.23defines) used to use single quotes:
`ROS_PACKAGE_NAME='"foo"'`
