### PR TITLE
rosmsg does not show messages existing only in devel space

### DIFF
--- a/tools/rosmsg/package.xml
+++ b/tools/rosmsg/package.xml
@@ -19,6 +19,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend version_gte="0.6.4">catkin</run_depend>
   <run_depend>genmsg</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>rosbag</run_depend>


### PR DESCRIPTION
Initially reported here: http://answers.ros.org/question/147586/unable-to-locate-custom-action-using-rosmsg-with-catkin

This effects especially messages generated for actions.
