### PR TITLE
readd g_level_lockup symbol for backward compatibility when log4cxx is being used

### DIFF
--- a/tools/rosconsole/CMakeLists.txt
+++ b/tools/rosconsole/CMakeLists.txt
@@ -47,7 +47,7 @@ catkin_package(
   CFG_EXTRAS rosconsole-extras.cmake
 )
 
-include(cmake/rosconsole-extras.cmake)
+include(${CATKIN_DEVEL_PREFIX}/share/${PROJECT_NAME}/cmake/rosconsole-extras.cmake)
 
 # See ticket: https://code.ros.org/trac/ros/ticket/3626
 # On mac use g++-4.2

--- a/tools/rosconsole/cmake/rosconsole-extras.cmake.in
+++ b/tools/rosconsole/cmake/rosconsole-extras.cmake.in
@@ -7,4 +7,9 @@ cmake_policy(SET CMP0005 NEW)
 # add ROS_PACKAGE_NAME define required by the named logging macros
 add_definitions(-DROS_PACKAGE_NAME=\"${PROJECT_NAME}\")
 
+if("@ROSCONSOLE_BACKEND@" STREQUAL "log4cxx")
+  # add ROSCONSOLE_BACKEND_LOG4CXX define required for backward compatible log4cxx symbols
+  add_definitions(-DROSCONSOLE_BACKEND_LOG4CXX)
+endif()
+
 cmake_policy(POP)

--- a/tools/rosconsole/include/ros/console.h
+++ b/tools/rosconsole/include/ros/console.h
@@ -41,6 +41,10 @@
 #include <ros/macros.h>
 #include <map>
 
+#ifdef ROSCONSOLE_BACKEND_LOG4CXX
+#include "log4cxx/level.h"
+#endif
+
 // Import/export for windows dll's and visibility for gcc shared libraries.
 
 #ifdef ROS_BUILD_SHARED_LIBS // ros is being built around shared libraries
@@ -74,6 +78,10 @@ namespace console
 {
 
 ROSCONSOLE_DECL void shutdown();
+
+#ifdef ROSCONSOLE_BACKEND_LOG4CXX
+extern ROSCONSOLE_DECL log4cxx::LevelPtr g_level_lookup[];
+#endif
 
 extern ROSCONSOLE_DECL bool get_loggers(std::map<std::string, levels::Level>& loggers);
 extern ROSCONSOLE_DECL bool set_logger_level(const std::string& name, levels::Level level);

--- a/tools/rosconsole/src/rosconsole/rosconsole.cpp
+++ b/tools/rosconsole/src/rosconsole/rosconsole.cpp
@@ -48,7 +48,6 @@
 #include <cstring>
 #include <stdexcept>
 
-
 // declare interface for rosconsole implementations
 namespace ros
 {
@@ -82,6 +81,16 @@ bool g_initialized = false;
 bool g_shutting_down = false;
 boost::mutex g_init_mutex;
 
+#ifdef ROSCONSOLE_BACKEND_LOG4CXX
+log4cxx::LevelPtr g_level_lookup[levels::Count] =
+{
+  log4cxx::Level::getDebug(),
+  log4cxx::Level::getInfo(),
+  log4cxx::Level::getWarn(),
+  log4cxx::Level::getError(),
+  log4cxx::Level::getFatal(),
+};
+#endif
 std::string g_last_error_message = "Unknown Error";
 
 #ifdef WIN32


### PR DESCRIPTION
@tfoote @wjwwood I am not sure if you have seen this:
- http://answers.ros.org/question/116436/missing-log4cxx-on-latest-ros_comm/
- https://github.com/ros-drivers/hokuyo_node/pull/8

Since I don't think that it is a good idea to pull the changes back out I would propose to readd the symbol in question (`g_level_lookup`) as done in this pull request. That backward compatible symbol can be removed for indigo again. Downstream packages will still need to explicitly state their dependency on log4cxx - I think that is reasonable since these packages are simply relying on a transitive dependency (which is gone now).
