### PR TITLE
implement optional queueing for rospy publications (#169)

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -355,3 +355,78 @@ class TCPROSHandler(rospy.impl.transport.ProtocolHandler):
                 topic.add_connection(transport)
             
 
+class QueuedConnection(object):
+    """
+    It wraps a Transport instance and behaves like one
+    but it queues the data written to it and relays them
+    asynchronously to the wrapped instance.
+    """
+
+    def __init__(self, connection, queue_size):
+        """
+        ctor.
+        @param connection: the wrapped transport instance
+        @type  connection: Transport
+        @param queue_size: the maximum size of the queue, zero means infinite
+        @type  queue_size: int
+        """
+        super(QueuedConnection, self).__init__()
+        self._connection = connection
+        self._queue_size = queue_size
+
+        self._lock = threading.Lock()
+        self._cond_data_available = threading.Condition(self._lock)
+        self._cond_queue_swapped = threading.Condition(self._lock)
+        self._queue = []
+        self._waiting = False
+        self._error = None
+
+        self._thread = threading.Thread(target=self._run)
+        self._thread.start()
+
+    def __getattr__(self, name):
+        if name.startswith('__'):
+            raise AttributeError(name)
+        return getattr(self._connection, name)
+
+    def write_data(self, data):
+        with self._lock:
+            # if there was previously an error within the dispatch thread raise it
+            if self._error:
+                error = self._error
+                self._error = None
+                raise error
+            # pop oldest data if queue limit is reached
+            if self._queue_size > 0 and len(self._queue) == self._queue_size:
+                del self._queue[0]
+            self._queue.append(data)
+            self._cond_data_available.notify()
+            # ensure that thread has actually swapped the queues and is processig them
+            # if it was waiting for being notified
+            # to enforce behavior to be as close as possible to blocking
+            if self._waiting:
+                self._cond_queue_swapped.wait()
+        return True
+
+    def _run(self):
+        while not self._connection.done:
+            queue = []
+            with self._lock:
+                # wait for available data
+                while not self._queue and not self._connection.done:
+                    self._waiting = True
+                    self._cond_data_available.wait(1.0)
+                    self._waiting = False
+                    if self._queue:
+                        self._cond_queue_swapped.notify()
+                # take all data from queue for processing outside of the lock
+                if self._queue:
+                    queue = self._queue
+                    self._queue = []
+            # relay all data
+            for data in queue:
+                try:
+                    self._connection.write_data(data)
+                except Exception as e:
+                    with self._cond:
+                        self._error = e


### PR DESCRIPTION
Specifying the maximum queue size when creating a publisher (https://github.com/ros/ros_comm/blob/69fb651de8f547c7d48d57ea9cc7c78a492d77d9/clients/rospy/src/rospy/topics.py#L742) will make all `publish() calls being handled asynchronously. The functionality is implemented as an non-default option in order to not change the default behavior.

There are several side effects to this change:
- changing the internal behavior to asynchronous IO will expose error cases only after a repeated `publish()` call to the user code (since they don't happen immediately but asynchronously)
- this implementation will actually start dropping messages on the publisher side if the queue size is exceeded which is not the case for the current/default blocking API
- user land code needs to be updated in order to leverage the new functionality (e.g. in order to address issues like in #169)

@tfoote @wjwwood Please review.
