### PR TITLE
Catch exceptions when computing roslaunch dependencies.

### DIFF
--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -195,7 +195,12 @@ def check_roslaunch(f):
     
     errors = []
     # check for missing deps
-    base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f])
+    try:
+        base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f])
+    except Exception as e:
+        errors.append("Error resolving dependencies in %s: %s"%(f, str(e)))
+        missing = {}
+        file_deps = {}
     for pkg, miss in missing.iteritems():
         if miss:
             errors.append("Missing manifest dependencies: %s/manifest.xml: %s"%(pkg, ', '.join(miss)))


### PR DESCRIPTION
It's possible for the dependency calculation to throw exceptions if arguments don't exist, and possibly in other cases as well. Catch them and attempt to proceed.
