### PR TITLE
invalidate cached parent parameters when namespace parameter is set / changes

### DIFF
--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -762,7 +762,10 @@ void update(const std::string& key, const XmlRpc::XmlRpcValue& v)
 
   boost::mutex::scoped_lock lock(g_params_mutex);
 
-  g_params[clean_key] = v;
+  if (g_subscribed_params.find(clean_key) != g_subscribed_params.end())
+  {
+    g_params[clean_key] = v;
+  }
   invalidateParentParams(clean_key);
 }
 

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -232,17 +232,8 @@ bool del(const std::string& key)
   {
     boost::mutex::scoped_lock lock(g_params_mutex);
 
-    S_string::iterator sub_it = g_subscribed_params.find(mapped_key);
-    if (sub_it != g_subscribed_params.end())
-    {
-      g_subscribed_params.erase(sub_it);
-
-      M_Param::iterator param_it = g_params.find(mapped_key);
-      if (param_it != g_params.end())
-      {
-        g_params.erase(param_it);
-      }
-    }
+    g_subscribed_params.erase(mapped_key);
+    g_params.erase(mapped_key);
   }
 
   XmlRpc::XmlRpcValue params, result, payload;

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -101,6 +101,25 @@ TEST(Params, setThenGetStringCachedNodeHandle)
   ASSERT_STREQ( "asdf", param.c_str() );
 }
 
+TEST(Params, setThenGetNamespaceCached)
+{
+  std::string stringParam;
+  XmlRpc::XmlRpcValue structParam;
+  const std::string ns = "test_set_param_setThenGetStringCached2";
+  ASSERT_FALSE(param::getCached(ns, stringParam));
+
+  param::set(ns, std::string("a"));
+  ASSERT_TRUE(param::getCached(ns, stringParam));
+  ASSERT_STREQ("a", stringParam.c_str());
+
+  param::set(ns + "/foo", std::string("b"));
+  ASSERT_TRUE(param::getCached(ns + "/foo", stringParam));
+  ASSERT_STREQ("b", stringParam.c_str());
+  ASSERT_TRUE(param::getCached(ns, structParam));
+  ASSERT_TRUE(structParam.hasMember("foo"));
+  ASSERT_STREQ("b", static_cast<std::string>(structParam["foo"]).c_str());
+}
+
 TEST(Params, setThenGetCString)
 {
   param::set( "test_set_param", "asdf" );


### PR DESCRIPTION
This is a subset of #352 which fixes the cached parameters when values in a sub-namespace are set / change.
