### PR TITLE
adds op tool (for python operations)

### DIFF
--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -58,6 +58,7 @@ catkin_install_python(PROGRAMS
   scripts/mux_delete
   scripts/mux_list
   scripts/mux_select
+  scripts/op
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 #Testing

--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -20,6 +20,8 @@ catkin_package(
   CATKIN_DEPENDS message_runtime rosconsole roscpp std_msgs xmlrpcpp
  )
 
+catkin_add_env_hooks(20.transform SHELLS bash DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)
+
 add_library(topic_tools src/shape_shifter.cpp src/parse.cpp)
 target_link_libraries(topic_tools ${catkin_LIBRARIES})
 

--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -58,7 +58,7 @@ catkin_install_python(PROGRAMS
   scripts/mux_delete
   scripts/mux_list
   scripts/mux_select
-  scripts/op
+  scripts/transform
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 #Testing

--- a/tools/topic_tools/env-hooks/20.transform.bash
+++ b/tools/topic_tools/env-hooks/20.transform.bash
@@ -1,0 +1,42 @@
+function _roscomplete_node_transform
+{
+    local arg opts
+    COMPREPLY=()
+    arg="${COMP_WORDS[COMP_CWORD]}"
+    local cword=$COMP_CWORD
+    for a in $(seq $((COMP_CWORD-1))); do
+        if [ -z "${COMP_WORDS[a]//-*}" ]; then
+            ((cword--))
+        fi
+    done
+    local words=(${COMP_WORDS[@]//-*})
+
+    if [[ $cword == 3 ]]; then
+        opts=`rostopic list 2> /dev/null`
+        COMPREPLY=($(compgen -W "$opts" -- ${arg}))
+    elif [[ $cword == 5 ]]; then
+        opts=`rosmsg list 2> /dev/null`
+        COMPREPLY=($(compgen -W "$opts" -- ${arg}))
+    fi
+}
+
+_sav_transform_roscomplete_rosrun=$(complete | grep -w rosrun | awk '{print $3}')
+
+function is_transform_node
+{
+    local words=(${COMP_WORDS[@]//-*})
+    [ ${#words[@]} -gt 2 ] && \
+    [ "${words[1]}" = "topic_tools" ] && \
+    [ "${words[2]}" = "transform" ]
+}
+
+function _roscomplete_rosrun_transform
+{
+    if is_transform_node; then
+        _roscomplete_node_transform
+    else
+        eval "$_sav_transform_roscomplete_rosrun"
+    fi
+}
+
+complete -F "_roscomplete_rosrun_transform" "rosrun"

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -51,6 +51,10 @@ class TopicOp:
         self.expression = args.expression
 
         input_class, input_topic, self.input_fn = rostopic.get_topic_class(args.input)
+        if input_topic == None:
+            print 'ERROR: Wrong input topic (or topic field): %s'%args.input
+            exit()
+
         output_class = roslib.message.get_message_class(args.output_type)
 
         self.sub = rospy.Subscriber(input_topic, input_class, self.callback)

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -13,59 +13,28 @@ after performing a valid python operation (including numpy).
 The operations are done on the message, which is taken in the variable 'm'.
 
 * Some examples:
-$ rosrun topic_tools op /imu/orientation/x /x std_msgs/Float64 '-rad2deg(m)'
+$ rosrun topic_tools op /imu/orientation/x /x_in_degrees std_msgs/Float64 '-rad2deg(m)'
 $ rosrun topic_tools op /imu/orientation /norm std_msgs/Float64 'sqrt(sum(array([m.x, m.y, m.z, m.w])))'
-
-* Interactive mode:
-$ rosrun topic_tools op <in> <out> <type> <exp> True
-
-This goes into an ipdb debugger session inside the callback for the input (in)
-topic, so you can redefine the self.expression (exp) to use, or create new logic.
-Indeed you can create new attributes and def functions. However, you cannot:
-- self.expression cannot use an assignment
-- cannot create local variables
-
-In order to create a new function and variable, you can follow this example,
-which computes a weighted mean:
-ipdb> import types
-ipdb> self.mean = 0
-ipdb> def compute_mean(self, x): self.mean = 0.9 * self.mean + 0.1 * x; return self.mean
-ipdb> self.compute_mean = types.MethodType( compute_mean, self )
-ipdb> self.expression = 'self.compute_mean( m.data )'
-
-Once you are done, to avoid entering again in the callback, just do:
-ipdb> self.interactive = False
-before hitting 'c' to continue.
-
 """
 
 import roslib
-
 import rospy
 import rostopic
+
 import sys
 
-import ipdb
-
 from numpy import *
-
-def set_trace():
-    ip = ipapi.get()
-    def_colors = ip.options.colors
-    Pdb(def_colors).set_trace(sys._getframe().f_back)
-
 
 class TopicOp:
 
     def __init__( self ):
         if len( sys.argv ) < 4:
-            sys.exit( 'Usage: %s <input> <output topic> <output type> [<expression on m>] [<interactive mode>]' % sys.argv[0] )
+            sys.exit( 'Usage: %s <input> <output topic> <output type> [<expression on m>]' % sys.argv[0] )
 
         self.input        = sys.argv[1]
         self.output_topic = sys.argv[2]
         self.output_type  = sys.argv[3]
         self.expression   = sys.argv[4] if len( sys.argv ) > 4 else 'm'
-        self.interactive  = sys.argv[5] == 'True' if len( sys.argv ) > 5 else False
 
         # We need the class, rather than the type,
         # so we use get_topic_class instead of get_topic_type.
@@ -80,9 +49,6 @@ class TopicOp:
             m = self.input_fn( msg )
         else:
             m = msg
-
-        if self.interactive:
-            ipdb.set_trace()
 
         res = eval( self.expression )
         self.pub.publish( res )

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -31,7 +31,7 @@ class TopicOp:
     def __init__(self):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.RawTextHelpFormatter,
-            description='Make a python operation on a topic.\n\n'
+            description='Apply a Python operation to a topic.\n\n'
                         'Usage:\n\t<input> <output topic> <output type> [<expression on m>]\n\n'
                         'Example:\n\trosrun topic_tools op /imu/orientation /norm std_msgs/Float64 \'sqrt(sum(array([m.x, m.y, m.z, m.w])))\'')
         parser.add_argument('input')

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -30,12 +30,17 @@ class TopicOp:
         parser = argparse.ArgumentParser(
             formatter_class=argparse.RawTextHelpFormatter,
             description='Apply a Python operation to a topic.\n\n'
-                        'Usage:\n\t<input> <output topic> <output type> [<expression on m>]\n\n'
-                        'Example:\n\trosrun topic_tools op /imu/orientation /norm std_msgs/Float64 \'sqrt(sum(array([m.x, m.y, m.z, m.w])))\'')
-        parser.add_argument('input')
-        parser.add_argument('output_topic')
-        parser.add_argument('output_type')
-        parser.add_argument('expression', default='m')
+                        'Usage:\n\trosrun topic_tools op '
+                        '<input> <output topic> <output type> '
+                        '[<expression on m>]\n\n'
+                        'Example:\n\trosrun topic_tools op /imu/orientation '
+                        '/norm std_msgs/Float64 '
+                        '\'sqrt(sum(array([m.x, m.y, m.z, m.w])))\'')
+        parser.add_argument('input', help='Input topic or topic field.')
+        parser.add_argument('output_topic', help='Output topic.')
+        parser.add_argument('output_type', help='Output topic type.')
+        parser.add_argument('expression', default='m',
+                help='Python expression to apply on the input message \'m\'.')
 
         args = parser.parse_args()
 

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -43,8 +43,6 @@ class TopicOp:
 
         self.expression = args.expression
 
-        # We need the class, rather than the type,
-        # so we use get_topic_class instead of get_topic_type.
         input_class, input_topic, self.input_fn = rostopic.get_topic_class(args.input)
         output_class = roslib.message.get_message_class(args.output_type)
 
@@ -65,7 +63,7 @@ if __name__ == '__main__':
 
     rospy.init_node('op', anonymous=True)
 
-    x = TopicOp()
+    app = TopicOp()
 
     while not rospy.is_shutdown():
         rospy.spin()

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -13,11 +13,11 @@ after performing a valid python operation (including numpy).
 The operations are done on the message, which is taken in the variable 'm'.
 
 * Some examples:
-$ rosrun pal_topic_tools op /imu/orientation/x /x std_msgs/Float64 '-rad2deg(m)'
-$ rosrun pal_topic_tools op /imu/orientation /norm std_msgs/Float64 'sqrt(sum(array([m.x, m.y, m.z, m.w])))'
+$ rosrun topic_tools op /imu/orientation/x /x std_msgs/Float64 '-rad2deg(m)'
+$ rosrun topic_tools op /imu/orientation /norm std_msgs/Float64 'sqrt(sum(array([m.x, m.y, m.z, m.w])))'
 
 * Interactive mode:
-$ rosrun pal_topic_tools op <in> <out> <type> <exp> True
+$ rosrun topic_tools op <in> <out> <type> <exp> True
 
 This goes into an ipdb debugger session inside the callback for the input (in)
 topic, so you can redefine the self.expression (exp) to use, or create new logic.
@@ -40,7 +40,6 @@ before hitting 'c' to continue.
 """
 
 import roslib
-roslib.load_manifest('pal_topic_tools')
 
 import rospy
 import rostopic

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Created on Fri Aug  9 12:13:00 2013
+
+@author: enriquefernandez
+@todo: support non-scalar output types (requires defining a syntax for the expression, maybe YAML)
+
+Allows to take a topic or one of it fields and output it on another topic
+after performing a valid python operation (including numpy).
+
+The operations are done on the message, which is taken in the variable 'm'.
+
+* Some examples:
+$ rosrun pal_topic_tools op /imu/orientation/x /x std_msgs/Float64 '-rad2deg(m)'
+$ rosrun pal_topic_tools op /imu/orientation /norm std_msgs/Float64 'sqrt(sum(array([m.x, m.y, m.z, m.w])))'
+
+* Interactive mode:
+$ rosrun pal_topic_tools op <in> <out> <type> <exp> True
+
+This goes into an ipdb debugger session inside the callback for the input (in)
+topic, so you can redefine the self.expression (exp) to use, or create new logic.
+Indeed you can create new attributes and def functions. However, you cannot:
+- self.expression cannot use an assignment
+- cannot create local variables
+
+In order to create a new function and variable, you can follow this example,
+which computes a weighted mean:
+ipdb> import types
+ipdb> self.mean = 0
+ipdb> def compute_mean(self, x): self.mean = 0.9 * self.mean + 0.1 * x; return self.mean
+ipdb> self.compute_mean = types.MethodType( compute_mean, self )
+ipdb> self.expression = 'self.compute_mean( m.data )'
+
+Once you are done, to avoid entering again in the callback, just do:
+ipdb> self.interactive = False
+before hitting 'c' to continue.
+
+"""
+
+import roslib
+roslib.load_manifest('pal_topic_tools')
+
+import rospy
+import rostopic
+import sys
+
+import ipdb
+
+from numpy import *
+
+def set_trace():
+    ip = ipapi.get()
+    def_colors = ip.options.colors
+    Pdb(def_colors).set_trace(sys._getframe().f_back)
+
+
+class TopicOp:
+
+    def __init__( self ):
+        if len( sys.argv ) < 4:
+            sys.exit( 'Usage: %s <input> <output topic> <output type> [<expression on m>] [<interactive mode>]' % sys.argv[0] )
+
+        self.input        = sys.argv[1]
+        self.output_topic = sys.argv[2]
+        self.output_type  = sys.argv[3]
+        self.expression   = sys.argv[4] if len( sys.argv ) > 4 else 'm'
+        self.interactive  = sys.argv[5] == 'True' if len( sys.argv ) > 5 else False
+
+        # We need the class, rather than the type,
+        # so we use get_topic_class instead of get_topic_type.
+        self.input_class, self.input_topic, self.input_fn = rostopic.get_topic_class( self.input )
+        self.output_class = roslib.message.get_message_class( self.output_type )
+
+        self.sub = rospy.Subscriber( self.input_topic, self.input_class, self.callback )
+        self.pub = rospy.Publisher( self.output_topic, self.output_class )
+
+    def callback( self, msg ):
+        if self.input_fn is not None:
+            m = self.input_fn( msg )
+        else:
+            m = msg
+
+        if self.interactive:
+            ipdb.set_trace()
+
+        res = eval( self.expression )
+        self.pub.publish( res )
+
+
+if __name__ == '__main__':
+
+    rospy.init_node('op', anonymous=True)
+
+    x = TopicOp()
+
+    while not rospy.is_shutdown():
+        rospy.spin()
+

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -21,37 +21,44 @@ import roslib
 import rospy
 import rostopic
 
-import sys
+import argparse
 
+# Allow for numpy operations in the given expression
 from numpy import *
 
 class TopicOp:
 
-    def __init__( self ):
-        if len( sys.argv ) < 4:
-            sys.exit( 'Usage: %s <input> <output topic> <output type> [<expression on m>]' % sys.argv[0] )
+    def __init__(self):
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.RawTextHelpFormatter,
+            description='Make a python operation on a topic.\n\n'
+                        'Usage:\n\t<input> <output topic> <output type> [<expression on m>]\n\n'
+                        'Example:\n\trosrun topic_tools op /imu/orientation /norm std_msgs/Float64 \'sqrt(sum(array([m.x, m.y, m.z, m.w])))\'')
+        parser.add_argument('input')
+        parser.add_argument('output_topic')
+        parser.add_argument('output_type')
+        parser.add_argument('expression', default='m')
 
-        self.input        = sys.argv[1]
-        self.output_topic = sys.argv[2]
-        self.output_type  = sys.argv[3]
-        self.expression   = sys.argv[4] if len( sys.argv ) > 4 else 'm'
+        args = parser.parse_args()
+
+        self.expression = args.expression
 
         # We need the class, rather than the type,
         # so we use get_topic_class instead of get_topic_type.
-        self.input_class, self.input_topic, self.input_fn = rostopic.get_topic_class( self.input )
-        self.output_class = roslib.message.get_message_class( self.output_type )
+        input_class, input_topic, self.input_fn = rostopic.get_topic_class(args.input)
+        output_class = roslib.message.get_message_class(args.output_type)
 
-        self.sub = rospy.Subscriber( self.input_topic, self.input_class, self.callback )
-        self.pub = rospy.Publisher( self.output_topic, self.output_class )
+        self.sub = rospy.Subscriber(input_topic, input_class, self.callback)
+        self.pub = rospy.Publisher(args.output_topic, output_class)
 
-    def callback( self, msg ):
+    def callback(self, msg):
         if self.input_fn is not None:
-            m = self.input_fn( msg )
+            m = self.input_fn(msg)
         else:
             m = msg
 
-        res = eval( self.expression )
-        self.pub.publish( res )
+        res = eval(self.expression)
+        self.pub.publish(res)
 
 
 if __name__ == '__main__':

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 
 """
-Created on Fri Aug  9 12:13:00 2013
-
 @author: enriquefernandez
 @todo: support non-scalar output types (requires defining a syntax for the expression, maybe YAML)
 

--- a/tools/topic_tools/scripts/op
+++ b/tools/topic_tools/scripts/op
@@ -30,6 +30,10 @@ class TopicOp:
         parser = argparse.ArgumentParser(
             formatter_class=argparse.RawTextHelpFormatter,
             description='Apply a Python operation to a topic.\n\n'
+                        'A node is created that subscribes to a topic,\n'
+                        'applies a Python expression to the topic (or topic\n'
+                        'field) message \'m\', and publishes the result\n'
+                        'through another topic.\n\n'
                         'Usage:\n\trosrun topic_tools op '
                         '<input> <output topic> <output type> '
                         '[<expression on m>]\n\n'

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -15,6 +15,8 @@ $ rosrun topic_tools transform /imu/orientation/x /x_in_degrees std_msgs/Float64
 $ rosrun topic_tools transform /imu/orientation /norm std_msgs/Float64 'sqrt(sum(array([m.x, m.y, m.z, m.w])))'
 """
 
+from __future__ import print_function
+
 import roslib
 import rospy
 import rostopic
@@ -52,7 +54,7 @@ class TopicOp:
 
         input_class, input_topic, self.input_fn = rostopic.get_topic_class(args.input)
         if input_topic == None:
-            print 'ERROR: Wrong input topic (or topic field): %s'%args.input
+            print('ERROR: Wrong input topic (or topic field):', args.input)
             exit()
 
         output_class = roslib.message.get_message_class(args.output_type)
@@ -65,14 +67,14 @@ class TopicOp:
             m = self.input_fn(m)
 
         try:
-            res = eval(self.expression, {}, {"m":m})
+            res = eval(self.expression, {}, {'m':m})
             self.pub.publish(res)
         except NameError as e:
-            print "Expression using variables other than 'm': %s"%e.message
+            print('Expression using variables other than ''m'':', e.message)
         except UnboundLocalError as e:
-            print "Wrong expression: %s"%e.message
+            print('Wrong expression:' , e.message)
         except:
-            print "Wrong expression"
+            print('Wrong expression')
 
 
 if __name__ == '__main__':

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -11,8 +11,8 @@ after performing a valid python operation (including numpy).
 The operations are done on the message, which is taken in the variable 'm'.
 
 * Some examples:
-$ rosrun topic_tools op /imu/orientation/x /x_in_degrees std_msgs/Float64 '-rad2deg(m)'
-$ rosrun topic_tools op /imu/orientation /norm std_msgs/Float64 'sqrt(sum(array([m.x, m.y, m.z, m.w])))'
+$ rosrun topic_tools transform /imu/orientation/x /x_in_degrees std_msgs/Float64 '-rad2deg(m)'
+$ rosrun topic_tools transform /imu/orientation /norm std_msgs/Float64 'sqrt(sum(array([m.x, m.y, m.z, m.w])))'
 """
 
 import roslib
@@ -34,10 +34,10 @@ class TopicOp:
                         'applies a Python expression to the topic (or topic\n'
                         'field) message \'m\', and publishes the result\n'
                         'through another topic.\n\n'
-                        'Usage:\n\trosrun topic_tools op '
+                        'Usage:\n\trosrun topic_tools transform '
                         '<input> <output topic> <output type> '
                         '[<expression on m>]\n\n'
-                        'Example:\n\trosrun topic_tools op /imu/orientation '
+                        'Example:\n\trosrun topic_tools transform /imu/orientation '
                         '/norm std_msgs/Float64 '
                         '\'sqrt(sum(array([m.x, m.y, m.z, m.w])))\'')
         parser.add_argument('input', help='Input topic or topic field.')
@@ -72,7 +72,7 @@ class TopicOp:
 
 if __name__ == '__main__':
 
-    rospy.init_node('op', anonymous=True)
+    rospy.init_node('transform', anonymous=True)
 
     app = TopicOp()
 

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -60,14 +60,19 @@ class TopicOp:
         self.sub = rospy.Subscriber(input_topic, input_class, self.callback)
         self.pub = rospy.Publisher(args.output_topic, output_class)
 
-    def callback(self, msg):
+    def callback(self, m):
         if self.input_fn is not None:
-            m = self.input_fn(msg)
-        else:
-            m = msg
+            m = self.input_fn(m)
 
-        res = eval(self.expression)
-        self.pub.publish(res)
+        try:
+            res = eval(self.expression, {}, {"m":m})
+            self.pub.publish(res)
+        except NameError as e:
+            print "Expression using variables other than 'm': %s"%e.message
+        except UnboundLocalError as e:
+            print "Wrong expression: %s"%e.message
+        except:
+            print "Wrong expression"
 
 
 if __name__ == '__main__':

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -58,7 +58,7 @@ class TopicOp:
         output_class = roslib.message.get_message_class(args.output_type)
 
         self.sub = rospy.Subscriber(input_topic, input_class, self.callback)
-        self.pub = rospy.Publisher(args.output_topic, output_class)
+        self.pub = rospy.Publisher(args.output_topic, output_class, queue_size=1)
 
     def callback(self, m):
         if self.input_fn is not None:

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -21,6 +21,7 @@ import roslib
 import rospy
 import rostopic
 
+import sys
 import argparse
 
 # Allow for numpy operations in the given expression
@@ -74,7 +75,8 @@ class TopicOp:
         except UnboundLocalError as e:
             print('Wrong expression:' , e.message)
         except:
-            print('Wrong expression')
+            print('Wrong expression:' , sys.exc_info()[0])
+            raise
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Allows to do python operations between message fields taken from several topics.

A typical use case consist on calculating the norm of a vector, or converting a quaternion to Euler angles for visualization; some examples are included in the `op` python script header comment.
