### PR TITLE
roscpp: fixed name resolution of "/"

### DIFF
--- a/clients/roscpp/src/libros/names.cpp
+++ b/clients/roscpp/src/libros/names.cpp
@@ -107,7 +107,7 @@ std::string clean(const std::string& name)
     pos = clean.find("//", pos);
   }
 
-  if (*clean.rbegin() == '/')
+  if (clean.size() > 1 && *clean.rbegin() == '/')
   {
     clean.erase(clean.size() - 1, 1);
   }


### PR DESCRIPTION
This patches fixes a bug in roscpp's names module, that caused the string `"/"` to be resolved as empty string because the trailing slash was removed by `ros::names::clean("/")`. I guess this is not intended.

For example, the following code works to get a XmlRpcValue of all parameters:

```
XmlRpc::XmlRpcValue all_parameters;
assert(ros::param::get("", all_parameters));
```

while the following returns an error:

```
XmlRpc::XmlRpcValue all_parameters;
assert(ros::param::get("/", all_parameters));
```

Additionally, I am not sure if the result of the `ros::names::clean()` function was well-defined for empty strings.
