### PR TITLE
roscpp: Adding std::vector and std::map rosparam sets/gets

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -1384,20 +1384,92 @@ if (handle)
    * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
    */
   void setParam(const std::string& key, double d) const;
-  /** \brief Set a integer value on the parameter server.
+  /** \brief Set an integer value on the parameter server.
    *
    * \param key The key to be used in the parameter server's dictionary
    * \param i The value to be inserted.
    * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
    */
   void setParam(const std::string& key, int i) const;
-  /** \brief Set a integer value on the parameter server.
+  /** \brief Set a boolean value on the parameter server.
    *
    * \param key The key to be used in the parameter server's dictionary
    * \param b The value to be inserted.
    * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
    */
   void setParam(const std::string& key, bool b) const;
+
+  /** \brief Set a string vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param vec The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::vector<std::string>& vec) const;
+  /** \brief Set a double vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param vec The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::vector<double>& vec) const;
+  /** \brief Set a float vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param vec The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::vector<float>& vec) const;
+  /** \brief Set a int vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param vec The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::vector<int>& vec) const;
+  /** \brief Set a bool vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param vec The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::vector<bool>& vec) const;
+
+  /** \brief Set a string vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param map The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::map<std::string, std::string>& map) const;
+  /** \brief Set a double vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param map The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::map<std::string, double>& map) const;
+  /** \brief Set a float vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param map The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::map<std::string, float>& map) const;
+  /** \brief Set a int vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param map The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::map<std::string, int>& map) const;
+  /** \brief Set a bool vector value on the parameter server.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param map The value to be inserted.
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  void setParam(const std::string& key, const std::map<std::string, bool>& map) const;
 
   /** \brief Get a string value from the parameter server.
    *
@@ -1419,7 +1491,7 @@ if (handle)
    * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
    */
   bool getParam(const std::string& key, double& d) const;
-  /** \brief Get a integer value from the parameter server.
+  /** \brief Get an integer value from the parameter server.
    *
    * If you want to provide a default value in case the key does not exist use param().
    *
@@ -1453,6 +1525,118 @@ if (handle)
    */
   bool getParam(const std::string& key, XmlRpc::XmlRpcValue& v) const;
 
+  /** \brief Get a string vector value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::vector<std::string>& vec) const;
+  /** \brief Get a double vector value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::vector<double>& vec) const;
+  /** \brief Get a float vector value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::vector<float>& vec) const;
+  /** \brief Get an int vector value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::vector<int>& vec) const;
+  /** \brief Get a boolean vector value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::vector<bool>& vec) const;
+
+  /** \brief Get a string map value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::map<std::string, std::string>& map) const;
+  /** \brief Get a double map value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::map<std::string, double>& map) const;
+  /** \brief Get a float map value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::map<std::string, float>& map) const;
+  /** \brief Get an int map value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::map<std::string, int>& map) const;
+  /** \brief Get a boolean map value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, std::map<std::string, bool>& map) const;
+
   /** \brief Get a string value from the parameter server, with local caching
    *
    * If you want to provide a default value in case the key does not exist use param().
@@ -1483,7 +1667,21 @@ if (handle)
    * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
    */
   bool getParamCached(const std::string& key, double& d) const;
-  /** \brief Get a integer value from the parameter server, with local caching
+  /** \brief Get a float value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] f Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, float& f) const;
+  /** \brief Get an integer value from the parameter server, with local caching
    *
    * This method will cache parameters locally, and subscribe for updates from
    * the parameter server.  Once the parameter is retrieved for the first time
@@ -1525,6 +1723,148 @@ if (handle)
    * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
    */
   bool getParamCached(const std::string& key, XmlRpc::XmlRpcValue& v) const;
+
+  /** \brief Get a std::string vector value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::vector<std::string>& vec) const;
+  /** \brief Get a double vector value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::vector<double>& vec) const;
+  /** \brief Get a float vector value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::vector<float>& vec) const;
+  /** \brief Get a int vector value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::vector<int>& vec) const;
+  /** \brief Get a bool vector value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] vec Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::vector<bool>& vec) const;
+
+  /** \brief Get a string->std::string map value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::map<std::string, std::string>& map) const;
+  /** \brief Get a string->double map value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::map<std::string, double>& map) const;
+  /** \brief Get a string->float map value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::map<std::string, float>& map) const;
+  /** \brief Get a string->int map value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::map<std::string, int>& map) const;
+  /** \brief Get a string->bool map value from the parameter server, with local caching
+   *
+   * This method will cache parameters locally, and subscribe for updates from
+   * the parameter server.  Once the parameter is retrieved for the first time
+   * no subsequent getCached() calls with the same key will query the master --
+   * they will instead look up in the local cache.
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] map Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParamCached(const std::string& key, std::map<std::string, bool>& map) const;
 
   /** \brief Check whether a parameter exists on the parameter server.
    *

--- a/clients/roscpp/include/ros/param.h
+++ b/clients/roscpp/include/ros/param.h
@@ -32,6 +32,9 @@
 #include "common.h"
 #include "XmlRpcValue.h"
 
+#include <vector>
+#include <map>
+
 namespace ros
 {
 
@@ -69,20 +72,94 @@ ROSCPP_DECL void set(const std::string& key, const char* s);
  * \throws InvalidNameException if the key is not a valid graph resource name
  */
 ROSCPP_DECL void set(const std::string& key, double d);
-/** \brief Set a integer value on the parameter server.
+/** \brief Set an integer value on the parameter server.
  *
  * \param key The key to be used in the parameter server's dictionary
  * \param i The value to be inserted.
  * \throws InvalidNameException if the key is not a valid graph resource name
  */
 ROSCPP_DECL void set(const std::string& key, int i);
-/** \brief Set a integer value on the parameter server.
+/** \brief Set a bool value on the parameter server.
  *
  * \param key The key to be used in the parameter server's dictionary
  * \param b The value to be inserted.
  * \throws InvalidNameException if the key is not a valid graph resource name
  */
 ROSCPP_DECL void set(const std::string& key, bool b);
+
+
+/** \brief Set a string vector value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param vec The vector value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::vector<std::string>& vec);
+/** \brief Set a double vector value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param vec The vector value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::vector<double>& vec);
+/** \brief Set a float vector value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param vec The vector value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::vector<float>& vec);
+/** \brief Set an integer  vector value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param vec The vector value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::vector<int>& vec);
+/** \brief Set a bool vector value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param vec The vector value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::vector<bool>& vec);
+
+/** \brief Set a string->string map value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param map The map value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::map<std::string, std::string>& map);
+/** \brief Set a string->double map value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param map The map value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::map<std::string, double>& map);
+/** \brief Set a string->float map value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param map The map value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::map<std::string, float>& map);
+/** \brief Set a string->int map value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param map The map value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::map<std::string, int>& map);
+/** \brief Set a string->bool map value on the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param map The map value to be inserted.
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL void set(const std::string& key, const std::map<std::string, bool>& map);
+
 
 /** \brief Get a string value from the parameter server.
  *
@@ -111,7 +188,7 @@ ROSCPP_DECL bool get(const std::string& key, double& d);
  * \throws InvalidNameException if the key is not a valid graph resource name
  */
 ROSCPP_DECL bool get(const std::string& key, float& f);
-/** \brief Get a integer value from the parameter server.
+/** \brief Get an integer value from the parameter server.
  *
  * \param key The key to be used in the parameter server's dictionary
  * \param[out] i Storage for the retrieved value.
@@ -167,7 +244,7 @@ ROSCPP_DECL bool getCached(const std::string& key, std::string& s);
  * \throws InvalidNameException if the key is not a valid graph resource name
  */
 ROSCPP_DECL bool getCached(const std::string& key, double& d);
-/** \brief Get a integer value from the parameter server, with local caching
+/** \brief Get an integer value from the parameter server, with local caching
  *
  * This function will cache parameters locally, and subscribe for updates from
  * the parameter server.  Once the parameter is retrieved for the first time
@@ -209,6 +286,240 @@ ROSCPP_DECL bool getCached(const std::string& key, bool& b);
  * \throws InvalidNameException if the key is not a valid graph resource name
  */
 ROSCPP_DECL bool getCached(const std::string& key, XmlRpc::XmlRpcValue& v);
+
+/** \brief Get a string vector value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::vector<std::string>& vec);
+/** \brief Get a double  vector value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::vector<double>& vec);
+/** \brief Get a float  vector value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::vector<float>& vec);
+/** \brief Get an int vector value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::vector<int>& vec);
+/** \brief Get a bool vector value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::vector<bool>& vec);
+
+/** \brief Get a string vector value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::vector<std::string>& vec);
+/** \brief Get a double vector value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::vector<double>& vec);
+/** \brief Get a float vector value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::vector<float>& vec);
+/** \brief Get an int vector value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::vector<int>& vec);
+/** \brief Get a bool vector value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] vec Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::vector<bool>& vec);
+
+/** \brief Get a string->string map value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::map<std::string, std::string>& map);
+/** \brief Get a string->double map value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::map<std::string, double>& map);
+/** \brief Get a string->float map value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::map<std::string, float>& map);
+/** \brief Get a string->int map value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::map<std::string, int>& map);
+/** \brief Get a string->bool map value from the parameter server.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool get(const std::string& key, std::map<std::string, bool>& map);
+
+/** \brief Get a string->string map value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::map<std::string, std::string>& map);
+/** \brief Get a string->double map value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::map<std::string, double>& map);
+/** \brief Get a string->float map value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::map<std::string, float>& map);
+/** \brief Get a string->int map value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::map<std::string, int>& map);
+/** \brief Get a string->bool map value from the parameter server, with local caching
+ *
+ * This function will cache parameters locally, and subscribe for updates from
+ * the parameter server.  Once the parameter is retrieved for the first time
+ * no subsequent getCached() calls with the same key will query the master --
+ * they will instead look up in the local cache.
+ *
+ * \param key The key to be used in the parameter server's dictionary
+ * \param[out] map Storage for the retrieved value.
+ *
+ * \return true if the parameter value was retrieved, false otherwise
+ * \throws InvalidNameException if the key is not a valid graph resource name
+ */
+ROSCPP_DECL bool getCached(const std::string& key, std::map<std::string, bool>& map);
 
 /** \brief Check whether a parameter exists on the parameter server.
  *

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -510,97 +510,224 @@ void NodeHandle::shutdown()
   ok_ = false;
 }
 
-void NodeHandle::setParam(const std::string &key, const XmlRpc::XmlRpcValue &v) const
+void NodeHandle::setParam(const std::string& key, const XmlRpc::XmlRpcValue& v) const
 {
   return param::set(resolveName(key), v);
 }
 
-void NodeHandle::setParam(const std::string &key, const std::string &s) const
+void NodeHandle::setParam(const std::string& key, const std::string& s) const
 {
   return param::set(resolveName(key), s);
 }
 
-void NodeHandle::setParam(const std::string &key, const char* s) const
+void NodeHandle::setParam(const std::string& key, const char* s) const
 {
   return param::set(resolveName(key), s);
 }
 
-void NodeHandle::setParam(const std::string &key, double d) const
+void NodeHandle::setParam(const std::string& key, double d) const
 {
   return param::set(resolveName(key), d);
 }
 
-void NodeHandle::setParam(const std::string &key, int i) const
+void NodeHandle::setParam(const std::string& key, int i) const
 {
   return param::set(resolveName(key), i);
 }
 
-void NodeHandle::setParam(const std::string &key, bool b) const
+void NodeHandle::setParam(const std::string& key, bool b) const
 {
   return param::set(resolveName(key), b);
 }
 
-bool NodeHandle::hasParam(const std::string &key) const
+void NodeHandle::setParam(const std::string& key, const std::vector<std::string>& vec) const
+{
+  return param::set(resolveName(key), vec);
+}
+void NodeHandle::setParam(const std::string& key, const std::vector<double>& vec) const
+{
+  return param::set(resolveName(key), vec);
+}
+void NodeHandle::setParam(const std::string& key, const std::vector<float>& vec) const
+{
+  return param::set(resolveName(key), vec);
+}
+void NodeHandle::setParam(const std::string& key, const std::vector<int>& vec) const
+{
+  return param::set(resolveName(key), vec);
+}
+void NodeHandle::setParam(const std::string& key, const std::vector<bool>& vec) const
+{
+  return param::set(resolveName(key), vec);
+}
+
+void NodeHandle::setParam(const std::string& key, const std::map<std::string, std::string>& map) const
+{
+  return param::set(resolveName(key), map);
+}
+void NodeHandle::setParam(const std::string& key, const std::map<std::string, double>& map) const
+{
+  return param::set(resolveName(key), map);
+}
+void NodeHandle::setParam(const std::string& key, const std::map<std::string, float>& map) const
+{
+  return param::set(resolveName(key), map);
+}
+void NodeHandle::setParam(const std::string& key, const std::map<std::string, int>& map) const
+{
+  return param::set(resolveName(key), map);
+}
+void NodeHandle::setParam(const std::string& key, const std::map<std::string, bool>& map) const
+{
+  return param::set(resolveName(key), map);
+}
+
+bool NodeHandle::hasParam(const std::string& key) const
 {
   return param::has(resolveName(key));
 }
 
-bool NodeHandle::deleteParam(const std::string &key) const
+bool NodeHandle::deleteParam(const std::string& key) const
 {
   return param::del(resolveName(key));
 }
 
-bool NodeHandle::getParam(const std::string &key, XmlRpc::XmlRpcValue &v) const
+bool NodeHandle::getParam(const std::string& key, XmlRpc::XmlRpcValue& v) const
 {
   return param::get(resolveName(key), v);
 }
 
-bool NodeHandle::getParam(const std::string &key, std::string &s) const
+bool NodeHandle::getParam(const std::string& key, std::string& s) const
 {
   return param::get(resolveName(key), s);
 }
 
-bool NodeHandle::getParam(const std::string &key, double &d) const
+bool NodeHandle::getParam(const std::string& key, double& d) const
 {
   return param::get(resolveName(key), d);
 }
 
-bool NodeHandle::getParam(const std::string &key, int &i) const
+bool NodeHandle::getParam(const std::string& key, int& i) const
 {
   return param::get(resolveName(key), i);
 }
 
-bool NodeHandle::getParam(const std::string &key, bool &b) const
+bool NodeHandle::getParam(const std::string& key, bool& b) const
 {
   return param::get(resolveName(key), b);
 }
 
-bool NodeHandle::getParamCached(const std::string &key, XmlRpc::XmlRpcValue &v) const
+
+bool NodeHandle::getParam(const std::string& key, std::vector<std::string>& vec) const
+{
+  return param::get(resolveName(key), vec);
+}
+bool NodeHandle::getParam(const std::string& key, std::vector<double>& vec) const
+{
+  return param::get(resolveName(key), vec);
+}
+bool NodeHandle::getParam(const std::string& key, std::vector<float>& vec) const
+{
+  return param::get(resolveName(key), vec);
+}
+bool NodeHandle::getParam(const std::string& key, std::vector<int>& vec) const
+{
+  return param::get(resolveName(key), vec);
+}
+bool NodeHandle::getParam(const std::string& key, std::vector<bool>& vec) const
+{
+  return param::get(resolveName(key), vec);
+}
+
+bool NodeHandle::getParam(const std::string& key, std::map<std::string, std::string>& map) const
+{
+  return param::get(resolveName(key), map);
+}
+bool NodeHandle::getParam(const std::string& key, std::map<std::string, double>& map) const
+{
+  return param::get(resolveName(key), map);
+}
+bool NodeHandle::getParam(const std::string& key, std::map<std::string, float>& map) const
+{
+  return param::get(resolveName(key), map);
+}
+bool NodeHandle::getParam(const std::string& key, std::map<std::string, int>& map) const
+{
+  return param::get(resolveName(key), map);
+}
+bool NodeHandle::getParam(const std::string& key, std::map<std::string, bool>& map) const
+{
+  return param::get(resolveName(key), map);
+}
+
+bool NodeHandle::getParamCached(const std::string& key, XmlRpc::XmlRpcValue& v) const
 {
   return param::getCached(resolveName(key), v);
 }
 
-bool NodeHandle::getParamCached(const std::string &key, std::string &s) const
+bool NodeHandle::getParamCached(const std::string& key, std::string& s) const
 {
   return param::getCached(resolveName(key), s);
 }
 
-bool NodeHandle::getParamCached(const std::string &key, double &d) const
+bool NodeHandle::getParamCached(const std::string& key, double& d) const
 {
   return param::getCached(resolveName(key), d);
 }
 
-bool NodeHandle::getParamCached(const std::string &key, int &i) const
+bool NodeHandle::getParamCached(const std::string& key, int& i) const
 {
   return param::getCached(resolveName(key), i);
 }
 
-bool NodeHandle::getParamCached(const std::string &key, bool &b) const
+bool NodeHandle::getParamCached(const std::string& key, bool& b) const
 {
   return param::getCached(resolveName(key), b);
 }
 
-bool NodeHandle::searchParam(const std::string &key, std::string& result_out) const
+bool NodeHandle::getParamCached(const std::string& key, std::vector<std::string>& vec) const
+{
+  return param::getCached(resolveName(key), vec);
+}
+bool NodeHandle::getParamCached(const std::string& key, std::vector<double>& vec) const
+{
+  return param::getCached(resolveName(key), vec);
+}
+bool NodeHandle::getParamCached(const std::string& key, std::vector<float>& vec) const
+{
+  return param::getCached(resolveName(key), vec);
+}
+bool NodeHandle::getParamCached(const std::string& key, std::vector<int>& vec) const
+{
+  return param::getCached(resolveName(key), vec);
+}
+bool NodeHandle::getParamCached(const std::string& key, std::vector<bool>& vec) const
+{
+  return param::getCached(resolveName(key), vec);
+}
+
+bool NodeHandle::getParamCached(const std::string& key, std::map<std::string, std::string>& map) const
+{
+  return param::getCached(resolveName(key), map);
+}
+bool NodeHandle::getParamCached(const std::string& key, std::map<std::string, double>& map) const
+{
+  return param::getCached(resolveName(key), map);
+}
+bool NodeHandle::getParamCached(const std::string& key, std::map<std::string, float>& map) const
+{
+  return param::getCached(resolveName(key), map);
+}
+bool NodeHandle::getParamCached(const std::string& key, std::map<std::string, int>& map) const
+{
+  return param::getCached(resolveName(key), map);
+}
+bool NodeHandle::getParamCached(const std::string& key, std::map<std::string, bool>& map) const
+{
+  return param::getCached(resolveName(key), map);
+}
+
+bool NodeHandle::searchParam(const std::string& key, std::string& result_out) const
 {
   // searchParam needs a separate form of remapping -- remapping on the unresolved name, rather than the
   // resolved one.

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -36,6 +36,9 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <vector>
+#include <map>
+
 namespace ros
 {
 
@@ -47,7 +50,7 @@ M_Param g_params;
 boost::mutex g_params_mutex;
 S_string g_subscribed_params;
 
-void set(const std::string &key, const XmlRpc::XmlRpcValue &v)
+void set(const std::string& key, const XmlRpc::XmlRpcValue& v)
 {
   std::string mapped_key = ros::names::resolve(key);
 
@@ -73,7 +76,7 @@ void set(const std::string &key, const XmlRpc::XmlRpcValue &v)
   }
 }
 
-void set(const std::string &key, const std::string &s)
+void set(const std::string& key, const std::string& s)
 {
   // construct xmlrpc_c::value object of the std::string and
   // call param::set(key, xmlvalue);
@@ -81,7 +84,7 @@ void set(const std::string &key, const std::string &s)
   ros::param::set(key, v);
 }
 
-void set(const std::string &key, const char* s)
+void set(const std::string& key, const char* s)
 {
   // construct xmlrpc_c::value object of the std::string and
   // call param::set(key, xmlvalue);
@@ -90,13 +93,13 @@ void set(const std::string &key, const char* s)
   ros::param::set(key, v);
 }
 
-void set(const std::string &key, double d)
+void set(const std::string& key, double d)
 {
   XmlRpc::XmlRpcValue v(d);
   ros::param::set(key, v);
 }
 
-void set(const std::string &key, int i)
+void set(const std::string& key, int i)
 {
   XmlRpc::XmlRpcValue v(i);
   ros::param::set(key, v);
@@ -108,7 +111,89 @@ void set(const std::string& key, bool b)
   ros::param::set(key, v);
 }
 
-bool has(const std::string &key)
+template <class T>
+  void setImpl(const std::string& key, const std::vector<T>& vec)
+{
+  // Note: the XmlRpcValue starts off as "invalid" and assertArray turns it
+  // into an array type with the given size
+  XmlRpc::XmlRpcValue xml_vec;
+  xml_vec.setSize(vec.size());
+
+  // Copy the contents into the XmlRpcValue
+  for(size_t i=0; i < vec.size(); i++) {
+    xml_vec[i] = vec.at(i);
+  }
+
+  set(key, xml_vec);
+}
+
+void set(const std::string& key, const std::vector<std::string>& vec)
+{
+  setImpl(key, vec);
+}
+
+void set(const std::string& key, const std::vector<double>& vec)
+{
+  setImpl(key, vec);
+}
+
+void set(const std::string& key, const std::vector<float>& vec)
+{
+  setImpl(key, vec);
+}
+
+void set(const std::string& key, const std::vector<int>& vec)
+{
+  setImpl(key, vec);
+}
+
+void set(const std::string& key, const std::vector<bool>& vec)
+{
+  setImpl(key, vec);
+}
+
+template <class T>
+  void setImpl(const std::string& key, const std::map<std::string, T>& map)
+{
+  // Note: the XmlRpcValue starts off as "invalid" and assertArray turns it
+  // into an array type with the given size
+  XmlRpc::XmlRpcValue xml_value;
+  const XmlRpc::XmlRpcValue::ValueStruct& xml_map = (const XmlRpc::XmlRpcValue::ValueStruct &)(xml_value);
+
+  // Copy the contents into the XmlRpcValue
+  for(typename std::map<std::string, T>::const_iterator it = map.begin(); it != map.end(); ++it) {
+    xml_value[it->first] = it->second;
+  }
+
+  set(key, xml_value);
+}
+
+void set(const std::string& key, const std::map<std::string, std::string>& map)
+{
+  setImpl(key, map);
+}
+
+void set(const std::string& key, const std::map<std::string, double>& map)
+{
+  setImpl(key, map);
+}
+
+void set(const std::string& key, const std::map<std::string, float>& map)
+{
+  setImpl(key, map);
+}
+
+void set(const std::string& key, const std::map<std::string, int>& map)
+{
+  setImpl(key, map);
+}
+
+void set(const std::string& key, const std::map<std::string, bool>& map)
+{
+  setImpl(key, map);
+}
+
+bool has(const std::string& key)
 {
   XmlRpc::XmlRpcValue params, result, payload;
   params[0] = this_node::getName();
@@ -125,7 +210,7 @@ bool has(const std::string &key)
   return payload;
 }
 
-bool del(const std::string &key)
+bool del(const std::string& key)
 {
   std::string mapped_key = ros::names::resolve(key);
 
@@ -159,7 +244,7 @@ bool del(const std::string &key)
   return true;
 }
 
-bool getImpl(const std::string &key, XmlRpc::XmlRpcValue &v, bool use_cache)
+bool getImpl(const std::string& key, XmlRpc::XmlRpcValue& v, bool use_cache)
 {
   std::string mapped_key = ros::names::resolve(key);
 
@@ -230,7 +315,7 @@ bool getImpl(const std::string &key, XmlRpc::XmlRpcValue &v, bool use_cache)
   return ret;
 }
 
-bool getImpl(const std::string &key, std::string &s, bool use_cache)
+bool getImpl(const std::string& key, std::string& s, bool use_cache)
 {
   XmlRpc::XmlRpcValue v;
   if (!getImpl(key, v, use_cache))
@@ -241,7 +326,7 @@ bool getImpl(const std::string &key, std::string &s, bool use_cache)
   return true;
 }
 
-bool getImpl(const std::string &key, double &d, bool use_cache)
+bool getImpl(const std::string& key, double& d, bool use_cache)
 {
   XmlRpc::XmlRpcValue v;
   if (!getImpl(key, v, use_cache))
@@ -265,7 +350,7 @@ bool getImpl(const std::string &key, double &d, bool use_cache)
   return true;
 }
 
-bool getImpl(const std::string &key, float &f, bool use_cache)
+bool getImpl(const std::string& key, float& f, bool use_cache)
 {
   double d = static_cast<double>(f);
   bool result = getImpl(key, d, use_cache);
@@ -274,7 +359,7 @@ bool getImpl(const std::string &key, float &f, bool use_cache)
   return result;
 }
 
-bool getImpl(const std::string &key, int &i, bool use_cache)
+bool getImpl(const std::string& key, int& i, bool use_cache)
 {
   XmlRpc::XmlRpcValue v;
   if (!getImpl(key, v, use_cache))
@@ -309,7 +394,7 @@ bool getImpl(const std::string &key, int &i, bool use_cache)
   return true;
 }
 
-bool getImpl(const std::string &key, bool &b, bool use_cache)
+bool getImpl(const std::string& key, bool& b, bool use_cache)
 {
   XmlRpc::XmlRpcValue v;
   if (!getImpl(key, v, use_cache))
@@ -360,6 +445,11 @@ bool getCached(const std::string& key, double& d)
 	return getImpl(key, d, true);
 }
 
+bool getCached(const std::string& key, float& f)
+{
+	return getImpl(key, f, true);
+}
+
 bool getCached(const std::string& key, int& i)
 {
 	return getImpl(key, i, true);
@@ -374,6 +464,247 @@ bool getCached(const std::string& key, XmlRpc::XmlRpcValue& v)
 {
 	return getImpl(key, v, true);
 }
+
+template <class T> T xml_cast(XmlRpc::XmlRpcValue xml_value) 
+{
+  return static_cast<T>(xml_value);
+}
+
+template <class T> bool xml_castable(int XmlType) 
+{
+  return false;
+}
+
+template<> bool xml_castable<std::string>(int XmlType)
+{
+  return XmlType == XmlRpc::XmlRpcValue::TypeString;
+}
+
+template<> bool xml_castable<double>(int XmlType)
+{
+  return ( 
+      XmlType == XmlRpc::XmlRpcValue::TypeDouble ||
+      XmlType == XmlRpc::XmlRpcValue::TypeInt ||
+      XmlType == XmlRpc::XmlRpcValue::TypeBoolean );
+}
+
+template<> bool xml_castable<float>(int XmlType)
+{
+  return ( 
+      XmlType == XmlRpc::XmlRpcValue::TypeDouble ||
+      XmlType == XmlRpc::XmlRpcValue::TypeInt ||
+      XmlType == XmlRpc::XmlRpcValue::TypeBoolean );
+}
+
+template<> bool xml_castable<int>(int XmlType)
+{
+  return ( 
+      XmlType == XmlRpc::XmlRpcValue::TypeDouble ||
+      XmlType == XmlRpc::XmlRpcValue::TypeInt ||
+      XmlType == XmlRpc::XmlRpcValue::TypeBoolean );
+}
+
+template<> bool xml_castable<bool>(int XmlType)
+{
+  return ( 
+      XmlType == XmlRpc::XmlRpcValue::TypeDouble ||
+      XmlType == XmlRpc::XmlRpcValue::TypeInt ||
+      XmlType == XmlRpc::XmlRpcValue::TypeBoolean );
+}
+
+template<> double xml_cast(XmlRpc::XmlRpcValue xml_value)
+{
+  using namespace XmlRpc;
+  switch(xml_value.getType()) {
+    case XmlRpcValue::TypeDouble:
+      return static_cast<double>(xml_value);
+    case XmlRpcValue::TypeInt:
+      return static_cast<double>(static_cast<int>(xml_value));
+    case XmlRpcValue::TypeBoolean:
+      return static_cast<double>(static_cast<bool>(xml_value));
+  };
+}
+
+template<> float xml_cast(XmlRpc::XmlRpcValue xml_value)
+{
+  using namespace XmlRpc;
+  switch(xml_value.getType()) {
+    case XmlRpcValue::TypeDouble:
+      return static_cast<float>(static_cast<double>(xml_value));
+    case XmlRpcValue::TypeInt:
+      return static_cast<float>(static_cast<int>(xml_value));
+    case XmlRpcValue::TypeBoolean:
+      return static_cast<float>(static_cast<bool>(xml_value));
+  };
+}
+
+template<> int xml_cast(XmlRpc::XmlRpcValue xml_value)
+{
+  using namespace XmlRpc;
+  switch(xml_value.getType()) {
+    case XmlRpcValue::TypeDouble:
+      return static_cast<int>(static_cast<double>(xml_value));
+    case XmlRpcValue::TypeInt:
+      return static_cast<int>(xml_value);
+    case XmlRpcValue::TypeBoolean:
+      return static_cast<int>(static_cast<bool>(xml_value));
+  };
+}
+
+template<> bool xml_cast(XmlRpc::XmlRpcValue xml_value)
+{
+  using namespace XmlRpc;
+  switch(xml_value.getType()) {
+    case XmlRpcValue::TypeDouble:
+      return static_cast<bool>(static_cast<double>(xml_value));
+    case XmlRpcValue::TypeInt:
+      return static_cast<bool>(static_cast<int>(xml_value));
+    case XmlRpcValue::TypeBoolean:
+      return static_cast<bool>(xml_value);
+  };
+}
+  
+template <class T>
+  bool getImpl(const std::string& key, std::vector<T>& vec, bool cached)
+{
+  XmlRpc::XmlRpcValue xml_array;
+  if(!getImpl(key, xml_array, cached)) {
+    return false;
+  }
+
+  // Make sure it's an array type
+  if(xml_array.getType() != XmlRpc::XmlRpcValue::TypeArray) {
+    return false;
+  }
+
+  // Resize the target vector (destructive)
+  vec.resize(xml_array.size());
+
+  // Fill the vector with stuff
+  for (int i = 0; i < xml_array.size(); i++) {
+    if(!xml_castable<T>(xml_array[i].getType())) {
+      return false;
+    }
+
+    vec[i] = xml_cast<T>(xml_array[i]);
+  }
+
+  return true;
+}
+
+bool get(const std::string& key, std::vector<std::string>& vec)
+{
+  return getImpl(key, vec, false);
+}
+bool get(const std::string& key, std::vector<double>& vec)
+{
+  return getImpl(key, vec, false);
+}
+bool get(const std::string& key, std::vector<float>& vec)
+{
+  return getImpl(key, vec, false);
+}
+bool get(const std::string& key, std::vector<int>& vec)
+{
+  return getImpl(key, vec, false);
+}
+bool get(const std::string& key, std::vector<bool>& vec)
+{
+  return getImpl(key, vec, false);
+}
+
+bool getCached(const std::string& key, std::vector<std::string>& vec)
+{
+  return getImpl(key, vec, true);
+}
+bool getCached(const std::string& key, std::vector<double>& vec)
+{
+  return getImpl(key, vec, true);
+}
+bool getCached(const std::string& key, std::vector<float>& vec)
+{
+  return getImpl(key, vec, true);
+}
+bool getCached(const std::string& key, std::vector<int>& vec)
+{
+  return getImpl(key, vec, true);
+}
+bool getCached(const std::string& key, std::vector<bool>& vec)
+{
+  return getImpl(key, vec, true);
+}
+
+template <class T>
+  bool getImpl(const std::string& key, std::map<std::string, T>& map, bool cached)
+{
+  XmlRpc::XmlRpcValue xml_value;
+  if(!getImpl(key, xml_value, cached)) {
+    return false;
+  }
+
+  // Make sure it's a struct type
+  if(xml_value.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
+    return false;
+  }
+
+  // Fill the map with stuff
+  for (XmlRpc::XmlRpcValue::ValueStruct::const_iterator it = xml_value.begin();
+      it != xml_value.end();
+      ++it)
+  {
+    // Make sure this element is the right type
+    if(!xml_castable<T>(it->second.getType())) {
+      return false;
+    }
+    // Store the element
+    map[it->first] = xml_cast<T>(it->second);
+  }
+
+  return true;
+}
+
+bool get(const std::string& key, std::map<std::string, std::string>& map)
+{
+  return getImpl(key, map, false);
+}
+bool get(const std::string& key, std::map<std::string, double>& map)
+{
+  return getImpl(key, map, false);
+}
+bool get(const std::string& key, std::map<std::string, float>& map)
+{
+  return getImpl(key, map, false);
+}
+bool get(const std::string& key, std::map<std::string, int>& map)
+{
+  return getImpl(key, map, false);
+}
+bool get(const std::string& key, std::map<std::string, bool>& map)
+{
+  return getImpl(key, map, false);
+}
+
+bool getCached(const std::string& key, std::map<std::string, std::string>& map)
+{
+  return getImpl(key, map, true);
+}
+bool getCached(const std::string& key, std::map<std::string, double>& map)
+{
+  return getImpl(key, map, true);
+}
+bool getCached(const std::string& key, std::map<std::string, float>& map)
+{
+  return getImpl(key, map, true);
+}
+bool getCached(const std::string& key, std::map<std::string, int>& map)
+{
+  return getImpl(key, map, true);
+}
+bool getCached(const std::string& key, std::map<std::string, bool>& map)
+{
+  return getImpl(key, map, true);
+}
+
 
 bool search(const std::string& key, std::string& result_out)
 {

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -255,6 +255,260 @@ TEST(Params, doublePrecision)
   EXPECT_DOUBLE_EQ(d, 0.12345678912345678);
 }
 
+std::vector<std::string> vec_s, vec_s2;
+std::vector<double> vec_d, vec_d2;
+std::vector<float> vec_f, vec_f2;
+std::vector<int> vec_i, vec_i2;
+std::vector<bool> vec_b, vec_b2;
+
+TEST(Params, vectorStringParam)
+{
+  const std::string param_name = "vec_str_param";
+
+  vec_s.clear();
+  vec_s.push_back("foo");
+  vec_s.push_back("bar");
+  vec_s.push_back("baz");
+
+  ros::param::set(param_name, vec_s);
+
+  ASSERT_FALSE(ros::param::get(param_name, vec_d));
+  ASSERT_FALSE(ros::param::get(param_name, vec_f));
+  ASSERT_FALSE(ros::param::get(param_name, vec_i));
+  ASSERT_FALSE(ros::param::get(param_name, vec_b));
+
+  ASSERT_TRUE(ros::param::get(param_name, vec_s2));
+
+  ASSERT_EQ(vec_s.size(), vec_s2.size());
+  ASSERT_TRUE(std::equal(vec_s.begin(), vec_s.end(), vec_s2.begin()));
+
+  // Test empty vector
+  vec_s.clear();
+  ros::param::set(param_name, vec_s);
+  ASSERT_TRUE(ros::param::get(param_name, vec_s2));
+  ASSERT_EQ(vec_s.size(), vec_s2.size());
+}
+
+TEST(Params, vectorDoubleParam)
+{
+  const std::string param_name = "vec_double_param";
+
+  vec_d.clear();
+  vec_d.push_back(-0.123456789);
+  vec_d.push_back(3);
+  vec_d.push_back(3.01);
+  vec_d.push_back(7.01);
+
+  ros::param::set(param_name, vec_d);
+
+  ASSERT_FALSE(ros::param::get(param_name, vec_s));
+  ASSERT_TRUE(ros::param::get(param_name, vec_i));
+  ASSERT_TRUE(ros::param::get(param_name, vec_b));
+  ASSERT_TRUE(ros::param::get(param_name, vec_f));
+
+  ASSERT_TRUE(ros::param::get(param_name, vec_d2));
+
+  ASSERT_EQ(vec_d.size(), vec_d2.size());
+  ASSERT_TRUE(std::equal(vec_d.begin(), vec_d.end(), vec_d2.begin()));
+}
+
+TEST(Params, vectorFloatParam)
+{
+  const std::string param_name = "vec_float_param";
+
+  vec_f.clear();
+  vec_f.push_back(-0.123456789);
+  vec_f.push_back(0.0);
+  vec_f.push_back(3);
+  vec_f.push_back(3.01);
+
+  ros::param::set(param_name, vec_f);
+
+  ASSERT_FALSE(ros::param::get(param_name, vec_s));
+  ASSERT_TRUE(ros::param::get(param_name, vec_i));
+  ASSERT_TRUE(ros::param::get(param_name, vec_b));
+  ASSERT_TRUE(ros::param::get(param_name, vec_d));
+
+  ASSERT_EQ(vec_b[0],true);
+  ASSERT_EQ(vec_b[1],false);
+
+  ASSERT_TRUE(ros::param::get(param_name, vec_f2));
+
+  ASSERT_EQ(vec_f.size(), vec_f2.size());
+  ASSERT_TRUE(std::equal(vec_f.begin(), vec_f.end(), vec_f2.begin()));
+}
+
+TEST(Params, vectorIntParam)
+{
+  const std::string param_name = "vec_int_param";
+
+  vec_i.clear();
+  vec_i.push_back(-1);
+  vec_i.push_back(0);
+  vec_i.push_back(1337);
+  vec_i.push_back(2);
+
+  ros::param::set(param_name, vec_i);
+
+  ASSERT_FALSE(ros::param::get(param_name, vec_s));
+  ASSERT_TRUE(ros::param::get(param_name, vec_d));
+  ASSERT_TRUE(ros::param::get(param_name, vec_f));
+  ASSERT_TRUE(ros::param::get(param_name, vec_b));
+
+  ASSERT_EQ(vec_b[0],true);
+  ASSERT_EQ(vec_b[1],false);
+
+  ASSERT_TRUE(ros::param::get(param_name, vec_i2));
+
+  ASSERT_EQ(vec_i.size(), vec_i2.size());
+  ASSERT_TRUE(std::equal(vec_i.begin(), vec_i.end(), vec_i2.begin()));
+}
+
+TEST(Params, vectorBoolParam)
+{
+  const std::string param_name = "vec_bool_param";
+
+  vec_b.clear();
+  vec_b.push_back(true);
+  vec_b.push_back(false);
+  vec_b.push_back(true);
+  vec_b.push_back(true);
+
+  ros::param::set(param_name, vec_b);
+
+  ASSERT_FALSE(ros::param::get(param_name, vec_s));
+  ASSERT_TRUE(ros::param::get(param_name, vec_d));
+  ASSERT_TRUE(ros::param::get(param_name, vec_f));
+  ASSERT_TRUE(ros::param::get(param_name, vec_i));
+
+  ASSERT_EQ(vec_i[0],1);
+  ASSERT_EQ(vec_i[1],0);
+
+  ASSERT_TRUE(ros::param::get(param_name, vec_b2));
+
+  ASSERT_EQ(vec_b.size(), vec_b2.size());
+  ASSERT_TRUE(std::equal(vec_b.begin(), vec_b.end(), vec_b2.begin()));
+}
+
+std::map<std::string,std::string> map_s, map_s2;
+std::map<std::string,double> map_d, map_d2;
+std::map<std::string,float> map_f, map_f2;
+std::map<std::string,int> map_i, map_i2;
+std::map<std::string,bool> map_b, map_b2;
+
+TEST(Params, mapStringParam)
+{
+  const std::string param_name = "map_str_param";
+
+  map_s.clear();
+  map_s["a"] = "apple";
+  map_s["b"] = "blueberry";
+  map_s["c"] = "carrot";
+
+  ros::param::set(param_name, map_s);
+
+  ASSERT_FALSE(ros::param::get(param_name, map_d));
+  ASSERT_FALSE(ros::param::get(param_name, map_f));
+  ASSERT_FALSE(ros::param::get(param_name, map_i));
+  ASSERT_FALSE(ros::param::get(param_name, map_b));
+
+  ASSERT_TRUE(ros::param::get(param_name, map_s2));
+
+  ASSERT_EQ(map_s.size(), map_s2.size());
+  ASSERT_TRUE(std::equal(map_s.begin(), map_s.end(), map_s2.begin()));
+}
+
+TEST(Params, mapDoubleParam)
+{
+  const std::string param_name = "map_double_param";
+
+  map_d.clear();
+  map_d["a"] = 0.0;
+  map_d["b"] = -0.123456789;
+  map_d["c"] = 123456789;
+
+  ros::param::set(param_name, map_d);
+
+  ASSERT_FALSE(ros::param::get(param_name, map_s));
+  ASSERT_TRUE(ros::param::get(param_name, map_f));
+  ASSERT_TRUE(ros::param::get(param_name, map_i));
+  ASSERT_TRUE(ros::param::get(param_name, map_b));
+
+  ASSERT_TRUE(ros::param::get(param_name, map_d2));
+
+  ASSERT_EQ(map_d.size(), map_d2.size());
+  ASSERT_TRUE(std::equal(map_d.begin(), map_d.end(), map_d2.begin()));
+}
+
+TEST(Params, mapFloatParam)
+{
+  const std::string param_name = "map_float_param";
+
+  map_f.clear();
+  map_f["a"] = 0.0;
+  map_f["b"] = -0.123456789;
+  map_f["c"] = 123456789;
+
+  ros::param::set(param_name, map_f);
+
+  ASSERT_FALSE(ros::param::get(param_name, map_s));
+  ASSERT_TRUE(ros::param::get(param_name, map_d));
+  ASSERT_TRUE(ros::param::get(param_name, map_i));
+  ASSERT_TRUE(ros::param::get(param_name, map_b));
+
+  ASSERT_TRUE(ros::param::get(param_name, map_f2));
+
+  ASSERT_EQ(map_f.size(), map_f2.size());
+  ASSERT_TRUE(std::equal(map_f.begin(), map_f.end(), map_f2.begin()));
+}
+
+TEST(Params, mapIntParam)
+{
+  const std::string param_name = "map_int_param";
+
+  map_i.clear();
+  map_i["a"] = 0;
+  map_i["b"] = -1;
+  map_i["c"] = 1337;
+
+  ros::param::set(param_name, map_i);
+
+  ASSERT_FALSE(ros::param::get(param_name, map_s));
+  ASSERT_TRUE(ros::param::get(param_name, map_d));
+  ASSERT_TRUE(ros::param::get(param_name, map_f));
+  ASSERT_TRUE(ros::param::get(param_name, map_b));
+
+  ASSERT_TRUE(ros::param::get(param_name, map_i2));
+
+  ASSERT_EQ(map_i.size(), map_i2.size());
+  ASSERT_TRUE(std::equal(map_i.begin(), map_i.end(), map_i2.begin()));
+}
+
+TEST(Params, mapBoolParam)
+{
+  const std::string param_name = "map_bool_param";
+
+  map_b.clear();
+  map_b["a"] = true;
+  map_b["b"] = false;
+  map_b["c"] = true;
+
+  ros::param::set(param_name, map_b);
+
+  ASSERT_FALSE(ros::param::get(param_name, map_s));
+  ASSERT_TRUE(ros::param::get(param_name, map_d));
+  ASSERT_TRUE(ros::param::get(param_name, map_f));
+  ASSERT_TRUE(ros::param::get(param_name, map_i));
+
+  ASSERT_EQ(map_i["a"],1);
+  ASSERT_EQ(map_i["b"],0);
+
+  ASSERT_TRUE(ros::param::get(param_name, map_b2));
+
+  ASSERT_EQ(map_b.size(), map_b2.size());
+  ASSERT_TRUE(std::equal(map_b.begin(), map_b.end(), map_b2.begin()));
+}
+
 int
 main(int argc, char** argv)
 {


### PR DESCRIPTION
This patch adds the ability to call `ros::param::get()` and ros::param::set() with `std::vector<T>` and `std::map<std::string,T>` where T is one of (`std::string`, `double`, `float`, `int`, `bool`). 

Also some trivial doc fixes.
