### PR TITLE
Add hostname lookup failure to xmlrpc. Fixes #364

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -209,6 +209,7 @@ XmlRpcSocket::connect(int fd, std::string& host, int port)
   hints.ai_family = AF_UNSPEC;
   if (getaddrinfo(host.c_str(), NULL, &hints, &addr) != 0)
   {
+    fprintf(stderr, "Couldn't find an %s address for [%s]\n", s_use_ipv6_ ? "AF_INET6" : "AF_INET", host.c_str());
     return false;
   }
 


### PR DESCRIPTION
Now we get  nice error message if we cannot resolve the hostname of the hostname of the remote machine:

```
$ rostopic info /chatter
Type: std_msgs/String

Publishers: 
 * /talker (http://foo:58605/)

Subscribers: None

$ rosrun roscpp_tutorials listener
Couldn't find an AF_INET address for [foo]
```
