### PR TITLE
added param, has_param and launch_file substitution arg

### DIFF
--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -276,17 +276,18 @@ def _param(resolved, a, args, context, ros_config):
 
     def try_master(): # try to get param from master parameter server
         try:
-            param_value = rosparam.get_param(args[0])    
+            return rosparam.get_param(args[0])    
         except MasterError as e:
             raise SubstitutionException("ros parameter %s not found"%str(args[0]))
 
+
     if ros_config is None: 
-        try_master()
+        param_value = try_master()
     else:
         try:
             param_value = ros_config.params[args[0]].value
         except KeyError as e: 
-            try_master()
+            param_value = try_master()
     
     return resolved.replace("$(%s)"%a, str(param_value))
 

--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -323,6 +323,29 @@ def _has_param(resolved, a, args, context, ros_config):
 
     return resolved.replace("$(%s)"%a, str(has))
 
+def _launch_file(resolved, a, args, context, ros_config):
+    """
+    process $(launch_file idx=-1)
+    
+    :returns: updated resolved argument, ``str``
+    :raises: :exc:`SubstitutionException` : if idx out of bound (of ros_config.roslaunch_files)
+    :raises: :exc:`SubstitutionException` : if no ros_config given
+    """
+    if len(args) == 0:
+        idx = -1
+    else:
+        idx = args[0]
+
+    if ros_config is None: 
+        raise SubstitutionException("$(launch_file idx) no ros_config given [%s]"%(a))
+    else:
+        try:
+            value = ros_config.roslaunch_files[idx]
+        except IndexError as e: 
+            raise SubstitutionException("$(launch_file idx) idx out of bound [%s]"%(a))
+    
+    return resolved.replace("$(%s)"%a, str(value))
+
 
 def resolve_args(arg_str, context=None, resolve_anon=True, ros_config=None):
     """
@@ -364,6 +387,7 @@ def resolve_args(arg_str, context=None, resolve_anon=True, ros_config=None):
         'arg': _arg,        
         'param': _param,    
         'has_param': _has_param,    
+        'launch_file': _launch_file,    
     }
     resolved = _resolve_args(arg_str, context, ros_config, resolve_anon, commands)
     # than resolve 'find' as it requires the subsequent path to be expanded already
@@ -374,7 +398,7 @@ def resolve_args(arg_str, context=None, resolve_anon=True, ros_config=None):
     return resolved
 
 def _resolve_args(arg_str, context, ros_config, resolve_anon, commands):
-    valid = ['find', 'env', 'optenv', 'anon', 'arg', 'param', 'has_param']
+    valid = ['find', 'env', 'optenv', 'anon', 'arg', 'param', 'has_param', 'launch_file']
     resolved = arg_str
     for a in _collect_args(arg_str):
         splits = [s for s in a.split(' ') if s]

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -601,13 +601,17 @@ class XmlLoader(loader.Loader):
                         self._recurse_load(ros_config, tag.childNodes, child_ns, \
                                                default_machine, is_core, verbose)
             elif name == 'node':
-                # clone the context so that nodes' env does not pollute global env
-                n = self._node_tag(tag, context.child(''), ros_config, default_machine, verbose=verbose)
+                # backup the contexts env_vars and revert them afterwards so that nodes' env does not pollute global env
+                env_vars_backup = context.env_args[:]
+                n = self._node_tag(tag, context, ros_config, default_machine, verbose=verbose)
+                context.env_args = env_vars_backup
                 if n is not None:
                     ros_config.add_node(n, core=is_core, verbose=verbose)
             elif name == 'test':
-                # clone the context so that nodes' env does not pollute global env                
-                t = self._node_tag(tag, context.child(''), ros_config, default_machine, is_test=True, verbose=verbose)
+                # backup the contexts env_vars and revert them afterwards so that nodes' env does not pollute global env
+                env_vars_backup = context.env_args[:]
+                t = self._node_tag(tag, context, ros_config, default_machine, is_test=True, verbose=verbose)
+                context.env_args = env_vars_backup
                 if t is not None:
                     ros_config.add_test(t, verbose=verbose)
             elif name == 'param':

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -537,7 +537,7 @@ class XmlLoader(loader.Loader):
         return child_ns
         
     @ifunless
-    def _launch_tag(self, tag, ros_config, filename=None):  # TODO context should be provided for @ifunless
+    def _launch_tag(self, tag, context, ros_config, filename=None):
         # #2499
         deprecated = tag.getAttribute('deprecated')
         if deprecated:
@@ -569,7 +569,7 @@ class XmlLoader(loader.Loader):
         try:
             launch = self._parse_launch(inc_filename, verbose=verbose)
             ros_config.add_roslaunch_file(inc_filename)
-            self._launch_tag(launch, ros_config, filename=inc_filename)
+            self._launch_tag(launch, context, ros_config, filename=inc_filename)
             default_machine = \
                 self._recurse_load(ros_config, launch.childNodes, child_ns, \
                                        default_machine, is_core, verbose)
@@ -661,8 +661,8 @@ class XmlLoader(loader.Loader):
         if argv is None:
             argv = sys.argv
 
-        self._launch_tag(launch, ros_config, filename)
         self.root_context = loader.LoaderContext(get_ros_namespace(), filename)
+        self._launch_tag(launch, self.root_context, ros_config, filename)
         loader.load_sysargs_into_context(self.root_context, argv)
 
         if len(launch.getElementsByTagName('master')) > 0:


### PR DESCRIPTION
added `param`, `has_param` and `launch_file` substitution arg

`param` can substitute ros params
`has_param` can be substituted with bool value whether a ros param exists (e.g. for use in `if` or `unless`)
`launch_file` can be substituted with the name of (one of) the launch file(s) that is parsed until this point, without a given index of which launch file is wanted, the last one is used

also fixed an issue in `_launch_tag` where a ros_config instance where given to the ifunless decorator instead of a context

additionally it is now possible to access `ros_config` for more sophisticated substitution args
