### PR TITLE
make rostest in CMakeLists optional (ros/rosdistro#3010)

### DIFF
--- a/tools/rosnode/CMakeLists.txt
+++ b/tools/rosnode/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosnode)
-find_package(catkin REQUIRED COMPONENTS rostest)
+find_package(catkin REQUIRED)
 catkin_package()
 
 catkin_python_setup()
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest)
   add_rostest(test/rosnode.test)
 endif()

--- a/tools/rostopic/CMakeLists.txt
+++ b/tools/rostopic/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rostopic)
-find_package(catkin REQUIRED COMPONENTS rostest)
+find_package(catkin REQUIRED)
 catkin_package()
 
 catkin_python_setup()
@@ -9,5 +9,6 @@ install(PROGRAMS scripts/rostopic
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest)
   add_rostest(test/rostopic.test)
 endif()

--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(topic_tools)
-find_package(catkin COMPONENTS cpp_common message_generation rosconsole roscpp rostest rostime rosunit std_msgs xmlrpcpp)
+find_package(catkin COMPONENTS cpp_common message_generation rosconsole roscpp rostime std_msgs xmlrpcpp)
 
 include_directories(include)
 include_directories(${catkin_INCLUDE_DIRS})
@@ -62,6 +62,7 @@ install(PROGRAMS
 
 #Testing
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest rosunit)
   catkin_add_gtest(${PROJECT_NAME}-utest test/utest.cpp)
   if(TARGET ${PROJECT_NAME}-utest)
     target_link_libraries(${PROJECT_NAME}-utest topic_tools)

--- a/utilities/roswtf/CMakeLists.txt
+++ b/utilities/roswtf/CMakeLists.txt
@@ -1,10 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(roswtf)
-find_package(catkin REQUIRED COMPONENTS rostest)
+find_package(catkin REQUIRED)
 catkin_package()
 catkin_python_setup()
 
 if(CATKIN_ENABLE_TESTING)
+  find_package(rostest)
   add_rostest(test/roswtf.test)
   catkin_add_nosetests(test)
 endif()


### PR DESCRIPTION
I was unsure if I should add this commit to hydro-devel and/or indigo-devel. So for the moment, I just added this patch to the hydro-devel branch, because the latest release 1.10.1 was on this branch.
