### PR TITLE
roscpp: Fix clashing namespaces for ros::param::set

### DIFF
--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -124,32 +124,32 @@ template <class T>
     xml_vec[i] = vec.at(i);
   }
 
-  set(key, xml_vec);
+  ros::param::set(key, xml_vec);
 }
 
 void set(const std::string& key, const std::vector<std::string>& vec)
 {
-  setImpl(key, vec);
+  ros::param::setImpl(key, vec);
 }
 
 void set(const std::string& key, const std::vector<double>& vec)
 {
-  setImpl(key, vec);
+  ros::param::setImpl(key, vec);
 }
 
 void set(const std::string& key, const std::vector<float>& vec)
 {
-  setImpl(key, vec);
+  ros::param::setImpl(key, vec);
 }
 
 void set(const std::string& key, const std::vector<int>& vec)
 {
-  setImpl(key, vec);
+  ros::param::setImpl(key, vec);
 }
 
 void set(const std::string& key, const std::vector<bool>& vec)
 {
-  setImpl(key, vec);
+  ros::param::setImpl(key, vec);
 }
 
 template <class T>
@@ -165,32 +165,32 @@ template <class T>
     xml_value[it->first] = it->second;
   }
 
-  set(key, xml_value);
+  ros::param::set(key, xml_value);
 }
 
 void set(const std::string& key, const std::map<std::string, std::string>& map)
 {
-  setImpl(key, map);
+  ros::param::setImpl(key, map);
 }
 
 void set(const std::string& key, const std::map<std::string, double>& map)
 {
-  setImpl(key, map);
+  ros::param::setImpl(key, map);
 }
 
 void set(const std::string& key, const std::map<std::string, float>& map)
 {
-  setImpl(key, map);
+  ros::param::setImpl(key, map);
 }
 
 void set(const std::string& key, const std::map<std::string, int>& map)
 {
-  setImpl(key, map);
+  ros::param::setImpl(key, map);
 }
 
 void set(const std::string& key, const std::map<std::string, bool>& map)
 {
-  setImpl(key, map);
+  ros::param::setImpl(key, map);
 }
 
 bool has(const std::string& key)


### PR DESCRIPTION
Compiling on RHEL with gcc 4.4.6 resulted in the following error:

```
/usr/lib/gcc/x86_64-redhat-linux/4.4.6/../../../../include/c++/4.4.6/bits/stl_set.h: In function 'void ros::param::setImpl(const std::string&, const std::vector<T, std::allocator<_CharT> >&)':
/usr/lib/gcc/x86_64-redhat-linux/4.4.6/../../../../include/c++/4.4.6/bits/stl_set.h:87: error: 'template<class _Key, class _Compare, class _Alloc> class std::set' is not a function,
/home/codac-dev/rpmbuild/BUILD/ros-hydro-core-1.9.50/src/roscpp/include/ros/param.h:161: error:   conflict with 'void ros::param::set(const std::string&, const std::map<std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, std::less<std::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<const std::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool> > >&)'
```

Apparently the set was clashing with std::set for some reason.

Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
