### PR TITLE
Fix arg parsing when computing dependencies in roslaunch-check

### DIFF
--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -195,7 +195,16 @@ def check_roslaunch(f):
     
     errors = []
     # check for missing deps
-    base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f])
+    try:
+        base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f])
+    except rospkg.common.ResourceNotFound as r:
+        errors.append("Could not find package: %s included from %s"%(str(r), f))
+        missing = {}
+        file_deps = {}
+    except roslaunch.substitution_args.ArgException as e:
+        errors.append("Could not resolve arg %s in %s"%(str(e), f))
+        missing = {}
+        file_deps = {}
     for pkg, miss in missing.iteritems():
         if miss:
             errors.append("Missing manifest dependencies: %s/manifest.xml: %s"%(pkg, ', '.join(miss)))


### PR DESCRIPTION
parse_launch in depends.py isn't building up a context before evaluating args, so any `include`, `node` or `test` tags that reference an arg will fail.

This causes roslaunch-check to crash when parsing complex launch files such as https://github.com/ros-interactive-manipulation/pr2_object_manipulation/blob/groovy-devel/manipulation/pr2_object_manipulation_launch/launch/laser%2Bstereo-perception.launch
