### PR TITLE
roslz4: fix a python major version check in the python module

### DIFF
--- a/utilities/roslz4/src/_roslz4module.c
+++ b/utilities/roslz4/src/_roslz4module.c
@@ -444,7 +444,7 @@ init_roslz4(void)
   Py_INCREF(&LZ4Decompressor_Type);
   PyModule_AddObject(m, "LZ4Decompressor", (PyObject *)&LZ4Decompressor_Type);
 
-#if PY_MAJOR_VERSION
+#if PY_MAJOR_VERSION >= 3
   return m;
 #endif
 }


### PR DESCRIPTION
When building I get this:

```
[100%] Building C object CMakeFiles/roslz4_py.dir/src/_roslz4module.c.o
/usr/bin/cc  -Droslz4_py_EXPORTS -fPIC -I/tmp/rviz_ws/indigo/deps/src/ros_comm/roslz4/include -I/usr/local/include -I/System/Library/Frameworks/Python.framework/Headers    -o CMakeFiles/roslz4_py.dir/src/_roslz4module.c.o   -c /tmp/rviz_ws/indigo/deps/src/ros_comm/roslz4/src/_roslz4module.c
/tmp/rviz_ws/indigo/deps/src/ros_comm/roslz4/src/_roslz4module.c:448:3: error: void function 'init_roslz4' should not return a value [-Wreturn-type]
  return m;
  ^      ~
1 error generated.
```

This pull request fixes this for me.
