### PR TITLE
Adding 'doc' attribute to roslaunch <arg> tags

### DIFF
--- a/test/test_roslaunch/test/ros_args.launch
+++ b/test/test_roslaunch/test/ros_args.launch
@@ -1,0 +1,7 @@
+<launch>
+  <arg name="foo" default="true" doc="I pity the foo'."/>
+  <arg name="bar" doc="Someone walks into this."/>
+  <arg name="baz" default="false"/>
+  <arg name="nop"/>
+  <arg name="fix" value="true"/>
+</launch>

--- a/test/test_roslaunch/test/roslaunch.test
+++ b/test/test_roslaunch/test/roslaunch.test
@@ -1,3 +1,4 @@
 <launch>
   <test test-name="roslaunch_command_line_online" pkg="test_roslaunch" type="test_roslaunch_command_line_online.py" />
+  <test test-name="roslaunch_ros_args" pkg="test_roslaunch" type="test_roslaunch_ros_args.py" />
 </launch>

--- a/test/test_roslaunch/test/test_roslaunch_ros_args.py
+++ b/test/test_roslaunch/test/test_roslaunch_ros_args.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, The Johns Hopkins University
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+PKG = 'roslaunch'
+NAME = 'test_roslaunch_ros_args'
+
+import os
+import sys 
+import unittest
+
+import rostest
+
+import rospkg
+import roslaunch.arg_dump
+
+class TestRoslaunchRosArgs(unittest.TestCase):
+
+    def setUp(self):
+        self.vals = set()
+        self.msgs = {}
+
+    def test_roslaunch(self):
+        rospack = rospkg.RosPack()
+        filename = os.path.join(rospack.get_path('test_roslaunch'), 'test', 'ros_args.launch')
+
+        args = roslaunch.arg_dump.get_args([filename])
+
+        expected_args = {
+                'foo': ("I pity the foo'.", 'true'),
+                'bar': ("Someone walks into this.", None,),
+                'baz': (None, 'false'),
+                'nop': (None, None)}
+
+        self.assertEqual(args, expected_args)
+
+if __name__ == '__main__':
+    rostest.run(PKG, NAME, TestRoslaunchRosArgs, sys.argv)

--- a/tools/roslaunch/src/roslaunch/arg_dump.py
+++ b/tools/roslaunch/src/roslaunch/arg_dump.py
@@ -45,7 +45,7 @@ from roslaunch.config import load_config_default
 def get_args(roslaunch_files):
     loader = roslaunch.xmlloader.XmlLoader(resolve_anon=False)
     config = load_config_default(roslaunch_files, None, loader=loader, verbose=False, assign_machines=False)
-    return loader.root_context.resolve_dict['arg']
+    return loader.root_context.resolve_dict.get('arg_doc', {})
 
 def dump_args(roslaunch_files):
     """
@@ -55,9 +55,26 @@ def dump_args(roslaunch_files):
     @param roslaunch_files: list of launch files to load
     @type  roslaunch_files: str
     """
+
     try:
-        for arg in sorted(get_args(roslaunch_files).items()):
-        	print arg[0]
+        args = get_args(roslaunch_files)
+
+        if len(args) == 0:
+            print("No arguments.")
+        else:
+            required_args = [(name, (doc or 'undocumented', default)) for (name, (doc, default)) in args.items() if not default]
+            optional_args = [(name, (doc or 'undocumented', default)) for (name, (doc, default)) in args.items() if default]
+
+            if len(required_args) > 0:
+                print("Required Arguments:")
+                for (name, (doc, _)) in sorted(required_args):
+                    print("  %s: %s" % (name, doc))
+
+            if len(optional_args) > 0:
+                print("Optional Arguments:")
+                for (name, (doc, default)) in sorted(optional_args):
+                    print("  %s (default \"%s\"): %s" % (name, default, doc))
+
     except RLException as e:
         print >> sys.stderr, str(e)
         sys.exit(1)

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -209,7 +209,7 @@ class LoaderContext(object):
             self._remap_args.remove(m)
         self._remap_args.append(remap)
         
-    def add_arg(self, name, default=None, value=None):
+    def add_arg(self, name, default=None, value=None, doc=None):
         """
         Add 'arg' to existing context. Args are only valid for their immediate context.
         """
@@ -239,6 +239,16 @@ class LoaderContext(object):
             # no value or default: appending to arg_names is all we
             # need to do as it declares the existence of the arg.
             pass
+
+        # add arg documentation string dict if it doesn't exist yet and if it can be used
+        if not 'arg_doc' in resolve_dict:
+            resolve_dict['arg_doc'] = {}
+        arg_doc_dict = resolve_dict['arg_doc']
+
+        if not value:
+            # store the documentation for this argument
+            arg_doc_dict[name] = (doc, default)
+
         
     def remap_args(self):
         """

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -254,7 +254,7 @@ class XmlLoader(loader.Loader):
             raise XmlParseException(
                 "Invalid <param> tag: %s. \n\nParam xml is %s"%(e, tag.toxml()))
 
-    ARG_ATTRS = ('name', 'value', 'default')
+    ARG_ATTRS = ('name', 'value', 'default', 'doc')
     @ifunless
     def _arg_tag(self, tag, context, ros_config, verbose=True):
         """
@@ -263,13 +263,13 @@ class XmlLoader(loader.Loader):
         try:
             self._check_attrs(tag, context, ros_config, XmlLoader.ARG_ATTRS)
             (name,) = self.reqd_attrs(tag, context, ('name',))
-            value, default = self.opt_attrs(tag, context, ('value', 'default'))
+            value, default, doc = self.opt_attrs(tag, context, ('value', 'default', 'doc'))
             
             if value is not None and default is not None:
                 raise XmlParseException(
                     "<arg> tag must have one and only one of value/default.")
             
-            context.add_arg(name, value=value, default=default)
+            context.add_arg(name, value=value, default=default, doc=doc)
 
         except substitution_args.ArgException as e:
             raise XmlParseException(


### PR DESCRIPTION
This is implemented as described in https://github.com/ros/ros_comm/issues/294#issuecomment-37079708

Additionally, it brings `arg_dump.py` into python3 compliance with the `print()` function.

This should also be a viable modification for release into hydro.
