### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/clients/rospy/package.xml
+++ b/clients/rospy/package.xml
@@ -39,5 +39,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/tools/rosgraph/package.xml
+++ b/tools/rosgraph/package.xml
@@ -21,5 +21,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -34,5 +34,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/tools/rosmaster/package.xml
+++ b/tools/rosmaster/package.xml
@@ -16,5 +16,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/tools/rosmsg/package.xml
+++ b/tools/rosmsg/package.xml
@@ -26,5 +26,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/tools/rosnode/package.xml
+++ b/tools/rosnode/package.xml
@@ -23,5 +23,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/tools/rosparam/package.xml
+++ b/tools/rosparam/package.xml
@@ -24,5 +24,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/tools/rosservice/package.xml
+++ b/tools/rosservice/package.xml
@@ -25,5 +25,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/tools/rostest/package.xml
+++ b/tools/rostest/package.xml
@@ -22,5 +22,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>

--- a/utilities/roswtf/package.xml
+++ b/utilities/roswtf/package.xml
@@ -25,5 +25,6 @@
 
   <export>
     <rosdoc config="rosdoc.yaml"/>
+    <architecture_independent/>
   </export>
 </package>


### PR DESCRIPTION
These packages don't have any binaries in them, so they can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
