### PR TITLE
Use HTTP1.1: we get persistent connections for free

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -75,7 +75,12 @@ def isstring(s):
     except NameError:
         return isinstance(s, str)
 
-class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
+class BaseXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
+
+    # Use HTTP/1.1. This gives us persistent connections.
+    protocol_version = 'HTTP/1.1'
+
+class SilenceableXMLRPCRequestHandler(BaseXMLRPCRequestHandler):
     def log_message(self, format, *args):
         if 0:
             SimpleXMLRPCRequestHandler.log_message(self, format, *args)


### PR DESCRIPTION
Hi,

Currently rospy creates a new socket for every single request (eg. getParam call). Since sockets stay around for a while in CLOSE_WAIT state, this can become a serious problem.

Python's xmlrpc actually supports persistent connections. All that's needed is configuring SimpleXMLRPCRequestHandler to use HTTP 1.1 (vs. 1.0) and it'll automatically keep connections open and re-use them for subsequent calls.

With this you go from:

``` bash
$ sudo netstat -atpn | grep 11311 | wc -l
1434
$ python -c "from rosmaster import util; s = util.xmlrpcapi('http://localhost:11311'); [s.getParam('foo', 'bar') for i in range(1000)]"
$ sudo netstat -atpn | grep 11311 | wc -l
2449
```

to:

``` bash
$ sudo netstat -atpn | grep 11311 | wc -l
1728
$ python -c "from rosmaster import util; s = util.xmlrpcapi('http://localhost:11311'); [s.getParam('foo', 'bar') for i in range(1000)]"
siegfriedgevatter@thailand:svn:
$ sudo netstat -atpn | grep 11311 | wc -l
1732
```
