### PR TITLE
Added ability for applications to use rosbag recorder class and stop recording during usage

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -121,7 +121,7 @@ public:
 
     boost::shared_ptr<ros::Subscriber> subscribe(std::string const& topic);
 
-    int run();
+    int run(bool* stop_recording = NULL);
 
 private:
     void printUsage();
@@ -179,6 +179,8 @@ private:
     boost::mutex                  check_disk_mutex_;
     ros::WallTime                 check_disk_next_;
     ros::WallTime                 warn_next_;
+
+    bool*                         stop_recording_;       //!< used to end recording via a parent application
 };
 
 } // namespace rosbag

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -125,7 +125,20 @@ Recorder::Recorder(RecorderOptions const& options) :
 {
 }
 
-int Recorder::run() {
+int Recorder::run(bool* stop_recording) {
+
+    static bool false_bool = 0; // this should be used as a constant
+    // Check if the user passed in a pointer for the stop flag
+    if( !stop_recording )
+    {
+        // No stop flag given, set it to always false
+        stop_recording_ = &false_bool;
+    }
+    else
+    {
+        stop_recording_ = stop_recording;
+    }
+
     if (options_.trigger) {
         doTrigger();
         return 0;
@@ -146,7 +159,7 @@ int Recorder::run() {
     }
 
     ros::NodeHandle nh;
-    if (!nh.ok())
+    if (!nh.ok() || *stop_recording_)
         return 0;
 
     last_buffer_warn_ = Time();
@@ -166,7 +179,7 @@ int Recorder::run() {
     start_time_ = ros::Time::now();
 
     // Don't bother doing anything if we never got a valid time
-    if (!nh.ok())
+    if (!nh.ok() || *stop_recording_)
         return 0;
 
     ros::Subscriber trigger_sub;
@@ -189,8 +202,25 @@ int Recorder::run() {
     if (options_.record_all || options_.regex || (options_.node != std::string("")))
         check_master_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&Recorder::doCheckMaster, this, _1, boost::ref(nh)));
 
-    ros::MultiThreadedSpinner s(10);
-    ros::spin(s);
+    // If this class is being used within another application, it may need to have the ability to stop recording
+    if (stop_recording) // a stop flag was passed into the run() function so we need to allow the recording to end
+    {
+      // non-blocking spinner
+      ros::AsyncSpinner spinner(10);
+      spinner.start();
+
+      ros::Rate r(10);
+      while (ros::ok() && *stop_recording_ == false)
+      {
+        r.sleep();
+      }
+    }
+    else // default behavior
+    {
+      // blocking spinner
+      ros::MultiThreadedSpinner s(10);
+      ros::spin(s);
+    }
 
     queue_condition_.notify_all();
 
@@ -437,12 +467,12 @@ void Recorder::doRecord() {
     // Except it should only get checked if the node is not ok, and thus
     // it shouldn't be in contention.
     ros::NodeHandle nh;
-    while (nh.ok() || !queue_->empty()) {
+    while (!*stop_recording_ && ( nh.ok() || !queue_->empty() ) ) {
         boost::unique_lock<boost::mutex> lock(queue_mutex_);
 
         bool finished = false;
         while (queue_->empty()) {
-            if (!nh.ok()) {
+            if (!nh.ok() || *stop_recording_) {
                 lock.release()->unlock();
                 finished = true;
                 break;
@@ -486,10 +516,10 @@ void Recorder::doRecord() {
 void Recorder::doRecordSnapshotter() {
     ros::NodeHandle nh;
   
-    while (nh.ok() || !queue_queue_.empty()) {
+    while ( !*stop_recording_ && (nh.ok() || !queue_queue_.empty()) ) {
         boost::unique_lock<boost::mutex> lock(queue_mutex_);
         while (queue_queue_.empty()) {
-            if (!nh.ok())
+            if (!nh.ok() || *stop_recording_)
                 return;
             queue_condition_.wait(lock);
         }


### PR DESCRIPTION
The recorder class by default can only stop recording when the node is shutdown. This change adds a flag that allows ROS applications to start and stop recordings without having to deal with implementing their own subscribers and message handling logic.

The only change to the API is a single additional argument in a existing function, and it has a default value. Still, this probably should be targeted for indigo. I'm more just submitting this pull request for initial feedback. Maybe my implementation sucks, please let me know.

This change can be used with, for example, [rosbag_record_cpp](https://github.com/davetcoleman/rosbag_record_cpp/blob/master/src/rosbag_record.cpp)
