### PR TITLE
Fix return value on platforms where char is unsigned.

### DIFF
--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -163,7 +163,7 @@ public:
     void publish();
 
 private:
-    char readCharFromStdin();
+    int readCharFromStdin();
     void setupTerminal();
     void restoreTerminal();
 

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -474,7 +474,7 @@ void Player::restoreTerminal() {
     terminal_modified_ = false;
 }
 
-char Player::readCharFromStdin() {
+int Player::readCharFromStdin() {
 #ifdef __APPLE__
     fd_set testfd;
     FD_COPY(&stdin_fdset_, &testfd);


### PR DESCRIPTION
On platforms where char is unsigned (ARM), rosbag loops forever instead of playing normally, because readCharFromStdin() can never return EOF which is defined to be negative. This patch switches the return type from char to int, which is signed on all platforms.

Note that readCharFromStdin() is implemented on linux using getc, which returns int. It makes sense that readCharFromStdin(), which has similar return semantics, should have the same return type.

This patch fixes the following compile warning:

```
/home/hendrix/hydro/src/ros_comm/tools/rosbag/src/player.cpp: In member function
 ‘void rosbag::Player::doPublish(const rosbag::MessageInstance&)’:
/home/hendrix/hydro/src/ros_comm/tools/rosbag/src/player.cpp:338:18: warning: case label value is less than minimum value for type [enabled by default]
/home/hendrix/hydro/src/ros_comm/tools/rosbag/src/player.cpp: In member function
 ‘void rosbag::Player::doKeepAlive()’:
/home/hendrix/hydro/src/ros_comm/tools/rosbag/src/player.cpp:393:18: warning: case label value is less than minimum value for type [enabled by default]
```
