### PR TITLE
roscpp: support for /clock remapping

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -401,7 +401,7 @@ void start()
     if (use_sim_time)
     {
       ros::SubscribeOptions ops;
-      ops.init<rosgraph_msgs::Clock>("/clock", 1, clockCallback);
+      ops.init<rosgraph_msgs::Clock>(names::resolve("/clock"), 1, clockCallback);
       ops.callback_queue = getInternalCallbackQueue().get();
       TopicManager::instance()->subscribe(ops);
     }


### PR DESCRIPTION
/clock was the only topic which cannot be remapped, which hurt flexibility
without reason.

Admittedly, my use case for remapping /clock is somewhat weird (controlling rviz time from outside while also running gazebo in parallel), but hey, more flexibility can't hurt, right?

Also applies to hydro-devel and indigo-devel without problems.
