### PR TITLE
Simplify code: map.erase() can take a string directly

### DIFF
--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -221,12 +221,7 @@ bool del(const std::string& key)
     if (sub_it != g_subscribed_params.end())
     {
       g_subscribed_params.erase(sub_it);
-
-      M_Param::iterator param_it = g_params.find(mapped_key);
-      if (param_it != g_params.end())
-      {
-        g_params.erase(param_it);
-      }
+      g_params.erase(mapped_key);
     }
   }
 


### PR DESCRIPTION
Removes a few lines...

Out of curiosity, what's the reason for having g_subscribed_params in the first place? Does it make a speed difference (by requiring fewer memory accesses when the key is not in the subscriber list)?
