### PR TITLE
rospy: use threading module rather than thread

### DIFF
--- a/clients/rospy/src/rospy/impl/registration.py
+++ b/clients/rospy/src/rospy/impl/registration.py
@@ -39,10 +39,6 @@
 import socket
 import sys
 import logging
-try:
-	import _thread
-except ImportError:
-    import thread as _thread
 import threading
 import time
 import traceback
@@ -315,7 +311,7 @@ class RegManager(RegistrationListener):
             if uris and not self.handler.done:
                 for uri in uris:
                     # #1141: have to multithread this to prevent a bad publisher from hanging us
-                    _thread.start_new_thread(self._connect_topic_thread, (topic, uri))
+                    threading.Thread(target=self._connect_topic_thread, args=(topic, uri)).start()
 
     def _connect_topic_thread(self, topic, uri):
         try:

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -44,11 +44,6 @@ except ImportError:
 import socket
 import logging
 
-try:
-    import _thread
-except ImportError:
-    import thread as _thread
-    
 import threading
 import time
 import traceback
@@ -141,8 +136,8 @@ class TCPServer(object):
 
     def start(self):
         """Runs the run() loop in a separate thread"""
-        _thread.start_new_thread(self.run, ())
-        
+        threading.Thread(target=self.run, args=()).start()
+
     def run(self):
         """
         Main TCP receive loop. Should be run in a separate thread -- use start()

--- a/clients/rospy/src/rospy/impl/tcpros_service.py
+++ b/clients/rospy/src/rospy/impl/tcpros_service.py
@@ -62,10 +62,7 @@ import rospy.names
 
 import rospy.impl.validators
 
-try:
-	import _thread #py3k
-except ImportError:
-    import thread as _thread
+import threading
 
 if sys.hexversion > 0x03000000: #Python3
     def isstring(s):
@@ -247,7 +244,7 @@ def service_connection_handler(sock, client_addr, header):
             transport.write_header()
             # using threadpool reduced performance by an order of
             # magnitude, need to investigate better
-            _thread.start_new_thread(service.handle, (transport, header))
+            threading.Thread(target=service.handle, args=(transport, header)).start()
                 
         
 class TCPService(TCPROSTransportProtocol):

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -68,17 +68,15 @@ import struct
 import select
 try:
     from cStringIO import StringIO #Python 2.x
-    import thread as _thread # Python 2
     python3 = 0
     def isstring(s):
         return isinstance(s, basestring) #Python 2.x
 except ImportError:
     python3 = 1
     from io import StringIO, BytesIO #Python 3.x
-    import _thread 
     def isstring(s):
         return isinstance(s, str) #Python 3.x
-    		
+
 import threading
 import logging
 import time


### PR DESCRIPTION
This pull request modifies rospy to eliminate the use of the Python `thread` module and to instead use the Python `threading` module universally.  Reasons for doing this:
- Remove usage of deprecated module (must be imported as `_thread` in Python3)
- Allows the coverage tool in python to cover callbacks for services in rospy

For more information about the coverage bug with the `thread` modules, see:

https://bitbucket.org/ned/coveragepy/issue/244/coverage-doesnt-work-with-thread-not

I mostly replace lines like:

``` python
import thread
...
thread.start_new_thread(func, (arg1, arg2))
```

With sections like this:

``` python
import threading
...
threading.Thread(target=func, args=(arg1, arg2)).start()
```

Not keeping a reference to the Thread object after creation appears to be OK, according to this to this website:

http://bytes.com/topic/python/answers/160905-my-thread-safe-premature-garbage-collection
