### PR TITLE
modify rostest to wait when other instances are running

### DIFF
--- a/tools/rostest/scripts/rostest
+++ b/tools/rostest/scripts/rostest
@@ -31,5 +31,23 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import socket
+import time
 from rostest import rostestmain
+
+message_printed = False
+while True:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.bind(('127.0.0.1', 22421))  # choose port close to test roscore
+        break
+    except socket.error as e:
+        if e.errno != socket.errno.EADDRINUSE:
+            raise
+        if not message_printed:
+            print('Another rostest instance is currently running, waiting until it finished...')
+            message_printed = True
+        time.sleep(0.25)
+        continue
+
 rostestmain()


### PR DESCRIPTION
Until now rostest just fails when another instance is running. With this modification it actually waits (with a message) until other instances have finished. Than allows catkin to drop it's special handling of running unit tests single threaded.

For a workspace with the base ROS packages the time necessary to run the unit tests is reduced by roughly 15%. The result might vary significantly bases on the number and kind of tests and their order in CMake. (E.g. it does not prevent CMake to schedule N rostests where N-1 of them will ust be waiting.)

@tfoote @wjwwood Please review.
