### PR TITLE
Transport information in SlaveAPI::getBusInfo() for `roscpp` and `rospy` nodes

### DIFF
--- a/clients/roscpp/include/ros/intraprocess_publisher_link.h
+++ b/clients/roscpp/include/ros/intraprocess_publisher_link.h
@@ -55,6 +55,7 @@ public:
   void setPublisher(const IntraProcessSubscriberLinkPtr& publisher);
 
   virtual std::string getTransportType();
+  virtual std::string getTransportInfo();
   virtual void drop();
 
   /**

--- a/clients/roscpp/include/ros/intraprocess_subscriber_link.h
+++ b/clients/roscpp/include/ros/intraprocess_subscriber_link.h
@@ -53,6 +53,7 @@ public:
   virtual void enqueueMessage(const SerializedMessage& m, bool ser, bool nocopy);
   virtual void drop();
   virtual std::string getTransportType();
+  virtual std::string getTransportInfo();
   virtual bool isIntraprocess() { return true; }
   virtual void getPublishTypes(bool& ser, bool& nocopy, const std::type_info& ti);
 

--- a/clients/roscpp/include/ros/publisher_link.h
+++ b/clients/roscpp/include/ros/publisher_link.h
@@ -81,6 +81,7 @@ public:
    */
   virtual void handleMessage(const SerializedMessage& m, bool ser, bool nocopy) = 0;
   virtual std::string getTransportType() = 0;
+  virtual std::string getTransportInfo() = 0;
   virtual void drop() = 0;
 
   const std::string& getMD5Sum();

--- a/clients/roscpp/include/ros/subscriber_link.h
+++ b/clients/roscpp/include/ros/subscriber_link.h
@@ -74,6 +74,7 @@ public:
   virtual void drop() = 0;
 
   virtual std::string getTransportType() = 0;
+  virtual std::string getTransportInfo() = 0;
 
   virtual bool isIntraprocess() { return false; }
   virtual void getPublishTypes(bool& ser, bool& nocopy, const std::type_info& ti) { ser = true; nocopy = false; }

--- a/clients/roscpp/include/ros/transport/transport_tcp.h
+++ b/clients/roscpp/include/ros/transport/transport_tcp.h
@@ -97,6 +97,7 @@ public:
    * \brief Returns the port this transport is listening on
    */
   int getServerPort() { return server_port_; }
+  int getLocalPort() { return local_port_; }
 
   void setNoDelay(bool nodelay);
   void setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint32_t count);
@@ -148,8 +149,11 @@ private:
   bool is_server_;
   sockaddr_storage server_address_;
   socklen_t sa_len_;
+  sockaddr_storage local_address_;
+  socklen_t la_len_;
 
   int server_port_;
+  int local_port_;
   AcceptCallback accept_cb_;
 
   std::string cached_remote_host_;

--- a/clients/roscpp/include/ros/transport/transport_udp.h
+++ b/clients/roscpp/include/ros/transport/transport_udp.h
@@ -145,7 +145,9 @@ private:
 
   bool is_server_;
   sockaddr_in server_address_;
+  sockaddr_in local_address_;
   int server_port_;
+  int local_port_;
 
   std::string cached_remote_host_;
 

--- a/clients/roscpp/include/ros/transport_publisher_link.h
+++ b/clients/roscpp/include/ros/transport_publisher_link.h
@@ -60,6 +60,7 @@ public:
   const ConnectionPtr& getConnection() { return connection_; }
 
   virtual std::string getTransportType();
+  virtual std::string getTransportInfo();
   virtual void drop();
 
 private:

--- a/clients/roscpp/include/ros/transport_subscriber_link.h
+++ b/clients/roscpp/include/ros/transport_subscriber_link.h
@@ -53,6 +53,7 @@ public:
   virtual void enqueueMessage(const SerializedMessage& m, bool ser, bool nocopy);
   virtual void drop();
   virtual std::string getTransportType();
+  virtual std::string getTransportInfo();
 
 private:
   void onConnectionDropped(const ConnectionPtr& conn);

--- a/clients/roscpp/src/libros/intraprocess_publisher_link.cpp
+++ b/clients/roscpp/src/libros/intraprocess_publisher_link.cpp
@@ -127,6 +127,12 @@ std::string IntraProcessPublisherLink::getTransportType()
   return std::string("INTRAPROCESS");
 }
 
+std::string IntraProcessPublisherLink::getTransportInfo()
+{
+  // TODO: Check if we can dump more useful information here
+  return getTransportType();
+}
+
 void IntraProcessPublisherLink::getPublishTypes(bool& ser, bool& nocopy, const std::type_info& ti)
 {
   boost::recursive_mutex::scoped_lock lock(drop_mutex_);

--- a/clients/roscpp/src/libros/intraprocess_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/intraprocess_subscriber_link.cpp
@@ -88,6 +88,12 @@ std::string IntraProcessSubscriberLink::getTransportType()
   return std::string("INTRAPROCESS");
 }
 
+std::string IntraProcessSubscriberLink::getTransportInfo()
+{
+  // TODO: Check if we can dump more useful information here
+  return getTransportType();
+}
+
 void IntraProcessSubscriberLink::drop()
 {
   {

--- a/clients/roscpp/src/libros/publication.cpp
+++ b/clients/roscpp/src/libros/publication.cpp
@@ -282,11 +282,8 @@ XmlRpc::XmlRpcValue Publication::getStats()
   return stats;
 }
 
-// rospy returns values like this:
-// [(1, "('127.0.0.1', 62334)", 'o', 'TCPROS', '/chatter')]
-//
-// We're outputting something like this:
-// (0, (127.0.0.1, 62707), o, TCPROS, /chatter)
+// Publisher : [(connection_id, destination_caller_id, direction, transport, topic_name, connected, connection_info_string)*]
+// e.g. [(2, '/listener', 'o', 'TCPROS', '/chatter', 1, 'TCPROS connection on port 55878 to [127.0.0.1:44273 on socket 7]')]
 void Publication::getInfo(XmlRpc::XmlRpcValue& info)
 {
   boost::mutex::scoped_lock lock(subscriber_links_mutex_);
@@ -300,6 +297,8 @@ void Publication::getInfo(XmlRpc::XmlRpcValue& info)
     curr_info[2] = "o";
     curr_info[3] = (*c)->getTransportType();
     curr_info[4] = name_;
+    curr_info[5] = true; // For length compatibility with rospy
+    curr_info[6] = (*c)->getTransportInfo();
     info[info.size()] = curr_info;
   }
 }

--- a/clients/roscpp/src/libros/subscription.cpp
+++ b/clients/roscpp/src/libros/subscription.cpp
@@ -118,11 +118,8 @@ XmlRpcValue Subscription::getStats()
   return stats;
 }
 
-// rospy returns values like this:
-// (1, 'http://127.0.0.1:62365/', 'i', 'TCPROS', '/chatter')
-//
-// We're outputting something like this:
-// (0, http://127.0.0.1:62438/, i, TCPROS, /chatter)
+// [(connection_id, publisher_xmlrpc_uri, direction, transport, topic_name, connected, connection_info_string)*]
+// e.g. [(1, 'http://host:54893/', 'i', 'TCPROS', '/chatter', 1, 'TCPROS connection on port 59746 to [host:34318 on socket 11]')]
 void Subscription::getInfo(XmlRpc::XmlRpcValue& info)
 {
   boost::mutex::scoped_lock lock(publisher_links_mutex_);
@@ -136,6 +133,8 @@ void Subscription::getInfo(XmlRpc::XmlRpcValue& info)
     curr_info[2] = "i";
     curr_info[3] = (*c)->getTransportType();
     curr_info[4] = name_;
+    curr_info[5] = true; // For length compatibility with rospy
+    curr_info[6] = (*c)->getTransportInfo();
     info[info.size()] = curr_info;
   }
 }

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -55,6 +55,7 @@ TransportTCP::TransportTCP(PollSet* poll_set, int flags)
 , expecting_write_(false)
 , is_server_(false)
 , server_port_(-1)
+, local_port_(-1)
 , poll_set_(poll_set)
 , flags_(flags)
 {
@@ -110,6 +111,21 @@ bool TransportTCP::initializeSocket()
       std::stringstream ss;
       ss << getClientURI() << " on socket " << sock_;
       cached_remote_host_ = ss.str();
+    }
+  }
+
+  if (local_port_ < 0)
+  {
+    la_len_ = s_use_ipv6_  ? sizeof(sockaddr_in6) : sizeof(sockaddr_in);
+    getsockname(sock_, (sockaddr *)&local_address_, &la_len_);
+    switch (local_address_.ss_family)
+    {
+      case AF_INET:
+        local_port_ = ntohs(((sockaddr_in *)&local_address_)->sin_port);
+        break;
+      case AF_INET6:
+        local_port_ = ntohs(((sockaddr_in6 *)&local_address_)->sin6_port);
+        break;
     }
   }
 
@@ -217,6 +233,7 @@ bool TransportTCP::connect(const std::string& host, int port)
     sockaddr_in *address = (sockaddr_in*) &sas;
     sas_len = sizeof(sockaddr_in);
     
+    la_len_ = sizeof(sockaddr_in);
     address->sin_family = AF_INET;
     address->sin_port = htons(port);
     address->sin_addr.s_addr = ina.s_addr;
@@ -225,6 +242,7 @@ bool TransportTCP::connect(const std::string& host, int port)
   {
     sockaddr_in6 *address = (sockaddr_in6*) &sas;
     sas_len = sizeof(sockaddr_in6);
+    la_len_ = sizeof(sockaddr_in6);
     address->sin6_family = AF_INET6;
     address->sin6_port = htons(port);
     memcpy(address->sin6_addr.s6_addr, in6a.s6_addr, sizeof(in6a.s6_addr));
@@ -682,7 +700,9 @@ void TransportTCP::socketUpdate(int events)
 
 std::string TransportTCP::getTransportInfo()
 {
-  return "TCPROS connection to [" + cached_remote_host_ + "]";
+  std::stringstream str;
+  str << "TCPROS connection on port " << local_port_ << " to [" << cached_remote_host_ << "]";
+  return str.str();
 }
 
 std::string TransportTCP::getClientURI()

--- a/clients/roscpp/src/libros/transport_publisher_link.cpp
+++ b/clients/roscpp/src/libros/transport_publisher_link.cpp
@@ -298,5 +298,10 @@ std::string TransportPublisherLink::getTransportType()
   return connection_->getTransport()->getType();
 }
 
+std::string TransportPublisherLink::getTransportInfo()
+{
+  return connection_->getTransport()->getTransportInfo();
+}
+
 } // namespace ros
 

--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -220,6 +220,11 @@ std::string TransportSubscriberLink::getTransportType()
   return connection_->getTransport()->getType();
 }
 
+std::string TransportSubscriberLink::getTransportInfo()
+{
+  return connection_->getTransport()->getTransportInfo();
+}
+
 void TransportSubscriberLink::drop()
 {
   // Only drop the connection if it's not already sending a header error

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -461,6 +461,14 @@ class TCPROSTransport(Transport):
         self.md5sum = None
         self.type = None 
             
+    def get_transport_info(self):
+        """
+        Get detailed connection information.
+        Similar to getTransportInfo() in 'libros/transport/transport_tcp.cpp'
+        e.g. TCPROS connection on port 41374 to [127.0.0.1:40623 on socket 6]
+        """
+        return "%s connection on port %s to [%s:%s on socket %s]" % (self.transport_type, self.local_endpoint[1], self.remote_endpoint[0], self.remote_endpoint[1], self._fileno)
+
     def fileno(self):
         """
         Get descriptor for select
@@ -488,6 +496,7 @@ class TCPROSTransport(Transport):
         self.socket = sock
         self.endpoint_id = endpoint_id
         self._fileno = sock.fileno()
+        self.local_endpoint = self.socket.getsockname()
 
     def connect(self, dest_addr, dest_port, endpoint_id, timeout=None):
         """
@@ -531,6 +540,8 @@ class TCPROSTransport(Transport):
             self.socket.connect((dest_addr, dest_port))
             self.write_header()
             self.read_header()
+            self.local_endpoint = self.socket.getsockname()
+            self.remote_endpoint = (dest_addr, dest_port)
         except TransportInitError as tie:
             rospyerr("Unable to initiate TCP/IP socket to %s:%s (%s): %s"%(dest_addr, dest_port, endpoint_id, traceback.format_exc()))            
             raise

--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -351,6 +351,7 @@ class TCPROSHandler(rospy.impl.transport.ProtocolHandler):
                 protocol = TCPROSPub(resolved_topic_name, topic.data_class, is_latch=topic.is_latch, headers=topic.headers)
                 transport = TCPROSTransport(protocol, resolved_topic_name)
                 transport.set_socket(sock, header['callerid'])
+                transport.remote_endpoint = client_addr
                 transport.write_header()
                 topic.add_connection(transport)
             

--- a/clients/rospy/src/rospy/impl/transport.py
+++ b/clients/rospy/src/rospy/impl/transport.py
@@ -79,6 +79,10 @@ class Transport(object):
         # Number of messages that have passed through this transport
         self.stat_num_msg = 0         
     
+        # Endpoint Details (IP, Port)
+        self.local_endpoint = (0, 0)
+        self.remote_endpoint = (0, 0)
+
     def fileno(self):
         """
         Get a file descriptor for select() if available
@@ -105,6 +109,11 @@ class Transport(object):
     def write_data(self, data):
         raise Exception("not implemented")
 
+    ## Implements the getTransportInfo() from roscpp
+    ## Similar to getTransportInfo() in 'libros/transport/transport_tcp.cpp'
+    def get_transport_info(self):
+        raise NotImplementedError
+
 ## Shell class to hold stats about transport that is being killed off.
 ## This allows the information to stick around but the original Tranport to be gc'd
 class DeadTransport(Transport):
@@ -120,6 +129,12 @@ class DeadTransport(Transport):
         self.stat_num_msg = transport.stat_num_msg
         self.done         = True
         self.endpoint_id  = transport.endpoint_id
+        self.local_endpoint = transport.local_endpoint
+        self.remote_endpoint = transport.remote_endpoint
+
+    ## @param self
+    def get_transport_info(self):
+        return "Closed %s connection on port %s to [%s:%s]" % (self.transport_type, self.local_endpoint[1], self.remote_endpoint[0], self.remote_endpoint[1])
 
 ## ProtocolHandler interface: implements topic communication for a
 ## particular protocol(s).  In order to understand the methods of this

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -429,12 +429,15 @@ class _TopicImpl(object):
         """
         Get the stats for this topic
         @return: stats for topic in getBusInfo() format::
-          ((connection_id, destination_caller_id, direction, transport, topic_name, connected)*)
+          Publisher:
+          ((connection_id, destination_caller_id, direction, transport, topic_name, connected, connection_info_string)*)
+          Subscriber:
+          ((connection_id, publisher_xmlrpc_uri, direction, transport, topic_name, connected, connection_info_string)*)
         @rtype: list
         """
         # save referenceto avoid locking
         connections = self.connections
-        return [(c.id, c.endpoint_id, c.direction, c.transport_type, self.resolved_name, True) for c in connections]
+        return [(c.id, c.endpoint_id, c.direction, c.transport_type, self.resolved_name, True, c.get_transport_info()) for c in connections]
 
     def get_stats(self): # STATS
         """Get the stats for this topic (API stub)"""


### PR DESCRIPTION
With the following changes, `roscpp` and `rospy` nodes will append an extra field to `getBusInfo()` response [in [slave XMLRPC API](http://wiki.ros.org/ROS/Slave_API)] to include detailed transport information. The format is as follows:

_CONNTYPE_ connection on port _LOCALPORT_ to [_REMOTEHOST_:_PORT_ on socket  _SOCKETNUMBER_]

e.g.

```
TCPROS connection on port 56858 to [127.0.0.1:32993 on socket 10]
```
- It looks as if `UDPROS` is not completely supported by `rospy`. Therefore no response will be sent by `rospy` nodes using UDP (is it even possible?).
- For `roscpp` and UDP, I could not find a way to reliably determine `remotehost:port`  and `socketnumber` for _subscriber_ links. (_publisher_ links work fine.)
- This PR also adds an extra field to `roscpp` `getBusInfo()` responses to make the length equal to responses sent by `rospy` nodes.  

This is my first time to send pull request to core ROS packages. Any comment or hints is highly appreciated. I am also more than happy to write tests for the new feature if it is required. 
