### PR TITLE
Topic/Connection statistic measurements

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(roscpp
   src/libros/topic_manager.cpp
   src/libros/poll_manager.cpp
   src/libros/publication.cpp
+  src/libros/statistics.cpp
   src/libros/intraprocess_subscriber_link.cpp
   src/libros/intraprocess_publisher_link.cpp
   src/libros/callback_queue.cpp

--- a/clients/roscpp/include/ros/statistics.h
+++ b/clients/roscpp/include/ros/statistics.h
@@ -68,12 +68,12 @@ public:
 private:
 
   // these are hard constrains
-  static const int MAX_WINDOW = 64;
-  static const int MIN_WINDOW = 4;
+  int max_window;
+  int min_window;
 
   // these are soft constrains 
-  static const int MAX_ELEMENTS = 100;
-  static const int MIN_ELEMENTS = 10;
+  int max_elements;
+  int min_elements;
 
   bool enable_statistics;
 

--- a/clients/roscpp/include/ros/statistics.h
+++ b/clients/roscpp/include/ros/statistics.h
@@ -92,7 +92,7 @@ private:
     // arrival times of all messages within the current window
     std::list<ros::Time> arrival_time_list;
     // delays all messages within the current window (if available)
-    std::list<double> delay_list;
+    std::list<ros::Duration> delay_list;
     // number of dropped messages
     uint64_t dropped_msgs;
     // latest sequence number observered (if available)

--- a/clients/roscpp/include/ros/statistics.h
+++ b/clients/roscpp/include/ros/statistics.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2013-2014, Dariush Forouher
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef STATISTICS_H
+#define STATISTICS_H
+
+#include "forwards.h"
+#include "poll_set.h"
+#include "common.h"
+#include "publisher.h"
+#include <ros/time.h>
+#include "ros/subscription_callback_helper.h"
+#include <map>
+
+namespace ros
+{
+
+/**
+ * \brief This class logs statistics data about a ROS connection and
+ * publishs them periodically on a common topic.
+ *
+ * It provides a callback() function that has to be called everytime
+ * a new message arrives on a topic.
+ */
+class ROSCPP_DECL StatisticsLogger
+{
+public:
+
+  /**
+   * Constructior
+   */
+  StatisticsLogger();
+
+  /**
+   * Actual initialization. Must be called before the first call to callback()
+   */
+  void init(const SubscriptionCallbackHelperPtr& helper);
+
+  /**
+   * Callback function. Must be called for every message received.
+   */
+  void callback(const boost::shared_ptr<M_string>& connection_header, const std::string& topic, const std::string& callerid, const SerializedMessage& m, const uint64_t& bytes_sent, const ros::Time& received_time, const bool dropped);
+
+private:
+
+  // these are hard constrains
+  static const int MAX_WINDOW = 64;
+  static const int MIN_WINDOW = 4;
+
+  // these are soft constrains 
+  static const int MAX_ELEMENTS = 100;
+  static const int MIN_ELEMENTS = 10;
+
+  bool enable_statistics;
+
+  // remember, if this message type has a header
+  bool hasHeader_;
+
+  // frequency to publish statistics
+  double pub_frequency_;
+
+  // publisher for statistics data
+  ros::Publisher pub_;
+
+  struct StatData {
+    // last time, we published /statistics data
+    ros::Time last_publish;
+    // arrival times of all messages within the current window
+    std::list<ros::Time> arrival_time_list;
+    // delays all messages within the current window (if available)
+    std::list<double> delay_list;
+    // number of dropped messages
+    uint64_t dropped_msgs;
+    // latest sequence number observered (if available)
+    uint64_t last_seq;
+    // latest total traffic volume observed
+    uint64_t stat_bytes_last;
+  };
+
+  // storage for statistics data
+  std::map<std::string, struct StatData> map_;
+};
+
+}
+
+#endif

--- a/clients/roscpp/include/ros/subscription.h
+++ b/clients/roscpp/include/ros/subscription.h
@@ -34,6 +34,7 @@
 #include "ros/forwards.h"
 #include "ros/transport_hints.h"
 #include "ros/xmlrpc_manager.h"
+#include "ros/statistics.h"
 #include "XmlRpc.h"
 
 #include <boost/thread.hpp>
@@ -224,6 +225,8 @@ private:
   boost::mutex publisher_links_mutex_;
 
   TransportHints transport_hints_;
+
+  StatisticsLogger statistics_;
 
   struct LatchInfo
   {

--- a/clients/roscpp/include/ros/subscription_callback_helper.h
+++ b/clients/roscpp/include/ros/subscription_callback_helper.h
@@ -74,6 +74,7 @@ public:
   virtual void call(SubscriptionCallbackHelperCallParams& params) = 0;
   virtual const std::type_info& getTypeInfo() = 0;
   virtual bool isConst() = 0;
+  virtual bool hasHeader() = 0;
 };
 typedef boost::shared_ptr<SubscriptionCallbackHelper> SubscriptionCallbackHelperPtr;
 
@@ -107,6 +108,11 @@ public:
   void setCreateFunction(const CreateFunction& create)
   {
     create_ = create;
+  }
+
+  virtual bool hasHeader()
+  {
+     return message_traits::hasHeader<typename ParameterAdapter<P>::Message>();
   }
 
   virtual VoidConstPtr deserialize(const SubscriptionCallbackHelperDeserializeParams& params)

--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2013-2014, Dariush Forouher
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Stanford University or Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ros/statistics.h"
+#include "ros/node_handle.h"
+#include <rosgraph_msgs/TopicStatistics.h>
+#include "ros/this_node.h"
+#include "ros/message_traits.h"
+#include "std_msgs/Header.h"
+#include "ros/param.h"
+
+namespace ros
+{
+
+StatisticsLogger::StatisticsLogger()
+: enable_statistics(false),pub_frequency_(4.0)
+{
+}
+
+void StatisticsLogger::init(const SubscriptionCallbackHelperPtr& helper) {
+  hasHeader_ = helper->hasHeader();
+  param::param("/enable_statistics", enable_statistics, enable_statistics);
+}
+
+void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_header,
+				const std::string& topic, const std::string& callerid, const SerializedMessage& m, const uint64_t& bytes_sent,
+				const ros::Time& received_time, const bool dropped)
+{
+  struct StatData stats;
+
+  if (!enable_statistics)
+    return;
+
+  // ignore /clock for safety and /statistics to reduce noise
+  if (topic == "/statistics" || topic == "/clock")
+    return;
+
+  // callerid identifies the connection
+  std::map<std::string,struct StatData>::iterator stats_it = map_.find(callerid);
+  if (stats_it == map_.end()) {
+    // this is the first time, we received something on this connection
+    stats.stat_bytes_last = 0;
+    stats.dropped_msgs = 0;
+    stats.last_publish = ros::Time::now();
+    map_[callerid] = stats;
+  } else {
+    stats = map_[callerid];
+  }
+
+  stats.arrival_time_list.push_back(received_time);
+
+  if (dropped)
+    stats.dropped_msgs++;
+
+  // try to extract header, if the message has one. this fails sometimes,
+  // therefore the try-catch
+  if (hasHeader_) {
+    try {
+      std_msgs::Header header;
+      ros::serialization::IStream stream(m.message_start, m.num_bytes - (m.message_start - m.buf.get()));
+      ros::serialization::deserialize(stream, header);
+      stats.delay_list.push_back((received_time-header.stamp).toSec());
+    } catch (ros::serialization::StreamOverrunException& e) {
+      ROS_DEBUG("Error during header extraction for statistics (topic=%s, message_length=%li)", topic.c_str(), m.num_bytes - (m.message_start - m.buf.get()));
+      hasHeader_ = false;
+    }
+  }
+
+  // should publish new statistics?
+  if (stats.last_publish + ros::Duration(pub_frequency_) < received_time) {
+    ros::Time window_start = stats.last_publish;
+    stats.last_publish = received_time;
+
+    // fill the message with the aggregated data
+    rosgraph_msgs::TopicStatistics msg;
+    msg.topic = topic;
+    msg.node_pub = callerid;
+    msg.node_sub = ros::this_node::getName();
+    msg.window_start = window_start;
+    msg.window_stop = received_time;
+    msg.dropped_msgs = stats.dropped_msgs;
+    msg.traffic = (bytes_sent - stats.stat_bytes_last) / (received_time-window_start).toSec();
+
+    // not all message types have this
+    if (stats.delay_list.size()>0) {
+      msg.stamp_delay_mean = 0;
+      msg.stamp_delay_max = 0;
+      for(std::list<double>::iterator it = stats.delay_list.begin(); it != stats.delay_list.end(); it++) {
+	double delay = *it;
+	msg.stamp_delay_mean += delay;
+	if (delay > msg.stamp_delay_max)
+	    msg.stamp_delay_max = delay;
+      }
+      msg.stamp_delay_mean /= stats.delay_list.size();
+
+      msg.stamp_delay_variance = 0;
+      for(std::list<double>::iterator it = stats.delay_list.begin(); it != stats.delay_list.end(); it++) {
+	double t = msg.stamp_delay_mean - *it;
+	msg.stamp_delay_variance += t*t;
+      }
+      msg.stamp_delay_variance /= stats.delay_list.size();
+
+    } else {
+        // in that case, set to NaN
+        msg.stamp_delay_mean = nan("char-sequence");
+        msg.stamp_delay_variance = nan("char-sequence");
+        msg.stamp_delay_max = nan("char-sequence");
+    }
+
+    // first, calculate the mean period between messages in this connection
+    // we need at least two messages in the window for this.
+    if (stats.arrival_time_list.size()>1) {
+      msg.period_mean = 0;
+      msg.period_max = 0;
+
+      ros::Time prev;
+      for(std::list<ros::Time>::iterator it = stats.arrival_time_list.begin(); it != stats.arrival_time_list.end(); it++) {
+	if (it==stats.arrival_time_list.begin()) {
+	  prev = *it;
+	  continue;
+	}
+	double period = (*it-prev).toSec();
+	msg.period_mean += period;
+	if (period > msg.period_max)
+	    msg.period_max = period;
+	prev = *it;
+      }
+      msg.period_mean /= (stats.arrival_time_list.size()-1);
+
+      // then, calc the variance
+      msg.period_variance = 0;
+      for(std::list<ros::Time>::iterator it = stats.arrival_time_list.begin(); it != stats.arrival_time_list.end(); it++) {
+	if (it==stats.arrival_time_list.begin()) {
+	  prev = *it;
+	  continue;
+	}
+	double period = (*it-prev).toSec();
+	double t = msg.period_mean - period;
+	msg.period_variance += t*t;
+	prev = *it;
+	
+      }
+      msg.period_variance /= (stats.arrival_time_list.size()-1);
+
+    } else {
+        // in that case, set to NaN
+        msg.period_mean = nan("char-sequence");
+        msg.period_variance = nan("char-sequence");
+        msg.period_max = nan("char-sequence");
+    }
+ 
+      if (!pub_.getTopic().length()) {
+        ros::NodeHandle n("~");
+	// creating the publisher in the constructor results in a deadlock. so do it here.
+        pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics",1);
+      }
+
+    pub_.publish(msg);
+
+    // dynamic window resizing
+    if (stats.arrival_time_list.size() < MIN_ELEMENTS && pub_frequency_*2 <= MAX_WINDOW)
+      pub_frequency_ *= 2;
+    if (stats.arrival_time_list.size() > MAX_ELEMENTS && pub_frequency_/2 >= MIN_WINDOW)
+      pub_frequency_ /= 2;
+
+    // clear the window
+    stats.delay_list.clear();
+    stats.arrival_time_list.clear();
+    stats.dropped_msgs = 0;
+    stats.stat_bytes_last = bytes_sent;
+
+  }
+  // store the stats for this connection
+  map_[callerid] = stats;
+}
+
+
+} // namespace ros

--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -37,13 +37,17 @@ namespace ros
 {
 
 StatisticsLogger::StatisticsLogger()
-: enable_statistics(false),pub_frequency_(4.0)
+: pub_frequency_(1.0)
 {
 }
 
 void StatisticsLogger::init(const SubscriptionCallbackHelperPtr& helper) {
   hasHeader_ = helper->hasHeader();
-  param::param("/enable_statistics", enable_statistics, enable_statistics);
+  param::param("/enable_statistics", enable_statistics, false);
+  param::param("/statistics_window_min_elements", min_elements, 10);
+  param::param("/statistics_window_max_elements", min_elements, 100);
+  param::param("/statistics_window_min_size", min_elements, 4);
+  param::param("/statistics_window_max_size", max_elements, 64);
 }
 
 void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_header,
@@ -184,9 +188,9 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
     pub_.publish(msg);
 
     // dynamic window resizing
-    if (stats.arrival_time_list.size() < MIN_ELEMENTS && pub_frequency_*2 <= MAX_WINDOW)
+    if (stats.arrival_time_list.size() > max_elements && pub_frequency_ * 2 <= max_window)
       pub_frequency_ *= 2;
-    if (stats.arrival_time_list.size() > MAX_ELEMENTS && pub_frequency_/2 >= MIN_WINDOW)
+    if (stats.arrival_time_list.size() < min_elements && pub_frequency_ / 2 >= min_window)
       pub_frequency_ /= 2;
 
     // clear the window

--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -47,8 +47,8 @@ void StatisticsLogger::init(const SubscriptionCallbackHelperPtr& helper) {
 }
 
 void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_header,
-				const std::string& topic, const std::string& callerid, const SerializedMessage& m, const uint64_t& bytes_sent,
-				const ros::Time& received_time, const bool dropped)
+                                const std::string& topic, const std::string& callerid, const SerializedMessage& m, const uint64_t& bytes_sent,
+                                const ros::Time& received_time, const bool dropped)
 {
   struct StatData stats;
 
@@ -109,18 +109,21 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
     if (stats.delay_list.size()>0) {
       msg.stamp_delay_mean = ros::Duration(0);
       msg.stamp_delay_max = ros::Duration(0);
+
       for(std::list<ros::Duration>::iterator it = stats.delay_list.begin(); it != stats.delay_list.end(); it++) {
-	ros::Duration delay = *it;
-	msg.stamp_delay_mean += delay;
-	if (delay > msg.stamp_delay_max)
-	    msg.stamp_delay_max = delay;
+        ros::Duration delay = *it;
+        msg.stamp_delay_mean += delay;
+
+        if (delay > msg.stamp_delay_max)
+            msg.stamp_delay_max = delay;
       }
+
       msg.stamp_delay_mean *= 1.0/stats.delay_list.size();
 
       msg.stamp_delay_stddev = ros::Duration(0);
       for(std::list<ros::Duration>::iterator it = stats.delay_list.begin(); it != stats.delay_list.end(); it++) {
-	ros::Duration t = msg.stamp_delay_mean - *it;
-	msg.stamp_delay_stddev += ros::Duration(t.toSec()*t.toSec());
+        ros::Duration t = msg.stamp_delay_mean - *it;
+        msg.stamp_delay_stddev += ros::Duration(t.toSec()*t.toSec());
       }
       msg.stamp_delay_stddev = ros::Duration(sqrt(msg.stamp_delay_stddev.toSec()/stats.delay_list.size()));
 
@@ -139,30 +142,29 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
 
       ros::Time prev;
       for(std::list<ros::Time>::iterator it = stats.arrival_time_list.begin(); it != stats.arrival_time_list.end(); it++) {
-	if (it==stats.arrival_time_list.begin()) {
-	  prev = *it;
-	  continue;
-	}
-	ros::Duration period = (*it-prev);
-	msg.period_mean += period;
-	if (period > msg.period_max)
-	    msg.period_max = period;
-	prev = *it;
+        if (it==stats.arrival_time_list.begin()) {
+          prev = *it;
+          continue;
+        }
+        ros::Duration period = (*it-prev);
+        msg.period_mean += period;
+        if (period > msg.period_max)
+            msg.period_max = period;
+        prev = *it;
       }
       msg.period_mean *= 1.0/(stats.arrival_time_list.size()-1);
 
       // then, calc the stddev
       msg.period_stddev = ros::Duration(0);
       for(std::list<ros::Time>::iterator it = stats.arrival_time_list.begin(); it != stats.arrival_time_list.end(); it++) {
-	if (it==stats.arrival_time_list.begin()) {
-	  prev = *it;
-	  continue;
-	}
-	ros::Duration period = *it-prev;
-	ros::Duration t = msg.period_mean - period;
-	msg.period_stddev += ros::Duration(t.toSec()*t.toSec());
-	prev = *it;
-	
+        if (it==stats.arrival_time_list.begin()) {
+          prev = *it;
+          continue;
+        }
+        ros::Duration period = *it-prev;
+        ros::Duration t = msg.period_mean - period;
+        msg.period_stddev += ros::Duration(t.toSec()*t.toSec());
+        prev = *it;
       }
       msg.period_stddev = ros::Duration(sqrt(msg.period_stddev.toSec()/(stats.arrival_time_list.size()-1)));
 
@@ -172,10 +174,10 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
         msg.period_stddev = ros::Duration(0);
         msg.period_max = ros::Duration(0);
     }
- 
+
       if (!pub_.getTopic().length()) {
         ros::NodeHandle n("~");
-	// creating the publisher in the constructor results in a deadlock. so do it here.
+        // creating the publisher in the constructor results in a deadlock. so do it here.
         pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics",1);
       }
 

--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -64,7 +64,7 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
     return;
 
   // callerid identifies the connection
-  std::map<std::string,struct StatData>::iterator stats_it = map_.find(callerid);
+  std::map<std::string, struct StatData>::iterator stats_it = map_.find(callerid);
   if (stats_it == map_.end()) {
     // this is the first time, we received something on this connection
     stats.stat_bytes_last = 0;
@@ -110,7 +110,7 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
     msg.traffic = bytes_sent - stats.stat_bytes_last;
 
     // not all message types have this
-    if (stats.delay_list.size()>0) {
+    if (stats.delay_list.size() > 0) {
       msg.stamp_delay_mean = ros::Duration(0);
       msg.stamp_delay_max = ros::Duration(0);
 
@@ -122,14 +122,14 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
             msg.stamp_delay_max = delay;
       }
 
-      msg.stamp_delay_mean *= 1.0/stats.delay_list.size();
+      msg.stamp_delay_mean *= 1.0 / stats.delay_list.size();
 
       msg.stamp_delay_stddev = ros::Duration(0);
       for(std::list<ros::Duration>::iterator it = stats.delay_list.begin(); it != stats.delay_list.end(); it++) {
         ros::Duration t = msg.stamp_delay_mean - *it;
-        msg.stamp_delay_stddev += ros::Duration(t.toSec()*t.toSec());
+        msg.stamp_delay_stddev += ros::Duration(t.toSec() * t.toSec());
       }
-      msg.stamp_delay_stddev = ros::Duration(sqrt(msg.stamp_delay_stddev.toSec()/stats.delay_list.size()));
+      msg.stamp_delay_stddev = ros::Duration(sqrt(msg.stamp_delay_stddev.toSec() / stats.delay_list.size()));
 
     } else {
         // in that case, set to NaN
@@ -146,31 +146,33 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
 
       ros::Time prev;
       for(std::list<ros::Time>::iterator it = stats.arrival_time_list.begin(); it != stats.arrival_time_list.end(); it++) {
-        if (it==stats.arrival_time_list.begin()) {
+
+        if (it == stats.arrival_time_list.begin()) {
           prev = *it;
           continue;
         }
-        ros::Duration period = (*it-prev);
+
+        ros::Duration period = *it - prev;
         msg.period_mean += period;
         if (period > msg.period_max)
             msg.period_max = period;
         prev = *it;
       }
-      msg.period_mean *= 1.0/(stats.arrival_time_list.size()-1);
+      msg.period_mean *= 1.0 / (stats.arrival_time_list.size() - 1);
 
       // then, calc the stddev
       msg.period_stddev = ros::Duration(0);
       for(std::list<ros::Time>::iterator it = stats.arrival_time_list.begin(); it != stats.arrival_time_list.end(); it++) {
-        if (it==stats.arrival_time_list.begin()) {
+        if (it == stats.arrival_time_list.begin()) {
           prev = *it;
           continue;
         }
-        ros::Duration period = *it-prev;
+        ros::Duration period = *it - prev;
         ros::Duration t = msg.period_mean - period;
-        msg.period_stddev += ros::Duration(t.toSec()*t.toSec());
+        msg.period_stddev += ros::Duration(t.toSec() * t.toSec());
         prev = *it;
       }
-      msg.period_stddev = ros::Duration(sqrt(msg.period_stddev.toSec()/(stats.arrival_time_list.size()-1)));
+      msg.period_stddev = ros::Duration(sqrt(msg.period_stddev.toSec() / (stats.arrival_time_list.size() - 1)));
 
     } else {
         // in that case, set to NaN
@@ -179,11 +181,11 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
         msg.period_max = ros::Duration(0);
     }
 
-      if (!pub_.getTopic().length()) {
-        ros::NodeHandle n("~");
-        // creating the publisher in the constructor results in a deadlock. so do it here.
-        pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics",1);
-      }
+    if (!pub_.getTopic().length()) {
+      ros::NodeHandle n("~");
+      // creating the publisher in the constructor results in a deadlock. so do it here.
+      pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics", 1);
+    }
 
     pub_.publish(msg);
 

--- a/clients/roscpp/src/libros/subscription.cpp
+++ b/clients/roscpp/src/libros/subscription.cpp
@@ -657,6 +657,9 @@ uint32_t Subscription::handleMessage(const SerializedMessage& m, bool ser, bool 
     }
   }
 
+  // measure statistics
+  statistics_.callback(connection_header,name_,link->getCallerID(),m,link->getStats().bytes_received_,receipt_time, drops>0);
+
   // If this link is latched, store off the message so we can immediately pass it to new subscribers later
   if (link->isLatched())
   {
@@ -677,6 +680,8 @@ bool Subscription::addCallback(const SubscriptionCallbackHelperPtr& helper, cons
 {
   ROS_ASSERT(helper);
   ROS_ASSERT(queue);
+
+  statistics_.init(helper);
 
   // Decay to a real type as soon as we have a subscriber with a real type
   {

--- a/clients/roscpp/src/libros/subscription.cpp
+++ b/clients/roscpp/src/libros/subscription.cpp
@@ -658,7 +658,7 @@ uint32_t Subscription::handleMessage(const SerializedMessage& m, bool ser, bool 
   }
 
   // measure statistics
-  statistics_.callback(connection_header,name_,link->getCallerID(),m,link->getStats().bytes_received_,receipt_time, drops>0);
+  statistics_.callback(connection_header, name_, link->getCallerID(), m, link->getStats().bytes_received_, receipt_time, drops > 0);
 
   // If this link is latched, store off the message so we can immediately pass it to new subscribers later
   if (link->isLatched())

--- a/clients/rospy/src/rospy/impl/statistics.py
+++ b/clients/rospy/src/rospy/impl/statistics.py
@@ -1,0 +1,303 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2013-2014 Dariush Forouher
+# All rights reserved.
+#
+# Based on code adapted from diagnostics_updater by Blaise Gassend
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+import struct
+import select
+
+try:
+    from cStringIO import StringIO #Python 2.x
+    import thread as _thread # Python 2
+    python3 = 0
+    def isstring(s):
+        return isinstance(s, basestring) #Python 2.x
+except ImportError:
+    python3 = 1
+    from io import StringIO, BytesIO #Python 3.x
+    import _thread 
+    def isstring(s):
+        return isinstance(s, str) #Python 3.x
+    		
+import threading
+import logging
+import time
+
+from itertools import chain
+import traceback
+
+import rosgraph.names
+
+from rospy.core import *
+from rospy.exceptions import ROSSerializationException, TransportTerminated
+from rospy.msg import serialize_message, args_kwds_to_message
+from rosgraph_msgs.msg import TopicStatistics
+
+from rospy.impl.registration import get_topic_manager, set_topic_manager, Registration, get_registration_listeners
+from rospy.impl.tcpros import get_tcpros_handler, DEFAULT_BUFF_SIZE
+
+_logger = logging.getLogger('rospy.impl.statistics')
+
+# Range of window length, in seconds
+MAX_WINDOW = 64
+MIN_WINDOW = 4
+
+# Range of acceptable messages in window.
+# Window size will be adjusted if number of observed is
+# outside this range.
+MAX_ELEMENTS = 100
+MIN_ELEMENTS = 10
+
+# wrap genpy implementation and map it to rospy namespace
+import genpy
+Message = genpy.Message
+
+_STATISTICS_TOPIC = "/statistics"
+_ENABLE_STATISTICS = "/enable_statistics"
+
+class SubscriberStatisticsLogger():
+    """
+    Class that monitors each subscriber.
+
+    this class basically just keeps a collection of ConnectionStatisticsLogger.
+    """
+
+    def __init__(self, subscriber):
+        self.subscriber = subscriber
+	self.connections = dict()
+
+	# only start statistics if the global param _ENABLE_STATISTICS is enabled.
+	self.enabled = self.is_enable_statistics()
+        pass
+
+    def is_enable_statistics(self):
+	"""
+	Check whether the user has enabled statistics using the parameter.
+	"""
+
+	master_uri = rosgraph.get_master_uri()
+	m = rospy.core.xmlrpcapi(master_uri)
+	code, msg, val = m.getParam(rospy.names.get_caller_id(), _ENABLE_STATISTICS)
+	if code == 1 and val:
+    	    return True
+	return False
+
+    def callback(self,msg,publisher, stat_bytes):
+	"""
+	This method is called for every message that has been received.
+	
+	@param msg: The message received.
+	@param publisher: The name of the publisher node that sent the msg
+	@param stat_bytes: A counter, how many bytes have been moved across
+		this connection since it exists.
+	
+	This method just looks up the ConnectionStatisticsLogger for the specific connection
+	between publisher and subscriber and delegates to statistics logging to that
+	instance.
+	"""
+
+        if not self.enabled:
+    	    return
+
+	# /clock is special, as it is subscribed very early
+	# also exclude /statistics to reduce noise.
+	if self.subscriber.name == "/clock" or self.subscriber.name == "/statistics":
+	    return
+
+	try:
+	    # create ConnectionStatisticsLogger for new connections
+	    logger = self.connections.get(publisher)
+	    if logger == None:
+		logger = ConnectionStatisticsLogger(self.subscriber.name, rospy.get_name(), publisher)
+		self.connections[publisher] = logger
+
+	    # delegate stuff to that instance
+    	    logger.callback(msg, stat_bytes)
+	except:
+	    ROS_ERROR("Unexpected error during statistics measurement: ", sys.exc_info()[0])
+	    pass
+
+
+class ConnectionStatisticsLogger():
+    """
+    Class that monitors lots of stuff for each connection
+    
+    is created whenever a subscriber is created.
+    is destroyed whenever its parent subscriber is destroyed.
+    its lifecycle is therefore bound to its parent subscriber.
+    
+    XXX: the are threading/concurrent access issues meantioned at different
+    places. what do i have to keep in mind?
+    - may there be callbacks called in parallel? sounds unlikely
+    - may additional methods (which i don't have any a.t.m., be called in
+      parallel? probably.
+
+    """
+
+    def __init__(self, topic, subscriber, publisher):
+        """
+        Constructor.
+
+	@param topic: Name of the topic
+	@param subscriber: Name of the subscriber
+	@param publisher: Name of the publisher
+
+	These three should uniquely identify the connection.
+        """
+
+	self.topic = topic
+        self.subscriber = subscriber
+	self.publisher = publisher
+
+	self.pub = rospy.Publisher(_STATISTICS_TOPIC, TopicStatistics)
+
+	# reset window
+	self.last_pub_time = rospy.Time(0)
+	self.pub_frequency = rospy.Duration(4.0)
+
+        # timestamp delay
+	self.delay_list_ = []
+
+	# period calculations
+	self.arrival_time_list_ = []
+
+        self.last_seq_ = 0
+        self.dropped_msgs_ = 0
+	self.window_start = rospy.Time.now()
+
+	# temporary variables
+	self.stat_bytes_last_ = 0
+	self.stat_bytes_window_ = 0
+        pass
+
+    def sendStatistics(self):
+	"""
+	Send out statistics. Aggregate collected stats information.
+
+	Currently done blocking. Might be moved to own thread later. But at the moment
+	any computation done here should be rather quick.
+	"""
+	curtime = rospy.Time.now()
+
+	window_start = self.window_start
+	self.window_start = curtime
+
+	msg = TopicStatistics()
+	msg.topic = self.topic
+	msg.node_sub = self.subscriber
+	msg.node_pub = self.publisher
+
+	msg.window_start = window_start
+	msg.window_stop  = curtime
+
+	delta_t = curtime - window_start
+
+	msg.traffic = self.stat_bytes_window_ / delta_t.to_sec()
+
+        msg.dropped_msgs = self.dropped_msgs_
+
+	# we can only calculate message delay if the messages did contain Header fields.
+	if len(self.delay_list_)>0:
+            msg.stamp_delay_mean = sum(self.delay_list_) / len(self.delay_list_)
+	    msg.stamp_delay_variance = sum((msg.stamp_delay_mean - value) ** 2 for value in self.delay_list_) / len(self.delay_list_)
+    	    msg.stamp_delay_max = max(self.delay_list_)
+	else:
+            msg.stamp_delay_mean = float('NaN')
+	    msg.stamp_delay_variance = float('NaN')
+	    msg.stamp_delay_max = float('NaN')
+
+	# computer period/frequency. we need at least two messages within the window to do this.
+	if len(self.arrival_time_list_)>1:
+	    periods = [j-i for i, j in zip(self.arrival_time_list_[:-1], self.arrival_time_list_[1:])]
+            msg.period_mean = sum(periods)/len(periods)
+	    msg.period_variance = sum((msg.period_mean - value) ** 2 for value in periods) / len(periods)
+            msg.period_max = max(periods)
+	else:
+            msg.period_mean = float('NaN')
+	    msg.period_variance = float('NaN')
+            msg.period_max = float('NaN')
+
+        self.pub.publish(msg)
+
+	# adjust window, if message count is not appropriate.
+	if len(self.arrival_time_list_) < MIN_ELEMENTS and self.pub_frequency*2 <= MAX_WINDOW:
+	    self.pub_frequency *= 2
+	if len(self.arrival_time_list_) > MAX_ELEMENTS and self.pub_frequency/2 >= MIN_WINDOW:
+	    self.pub_frequency /= 2
+
+	# clear collected stats, start new window.
+	self.delay_list_ = []
+	self.arrival_time_list_ = []
+        self.dropped_msgs_ = 0
+
+    def callback(self,msg, stat_bytes):
+        """
+	This method is called for every message, that is received on this
+	subscriber.
+	
+        this callback will keep some statistics and publish the results
+        periodically on a topic. the publishing should probably be done
+        asynchronically in another thread.
+
+	@param msg: The message, that has been received. The message has usually
+		been already deserialized. However this is not always the
+		case. (AnyMsg)
+	@param stat_bytes: A counter, how many bytes have been moved across
+		this connection since it exists.
+
+        Any computing-heavy stuff should be done somewhere else, as this
+	callback has to return before the message is delivered to the user.
+        """
+
+	self.arrival_time_list_.append(rospy.Time.now().to_sec())
+
+	# Calculate how many bytes of traffic did this message need?
+	self.stat_bytes_window_ = stat_bytes - self.stat_bytes_last_
+	self.stat_bytes_last_ = stat_bytes
+
+	# rospy has the feature to subscribe a topic with AnyMsg which aren't deserialized.
+	# Those subscribers won't have a header. But as these subscribers are rather rare
+	# ("rostopic hz" is the only one I know of), I'm gonna ignore them.
+	if msg._has_header:
+	    self.delay_list_.append((rospy.Time.now() - msg.header.stamp).to_sec())
+
+    	    if self.last_seq_ + 1 != msg.header.seq:
+                self.dropped_msgs_ = self.dropped_msgs_ + 1
+    	    self.last_seq_ = msg.header.seq
+
+	# send out statistics with a certain frequency
+        if self.last_pub_time + self.pub_frequency < rospy.Time.now():
+            self.last_pub_time = rospy.Time.now()
+            self.sendStatistics()
+
+

--- a/clients/rospy/src/rospy/impl/statistics.py
+++ b/clients/rospy/src/rospy/impl/statistics.py
@@ -32,39 +32,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-
-import struct
-import select
-
-try:
-    from cStringIO import StringIO #Python 2.x
-    import thread as _thread # Python 2
-    python3 = 0
-    def isstring(s):
-        return isinstance(s, basestring) #Python 2.x
-except ImportError:
-    python3 = 1
-    from io import StringIO, BytesIO #Python 3.x
-    import _thread 
-    def isstring(s):
-        return isinstance(s, str) #Python 3.x
-    		
-import threading
-import logging
-import time
-
-from itertools import chain
-import traceback
-
-import rosgraph.names
-
 from rospy.core import *
-from rospy.exceptions import ROSSerializationException, TransportTerminated
-from rospy.msg import serialize_message, args_kwds_to_message
 from rosgraph_msgs.msg import TopicStatistics
-
-from rospy.impl.registration import get_topic_manager, set_topic_manager, Registration, get_registration_listeners
-from rospy.impl.tcpros import get_tcpros_handler, DEFAULT_BUFF_SIZE
 
 _logger = logging.getLogger('rospy.impl.statistics')
 
@@ -77,10 +46,6 @@ MIN_WINDOW = 4
 # outside this range.
 MAX_ELEMENTS = 100
 MIN_ELEMENTS = 10
-
-# wrap genpy implementation and map it to rospy namespace
-import genpy
-Message = genpy.Message
 
 _STATISTICS_TOPIC = "/statistics"
 _ENABLE_STATISTICS = "/enable_statistics"

--- a/clients/rospy/src/rospy/impl/statistics.py
+++ b/clients/rospy/src/rospy/impl/statistics.py
@@ -185,7 +185,7 @@ class ConnectionStatisticsLogger():
 
         # we can only calculate message delay if the messages did contain Header fields.
         if len(self.delay_list_)>0:
-            msg.stamp_delay_mean = sum(self.delay_list_, rospy.Duration(0)) / len(self.delay_list_)
+            msg.stamp_delay_mean = rospy.Duration(sum(self.delay_list_, rospy.Duration(0)).to_sec() / len(self.delay_list_))
             variance = sum((rospy.Duration((msg.stamp_delay_mean - value).to_sec()**2) for value in self.delay_list_), rospy.Duration(0)) / len(self.delay_list_)
             msg.stamp_delay_stddev = rospy.Duration(sqrt(variance.to_sec()))
             msg.stamp_delay_max = max(self.delay_list_)
@@ -197,7 +197,7 @@ class ConnectionStatisticsLogger():
         # computer period/frequency. we need at least two messages within the window to do this.
         if len(self.arrival_time_list_)>1:
             periods = [j-i for i, j in zip(self.arrival_time_list_[:-1], self.arrival_time_list_[1:])]
-            msg.period_mean = sum(periods, rospy.Duration(0)) / len(periods)
+            msg.period_mean = rospy.Duration(sum(periods, rospy.Duration(0)).to_sec() / len(periods))
             variance = sum((rospy.Duration((msg.period_mean - value).to_sec()**2) for value in periods), rospy.Duration(0)) / len(periods)
             msg.period_stddev = rospy.Duration(sqrt(variance.to_sec()))
             msg.period_max = max(periods)

--- a/clients/rospy/src/rospy/impl/statistics.py
+++ b/clients/rospy/src/rospy/impl/statistics.py
@@ -65,8 +65,8 @@ class SubscriberStatisticsLogger():
         # Range of acceptable messages in window.
         # Window size will be adjusted if number of observed is
         # outside this range.
-        self.max_window = rospy.get_param("/statistics_window_max_length", 64)
-        self.min_window = rospy.get_param("/statistics_window_min_length", 1)
+        self.max_window = rospy.get_param("/statistics_window_max_size", 64)
+        self.min_window = rospy.get_param("/statistics_window_min_size", 4)
 
     def is_enable_statistics(self):
         return self.enabled
@@ -134,7 +134,7 @@ class ConnectionStatisticsLogger():
 
         # reset window
         self.last_pub_time = rospy.Time(0)
-        self.pub_frequency = rospy.Duration(4.0)
+        self.pub_frequency = rospy.Duration(1.0)
 
         # timestamp delay
         self.delay_list_ = []
@@ -202,9 +202,9 @@ class ConnectionStatisticsLogger():
         self.pub.publish(msg)
 
         # adjust window, if message count is not appropriate.
-        if len(self.arrival_time_list_) < self.min_elements and self.pub_frequency * 2 <= self.max_window:
+        if len(self.arrival_time_list_) > self.max_elements and self.pub_frequency * 2 <= self.max_window:
             self.pub_frequency *= 2
-        if len(self.arrival_time_list_) > self.max_elements and self.pub_frequency / 2 >= self.min_windowW:
+        if len(self.arrival_time_list_) < self.min_elements and self.pub_frequency / 2 >= self.min_windowW:
             self.pub_frequency /= 2
 
         # clear collected stats, start new window.

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -731,7 +731,7 @@ class TCPROSTransport(Transport):
                     if self.socket is not None:
                         msgs = self.receive_once()
                         if not self.done and not is_shutdown():
-                            msgs_callback(msgs,self)
+                            msgs_callback(msgs, self)
                     else:
                         self._reconnect()
 

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -435,6 +435,7 @@ class TCPROSTransport(Transport):
 
         self.socket = None
         self.endpoint_id = 'unknown'
+        self.callerid_pub = 'unknown'
         self.dest_address = None # for reconnection
         
         if python3 == 0: # Python 2.x
@@ -556,6 +557,7 @@ class TCPROSTransport(Transport):
             if not required in header:
                 raise TransportInitError("header missing required field [%s]"%required)
         self.md5sum = header['md5sum']
+        self.callerid_pub = header['callerid']
         self.type = header['type']
         if header.get('latching', '0') == '1':
             self.is_latched = True
@@ -587,6 +589,7 @@ class TCPROSTransport(Transport):
         if sock is None:
             return
         sock.setblocking(1)
+	# TODO: add bytes received to self.stat_bytes
         self._validate_header(read_ros_handshake_header(sock, self.read_buff, self.protocol.buff_size))
                 
     def send_message(self, msg, seq):
@@ -666,7 +669,7 @@ class TCPROSTransport(Transport):
                 if b.tell() >= 4:
                     p.read_messages(b, msg_queue, sock) 
                 if not msg_queue:
-                    recv_buff(sock, b, p.buff_size)
+                    self.stat_bytes += recv_buff(sock, b, p.buff_size)
             self.stat_num_msg += len(msg_queue) #STATS
             # set the _connection_header field
             for m in msg_queue:
@@ -728,7 +731,7 @@ class TCPROSTransport(Transport):
                     if self.socket is not None:
                         msgs = self.receive_once()
                         if not self.done and not is_shutdown():
-                            msgs_callback(msgs)
+                            msgs_callback(msgs,self)
                     else:
                         self._reconnect()
 


### PR DESCRIPTION
These patches add an enhancement to roscpp and rospy that monitors some metrics (period, traffic, message delay, dropped messages) over every ROS connection and periodically sends out aggregated statistics data over a common topic /statistics.

The rationale behind this is that it is currently hard to measure these things without actually subscribing to the topics. E.g., if you want to know at which frequency your Kinect camera publishes images, you have to check with "rostopic hz /foo". But that will create quite a noticable load on the system and in any case might show a misleading number.  These patches add a method to measure those things in a lightweight way for the whole system.

I've extended rqt_graph to annotate the edges of the ROS graph with the statistics measured:

![stats_viewer](https://cloud.githubusercontent.com/assets/676900/2579279/776bbb50-b99f-11e3-9eb8-a5451d611c08.png)

For backward compatibility these statistics are disabled by default. They can be enabled via "rosparam set enable_statistics true".

I believe this enhancement might of useful to the ROS community at large. If there are any questions, concerns, remarks, feel free to share them.

cheers
Dariush
