### PR TITLE
xmlrpcpp compile fix for libc++ (OSX)

### DIFF
--- a/utilities/xmlrpcpp/include/base64.h
+++ b/utilities/xmlrpcpp/include/base64.h
@@ -13,6 +13,10 @@
 # include <iterator>
 #endif
 
+#if defined(__clang__)
+	#include <ios>
+#endif
+
 static
 int _base64Chars[]= {'A','B','C','D','E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',
 				     'a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',


### PR DESCRIPTION
When compiling using libc++, <ios> needs to be defined for std::ios_base to be found. Compiles under OSX 10.9 with this fix.
