### PR TITLE
roscpp: Adding AsyncSpinner::canStart to check if a spinner can be started

### DIFF
--- a/clients/roscpp/include/ros/spinner.h
+++ b/clients/roscpp/include/ros/spinner.h
@@ -109,6 +109,11 @@ public:
 
 
   /**
+   * \brief Check if the spinner can be started. A spinner can't be started if
+   * another spinner is already running.
+   */
+  bool canStart();
+  /**
    * \brief Start this spinner spinning asynchronously
    */
   void start();


### PR DESCRIPTION
This adds the introspection described in https://github.com/ros/ros_comm/issues/277

Should a PR also be made against hydro?
