### PR TITLE
Adding explicit cmake policy to rosconsole-extras.cmake

### DIFF
--- a/tools/rosconsole/cmake/rosconsole-extras.cmake
+++ b/tools/rosconsole/cmake/rosconsole-extras.cmake
@@ -1,4 +1,5 @@
 # ros_comm/tools/rosconsole/cmake/rosconsole-extras.cmake
+cmake_policy(VERSION 2.8.3)
 
 # add ROS_PACKAGE_NAME define required by the named logging macros
 add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")


### PR DESCRIPTION
I don't know if this jives with the philosophy with the catkin/ros_comm maintainers but adding this to the `rosconsole-extras.cmake` prevents the user error (incorrect camke_minimum_required version) reported in https://github.com/ros/ros_comm/pull/245 from preventing packages to build. This `cmake_policty()` command should be local to this file only. I chose `cmake_policy()` instead of `cmake_minimum_required()` due to it's clearer meaning.

See the follwoing for reference: http://www.cmake.org/Wiki/CMake/Policies#Fixing_an_Interface_Breaks_Work-Arounds
