### PR TITLE
Allow rosbag "chunk threshold" to be adjusted when recording

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -100,6 +100,7 @@ struct ROSBAG_DECL RecorderOptions
     std::string     name;
     boost::regex    exclude_regex;
     uint32_t        buffer_size;
+    uint32_t        chunk_size;
     uint32_t        limit;
     bool            split;
     uint32_t        max_size;

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -56,6 +56,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("output-prefix,o", po::value<std::string>(), "prepend PREFIX to beginning of bag name")
       ("output-name,O", po::value<std::string>(), "record bagnamed NAME.bag")
       ("buffsize,b", po::value<int>()->default_value(256), "Use an internal buffer of SIZE MB (Default: 256)")
+      ("chunksize", po::value<int>()->default_value(768), "Set chunk size of message data, in KB (Default: 768. Advanced)")
       ("limit,l", po::value<int>()->default_value(0), "Only record NUM messages on each topic")
       ("bz2,j", "use BZ2 compression")
       ("split", po::value<int>()->implicit_value(0), "Split the bag file and continue recording when maximum size or maximum duration reached.")
@@ -126,6 +127,13 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       if (m < 0)
         throw ros::Exception("Buffer size must be 0 or positive");
       opts.buffer_size = 1048576 * m;
+    }
+    if (vm.count("chunksize"))
+    {
+      int chnk_sz = vm["chunksize"].as<int>();
+      if (chnk_sz < 0)
+        throw ros::Exception("Chunk size must be 0 or positive");
+      opts.chunk_size = 1024 * chnk_sz;
     }
     if (vm.count("limit"))
     {

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -104,6 +104,7 @@ RecorderOptions::RecorderOptions() :
     name(""),
     exclude_regex(),
     buffer_size(1048576 * 256),
+    chunk_size(1024 * 768),
     limit(0),
     split(false),
     max_size(0),
@@ -357,6 +358,7 @@ void Recorder::snapshotTrigger(std_msgs::Empty::ConstPtr trigger) {
 
 void Recorder::startWriting() {
     bag_.setCompression(options_.compression);
+    bag_.setChunkThreshold(options_.chunk_size);
 
     updateFilenames();
     try {

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -80,6 +80,7 @@ def record_cmd(argv):
     parser.add_option(      "--size",          dest="size",                         type='int',   action="store", help="record a bag of maximum size SIZE", metavar="SIZE")
     parser.add_option(      "--duration",      dest="duration",                     type='string',action="store", help="record a bag of maximum duration DURATION in seconds, unless 'm', or 'h' is appended.", metavar="DURATION")
     parser.add_option("-b", "--buffsize",      dest="buffsize",      default=256,   type='int',   action="store", help="use an internal buffer of SIZE MB (Default: %default, 0 = infinite)", metavar="SIZE")
+    parser.add_option("--chunksize",           dest="chunksize",     default=768,   type='int',   action="store", help="Advanced. Record to chunks of SIZE KB (Default: %default)", metavar="SIZE")
     parser.add_option("-l", "--limit",         dest="num",           default=0,     type='int',   action="store", help="only record NUM messages on each topic")
     parser.add_option(      "--node",          dest="node",          default=None,  type='string',action="store", help="record all topics subscribed to by a specific node")
     parser.add_option("-j", "--bz2",           dest="bz2",           default=False, action="store_true",          help="use BZ2 compression")
@@ -97,7 +98,8 @@ def record_cmd(argv):
         parser.error("Cannot find rosbag/record executable")
     cmd = [recordpath[0]]
 
-    cmd.extend(['--buffsize', str(options.buffsize)])
+    cmd.extend(['--buffsize',  str(options.buffsize)])
+    cmd.extend(['--chunksize', str(options.chunksize)])
 
     if options.num != 0:      cmd.extend(['--limit', str(options.num)])
     if options.quiet:         cmd.extend(["--quiet"])


### PR DESCRIPTION
For large files (above a few GB), opening bags can take a significant amount of time. The open step is slow because it seeks through the bag file, loading chunk data. By increasing the chunk size for a bag, we can reduce the opening time significantly.

I would like to allow users to be able to configure the chunk size of a bag file when recording. This will allow me to record bag files with larger chunk sizes. 
