### PR TITLE
add warning when queue_size is omitted for rospy publisher

### DIFF
--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -67,7 +67,7 @@ def init_rosout():
         global _rosout_pub
         if _rosout_pub is None:
             logger.info("initializing %s core topic"%_ROSOUT)
-            _rosout_pub = Publisher(_ROSOUT, Log, latch=True)
+            _rosout_pub = Publisher(_ROSOUT, Log, latch=True, queue_size=100)
             logger.info("connected to core topic %s"%_ROSOUT)
         return True
     except Exception as e:

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -757,6 +757,16 @@ class Publisher(Topic):
         'latched', meaning that any future subscribers will be sent
         that message immediately upon connection.
         @type  latch: bool
+        @param headers: If not None, a dictionary with additional header
+        key-values being used for future connections.
+        @type  headers: dict
+        @param queue_size: The queue size used for asynchronously
+        publishing messages from different threads.  A size of zero
+        means an infinite queue, which can be dangerous.  When the
+        keyword is not being used or when None is passed all
+        publishing will happen synchronously and a warning message
+        will be printed.
+        @type  queue_size: int
         @raise ROSException: if parameters are invalid     
         """
         super(Publisher, self).__init__(name, data_class, Registration.PUB)
@@ -771,7 +781,11 @@ class Publisher(Topic):
             self.impl.add_headers(headers)
         if queue_size is not None:
             self.impl.set_queue_size(queue_size)
-            
+        else:
+            import warnings
+            warnings.warn("The publisher should be created with an explicit keyword argument 'queue_size'. "
+                "Please see http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers for more information.", SyntaxWarning, stacklevel=2)
+
     def publish(self, *args, **kwds):
         """
         Publish message data object to this topic. 


### PR DESCRIPTION
The warning can be suppressed by setting:

```
export PYTHONWARNINGS="ignore::SyntaxWarning"
```

I choose `SyntaxWarning` since I wanted to make it distinguishable from the existing warnings in rospy (which are by default `UserWarnings`).

This **will** lead to a lot of warning for every existing Python code out there. I am just saying this explicitly. We should consider that and also might want to ask the community about that?

@esteve @tfoote @wjwwood Please review and provide feedback.
