### PR TITLE
Fixed compilation of base64.h on clang + libc++

### DIFF
--- a/utilities/xmlrpcpp/include/base64.h
+++ b/utilities/xmlrpcpp/include/base64.h
@@ -13,6 +13,12 @@
 # include <iterator>
 #endif
 
+#if defined(__clang__)
+    #include <ios>
+#else
+    #include <iosfwd>
+#endif
+
 static
 int _base64Chars[]= {'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
 				     'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',


### PR DESCRIPTION
If `<ios>` is not included, the compilation fails with the following
error:

```
In file included from
ros_comm-1.9.47/utilities/xmlrpcpp/src/XmlRpcValue.cpp:5:
ros_comm-1.9.47/utilities/xmlrpcpp/include/base64.h:231:13:
error: incomplete type 'std::__1::ios_base' named in nested name
specifier
_St |= _IOS_FAILBIT|_IOS_EOFBIT; return _First; // unexpected EOF
^~~~~~~~~~~~
```
