### PR TITLE
suppress boost::signals deprecation warning

### DIFF
--- a/clients/roscpp/include/ros/connection.h
+++ b/clients/roscpp/include/ros/connection.h
@@ -38,7 +38,16 @@
 #include "ros/header.h"
 #include "common.h"
 
+#ifndef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
 #include <boost/signals.hpp>
+#ifdef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
+
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/shared_array.hpp>

--- a/clients/roscpp/include/ros/poll_manager.h
+++ b/clients/roscpp/include/ros/poll_manager.h
@@ -31,7 +31,17 @@
 #include "forwards.h"
 #include "poll_set.h"
 #include "common.h"
+
+#ifndef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
 #include <boost/signals.hpp>
+#ifdef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
+
 #include <boost/thread/recursive_mutex.hpp>
 #include <boost/thread/thread.hpp>
 

--- a/utilities/message_filters/include/message_filters/cache.h
+++ b/utilities/message_filters/include/message_filters/cache.h
@@ -38,7 +38,17 @@
 #include <deque>
 #include "boost/thread.hpp"
 #include "boost/shared_ptr.hpp"
+
+#ifndef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
 #include <boost/signals.hpp>
+#ifdef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
+
 #include "ros/time.h"
 
 #include "connection.h"

--- a/utilities/message_filters/include/message_filters/subscriber.h
+++ b/utilities/message_filters/include/message_filters/subscriber.h
@@ -37,7 +37,16 @@
 
 #include <ros/ros.h>
 
+#ifndef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
 #include <boost/signals.hpp>
+#ifdef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
+
 #include <boost/thread/mutex.hpp>
 
 #include "connection.h"

--- a/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
@@ -44,7 +44,17 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <boost/thread/mutex.hpp>
+
+#ifndef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
 #include <boost/signals.hpp>
+#ifdef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
+
 #include <boost/bind.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>

--- a/utilities/message_filters/include/message_filters/sync_policies/exact_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/exact_time.h
@@ -44,7 +44,17 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <boost/thread/mutex.hpp>
+
+#ifndef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
 #include <boost/signals.hpp>
+#ifdef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
+
 #include <boost/bind.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>

--- a/utilities/message_filters/include/message_filters/synchronizer.h
+++ b/utilities/message_filters/include/message_filters/synchronizer.h
@@ -39,7 +39,17 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/function.hpp>
 #include <boost/thread/mutex.hpp>
+
+#ifndef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#define ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
 #include <boost/signals.hpp>
+#ifdef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef ros_BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#undef BOOST_SIGNALS_NO_DEPRECATION_WARNING
+#endif
+
 #include <boost/bind.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>


### PR DESCRIPTION
The approach to use local defines is favored over a global `add_definition()` in CMake since it will suppress warning only for the code in ros_comm. If user code uses the boost signal header they will still get the warning and have to suppress them on their own.
