### PR TITLE
Add Mux and Demux to hydro

### DIFF
--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -10,7 +10,11 @@ add_service_files(DIRECTORY srv
   MuxAdd.srv
   MuxDelete.srv
   MuxList.srv
-  MuxSelect.srv)
+  MuxSelect.srv
+  DemuxAdd.srv
+  DemuxDelete.srv
+  DemuxList.srv
+  DemuxSelect.srv)
 
 generate_messages(DEPENDENCIES std_msgs)
 
@@ -28,6 +32,10 @@ target_link_libraries(switch_mux topic_tools ${catkin_LIBRARIES})
 
 add_executable(mux src/mux.cpp)
 target_link_libraries(mux topic_tools ${catkin_LIBRARIES})
+add_dependencies(topic_tools topic_tools_gencpp)
+
+add_executable(demux src/demux.cpp)
+target_link_libraries(demux topic_tools ${catkin_LIBRARIES})
 add_dependencies(topic_tools topic_tools_gencpp)
 
 add_executable(relay src/relay.cpp)

--- a/tools/topic_tools/scripts/demux_add
+++ b/tools/topic_tools/scripts/demux_add
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import os
+import string
+
+import rospy
+
+# imports the DemuxAdd service 
+from topic_tools.srv import DemuxAdd
+
+USAGE = 'USAGE: demux_add DEMUX_NAME TOPIC'
+
+def call_srv(m, t):
+    # There's probably a nicer rospy way of doing this
+    s = m + '/add'
+    print "Waiting for service \"%s\""%(s)
+    rospy.wait_for_service(s)
+    print "Adding \"%s\" to demux \"%s\""%(t, m)
+    try:
+        srv = rospy.ServiceProxy(s, DemuxAdd)
+	return srv(t)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+
+def usage():
+    return "%s "%sys.argv[0]
+
+if __name__ == "__main__":
+    args = rospy.myargv()
+    if len(args) != 3:
+        print USAGE
+	sys.exit(1)
+
+    m = args[1]
+    t = args[2]
+    call_srv(m, t)

--- a/tools/topic_tools/scripts/demux_delete
+++ b/tools/topic_tools/scripts/demux_delete
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import os
+
+import rospy
+
+# imports the DemuxDelete service 
+from topic_tools.srv import DemuxDelete
+
+USAGE = 'USAGE: demux_delete DEMUX_NAME TOPIC'
+
+def call_srv(m, t):
+    # There's probably a nicer rospy way of doing this
+    s = m + '/delete'
+    print "Waiting for service \"%s\""%(s)
+    rospy.wait_for_service(s)
+    print "Deleting \"%s\" from demux \"%s\""%(t, m)
+    try:
+        srv = rospy.ServiceProxy(s, DemuxDelete)
+	return srv(t)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+
+def usage():
+    return "%s "%sys.argv[0]
+
+if __name__ == "__main__":
+    args = rospy.myargv()
+    if len(args) != 3:
+        print USAGE
+	sys.exit(1)
+
+    m = args[1]
+    t = args[2]
+    call_srv(m, t)

--- a/tools/topic_tools/scripts/demux_list
+++ b/tools/topic_tools/scripts/demux_list
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import os
+import string
+
+import rospy
+
+# imports the DemuxList service 
+from topic_tools.srv import DemuxList
+
+USAGE = 'USAGE: demux_list DEMUX_NAME'
+
+def call_srv(m):
+    # There's probably a nicer rospy way of doing this
+    s = m + '/list'
+    print "Waiting for service \"%s\""%(s)
+    rospy.wait_for_service(s)
+    print "Listing topics from demux \"%s\""%(m)
+    try:
+        srv = rospy.ServiceProxy(s, DemuxList)
+	resp = srv()
+	if resp:
+	    print resp.topics
+        return resp
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+
+def usage():
+    return "%s "%sys.argv[0]
+
+if __name__ == "__main__":
+    args = rospy.myargv()
+    if len(args) != 2:
+        print USAGE
+	sys.exit(1)
+
+    m = args[1]
+    call_srv(m)

--- a/tools/topic_tools/scripts/demux_select
+++ b/tools/topic_tools/scripts/demux_select
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+import os
+import string
+
+import rospy
+
+# imports the DemuxSelect service 
+from topic_tools.srv import DemuxSelect
+
+USAGE = 'USAGE: demux_select DEMUX_NAME TOPIC'
+
+def call_srv(m, t):
+    # There's probably a nicer rospy way of doing this
+    s = m + '/select'
+    print "Waiting for service \"%s\""%(s)
+    rospy.wait_for_service(s)
+    print "Selecting \"%s\" at demux \"%s\""%(t, m)
+    try:
+        srv = rospy.ServiceProxy(s, DemuxSelect)
+	return srv(t)
+    except rospy.ServiceException, e:
+        print "Service call failed: %s"%e
+
+def usage():
+    return "%s "%sys.argv[0]
+
+if __name__ == "__main__":
+    args = rospy.myargv()
+    if len(args) != 3:
+        print USAGE
+	sys.exit(1)
+
+    m = args[1]
+    t = args[2]
+    call_srv(m, t)

--- a/tools/topic_tools/src/demux.cpp
+++ b/tools/topic_tools/src/demux.cpp
@@ -1,9 +1,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 // demux is a generic ROS topic demultiplexer: one input topic is fanned out
-// to 1 of N output topics. A service and topic subscription are provided
-// to select between the outputs.
+// to 1 of N output topics. A service is provided to select between the outputs
 //
-// Copyright (C) 2009, Morgan Quigley
+// Copyright (C) 2014, Andreas Hermann
+// Code copied and adapted from the "toppic mux" by Morgan Quigley
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -29,72 +29,271 @@
 // POSSIBILITY OF SUCH DAMAGE.
 /////////////////////////////////////////////////////////////////////////////
 
-#include "ros/node.h"
+
+#include <cstdio>
+#include <vector>
+#include <list>
+#include "ros/console.h"
 #include "std_msgs/String.h"
 #include "topic_tools/DemuxSelect.h"
+#include "topic_tools/DemuxAdd.h"
+#include "topic_tools/DemuxList.h"
+#include "topic_tools/DemuxDelete.h"
 #include "topic_tools/shape_shifter.h"
+#include "topic_tools/parse.h"
 
 using std::string;
 using std::vector;
-using std::map;
+using std::list;
 using namespace topic_tools;
 
-static std_msgs::String g_sel_msg;
-static vector<string> g_output_topics, g_selected;
-static bool g_advertised = false;
-static ros::Node *g_node = NULL;
-static ShapeShifter g_in_msg;
+const static string g_none_topic = "__none";
+
+static ros::NodeHandle *g_node = NULL;
+
+static string g_input_topic;
+static ros::Subscriber g_sub; // the input toppic
+static ros::Publisher g_pub_selected; // publishes name of selected publisher toppic
+
+struct pub_info_t
+{
+  std::string topic_name;
+  ros::Publisher *pub;
+};
+
+void in_cb(const boost::shared_ptr<ShapeShifter const>& msg);
+
+static list<struct pub_info_t> g_pubs; // the list of publishers
+static list<struct pub_info_t>::iterator g_selected = g_pubs.end();
 
 bool sel_srv_cb( topic_tools::DemuxSelect::Request  &req,
                  topic_tools::DemuxSelect::Response &res )
 {
-  res.prev_topics = g_selected;
-  g_selected = req.topics;
-  printf("enabling demux on these topics:\n");
-  for (size_t i = 0; i < g_selected.size(); ++i)
-    printf("  %s\n", g_selected[i].c_str());
+  bool ret = false;
+  if (g_selected != g_pubs.end()) {
+    res.prev_topic = g_selected->topic_name;
+
+    // Unregister old topic
+    ROS_INFO("Unregistering %s", res.prev_topic.c_str());
+    if (g_selected->pub)
+	  g_selected->pub->shutdown();
+    delete g_selected->pub;
+    g_selected->pub = NULL;
+  }
+  else
+    res.prev_topic = string("");
+
+  // see if it's the magical '__none' topic, in which case we open the circuit
+  if (req.topic == g_none_topic)
+  {
+    ROS_INFO("demux selected to no output.");
+
+    g_selected = g_pubs.end();
+    ret = true;
+  }
+  else
+  {
+    ROS_INFO("trying to switch demux to %s", req.topic.c_str());
+    // spin through our vector of inputs and find this guy
+    for (list<struct pub_info_t>::iterator it = g_pubs.begin();
+	 it != g_pubs.end();
+	 ++it)
+    {
+      if (ros::names::resolve(it->topic_name) == ros::names::resolve(req.topic))
+      {
+        g_selected = it;
+        ROS_INFO("demux selected output: [%s]", it->topic_name.c_str());
+        ret = true;
+      }
+    }
+    if(!ret)
+    {
+    	ROS_WARN("Failed to switch to non-existing topic %s in demux.", req.topic.c_str());
+    }
+  }
+
+  if(ret)
+  {
+    std_msgs::String t;
+    t.data = req.topic;
+    g_pub_selected.publish(t);
+  }
+
+  return ret;
+}
+
+void in_cb(const boost::shared_ptr<ShapeShifter const>& msg)
+{
+  ROS_INFO("Received an incoming msg ...");
+  // when a message is incoming, check, if the requested publisher is already existing.
+  // if not, create it with the information available from the incoming message.
+  if(!g_selected->pub)
+  {
+	  try
+	  {
+		  g_selected->pub = new ros::Publisher(msg->advertise(*g_node, g_selected->topic_name, 10, false));
+	  }
+	  catch(ros::InvalidNameException& e)
+	  {
+		ROS_WARN("failed to add topic %s to demux, because it's an invalid name: %s",
+				g_selected->topic_name.c_str(), e.what());
+		return;
+	  }
+
+	  ROS_INFO("Added publisher %s to demux! Sleeping for 0.5 secs.", g_selected->topic_name.c_str());
+	  ros::Duration(0.5).sleep(); // sleep for half a second
+  }
+
+  // finally: send out the message over the active publisher
+  g_selected->pub->publish(msg);
+  ROS_INFO("... and sent it out again!");
+}
+
+bool list_topic_cb(topic_tools::DemuxList::Request& req,
+	 	   topic_tools::DemuxList::Response& res)
+{
+  for (list<struct pub_info_t>::iterator it = g_pubs.begin();
+       it != g_pubs.end();
+       ++it)
+  {
+    res.topics.push_back(it->topic_name);
+  }
+
   return true;
 }
 
-void in_cb()
+bool add_topic_cb(topic_tools::DemuxAdd::Request& req,
+		  topic_tools::DemuxAdd::Response& res)
 {
-  if (!ShapeShifter::typed)
+  // Check that it's not already in our list
+  ROS_INFO("trying to add %s to demux", req.topic.c_str());
+
+  // Can't add the __none topic
+  if(req.topic == g_none_topic)
   {
-    printf("reading first message header, setting datatype\n");
-    ShapeShifter::datatype = (*(g_in_msg.__connection_header))["type"];
-    ShapeShifter::md5 = (*(g_in_msg.__connection_header))["md5sum"];
-    ShapeShifter::msg_def = (*(g_in_msg.__connection_header))["message_definition"];
-    ShapeShifter::typed = true;
+    ROS_WARN("failed to add topic %s to demux, because it's reserved for special use",
+	     req.topic.c_str());
+    return false;
   }
-  if (!g_advertised)
+
+  // spin through our vector of inputs and find this guy
+  for (list<struct pub_info_t>::iterator it = g_pubs.begin();
+       it != g_pubs.end();
+       ++it)
   {
-    printf("advertising\n");
-    for (size_t i = 0; i < g_output_topics.size(); i++)
-      g_node->advertise<ShapeShifter>(g_output_topics[i], 10);
-    g_advertised = true;
+    if (ros::names::resolve(it->topic_name) == ros::names::resolve(req.topic))
+    {
+      ROS_WARN("tried to add a topic that demux was already publishing: [%s]",
+	       it->topic_name.c_str());
+      return false;
+    }
   }
-  for (size_t i = 0; i < g_selected.size(); i++)
-    g_node->publish(g_selected[i], g_in_msg);
+
+  struct pub_info_t pub_info;
+  pub_info.topic_name = ros::names::resolve(req.topic);
+  pub_info.pub = NULL;
+  g_pubs.push_back(pub_info);
+
+  ROS_INFO("PRE added %s to demux", req.topic.c_str());
+
+  return true;
+}
+
+bool del_topic_cb(topic_tools::DemuxDelete::Request& req,
+		  topic_tools::DemuxDelete::Response& res)
+{
+  // Check that it's in our list
+  ROS_INFO("trying to delete %s from demux", req.topic.c_str());
+  // spin through our vector of inputs and find this guy
+  for (list<struct pub_info_t>::iterator it = g_pubs.begin();
+       it != g_pubs.end();
+       ++it)
+  {
+    if (ros::names::resolve(it->topic_name) == ros::names::resolve(req.topic))
+    {
+      // Can't delete the currently selected input, #2863
+      if(it == g_selected)
+      {
+        ROS_WARN("tried to delete currently selected topic %s from demux", req.topic.c_str());
+        return false;
+      }
+      if (it->pub)
+        it->pub->shutdown();
+      delete it->pub;
+      g_pubs.erase(it);
+      ROS_INFO("deleted topic %s from demux", req.topic.c_str());
+      return true;
+    }
+  }
+
+  ROS_WARN("tried to delete non-published topic %s from demux", req.topic.c_str());
+  return false;
 }
 
 int main(int argc, char **argv)
 {
-  if (argc < 4)
+  vector<string> args;
+  ros::removeROSArgs(argc, (const char**)argv, args);
+
+  if (args.size() < 3)
   {
-    printf("\nusage: demux IN_TOPIC OUT_TOPIC1 OUT_TOPIC2 [...]\n");
+    printf("\nusage: demux IN_TOPIC OUT_TOPIC1 [OUT_TOPIC2 [...]]\n\n");
     return 1;
   }
-  string in_topic = string(argv[1]);
-  ros::init(argc, argv, in_topic + string("_demux"));
-  for (int i = 2; i < argc; i++)
-    g_output_topics.push_back(argv[i]);
-  ros::Node n(in_topic + string("_demux"));
+  std::string topic_name;
+  if(!getBaseName(args[1], topic_name))
+    return 1;
+  ros::init(argc, argv, topic_name + string("_demux"),
+            ros::init_options::AnonymousName);
+  vector<string> topics;
+  for (unsigned int i = 2; i < args.size(); i++)
+    topics.push_back(args[i]);
+  ros::NodeHandle n;
   g_node = &n;
-  n.advertiseService(in_topic + string("_demux_select"), sel_srv_cb);
-  g_in_msg.topic = in_topic;
-  n.subscribe(in_topic, g_in_msg, in_cb, 10);
-  g_selected.push_back(g_output_topics[0]); // select the first one to start
+  g_input_topic = args[1];
+  // Put our API into the "demux" namespace, which the user should usually remap
+  ros::NodeHandle pnh("~");
+
+  // Latched publisher for selected output topic name
+  g_pub_selected = pnh.advertise<std_msgs::String>(string("selected"), 1, true);
+
+  for (size_t i = 0; i < topics.size(); i++)
+  {
+    struct pub_info_t pub_info;
+    pub_info.topic_name = ros::names::resolve(topics[i]);
+    pub_info.pub = NULL;
+    g_pubs.push_back(pub_info);
+    ROS_INFO("PRE added %s to demux", topics[i].c_str());
+  }
+  g_selected = g_pubs.begin(); // select first topic to start
+  std_msgs::String t;
+  t.data = g_selected->topic_name;
+  g_pub_selected.publish(t);
+
+  // Create the one subscriber
+  g_sub = ros::Subscriber(g_node->subscribe<ShapeShifter>(g_input_topic, 10, boost::bind(in_cb, _1)));
+
+
+  // New service
+  ros::ServiceServer ss_select = pnh.advertiseService(string("select"), sel_srv_cb);
+  ros::ServiceServer ss_add = pnh.advertiseService(string("add"), add_topic_cb);
+  ros::ServiceServer ss_list = pnh.advertiseService(string("list"), list_topic_cb);
+  ros::ServiceServer ss_del = pnh.advertiseService(string("delete"), del_topic_cb);
+
+  // Run
   ros::spin();
+
+  // Destruction
+  for (list<struct pub_info_t>::iterator it = g_pubs.begin();
+       it != g_pubs.end();
+       ++it)
+  {
+    if (it->pub)
+      it->pub->shutdown();
+    delete it->pub;
+  }
+
+  g_pubs.clear();
   return 0;
 }
 

--- a/tools/topic_tools/src/mux.cpp
+++ b/tools/topic_tools/src/mux.cpp
@@ -299,18 +299,18 @@ int main(int argc, char **argv)
   g_node = &n;
   g_output_topic = args[1];
   // Put our API into the "mux" namespace, which the user should usually remap
-  ros::NodeHandle pnh("~");
+  ros::NodeHandle mux_nh("mux"), pnh("~");
   pnh.getParam("lazy", g_lazy);
 
   // Latched publisher for selected input topic name
-  g_pub_selected = pnh.advertise<std_msgs::String>(string("selected"), 1, true);
+  g_pub_selected = mux_nh.advertise<std_msgs::String>(string("selected"), 1, true);
 
   for (size_t i = 0; i < topics.size(); i++)
   {
     struct sub_info_t sub_info;
     sub_info.msg = new ShapeShifter;
     sub_info.topic_name = ros::names::resolve(topics[i]);
-    sub_info.sub = new ros::Subscriber(g_node->subscribe<ShapeShifter>(sub_info.topic_name, 10, boost::bind(in_cb, _1, sub_info.msg)));
+    sub_info.sub = new ros::Subscriber(n.subscribe<ShapeShifter>(sub_info.topic_name, 10, boost::bind(in_cb, _1, sub_info.msg)));
 
     g_subs.push_back(sub_info);
   }
@@ -320,12 +320,12 @@ int main(int argc, char **argv)
   g_pub_selected.publish(t);
 
   // Backward compatibility
-  ros::ServiceServer ss = pnh.advertiseService(g_output_topic + string("_select"), sel_srv_cb_dep);
+  ros::ServiceServer ss = n.advertiseService(g_output_topic + string("_select"), sel_srv_cb_dep);
   // New service
-  ros::ServiceServer ss_select = pnh.advertiseService(string("select"), sel_srv_cb);
-  ros::ServiceServer ss_add = pnh.advertiseService(string("add"), add_topic_cb);
-  ros::ServiceServer ss_list = pnh.advertiseService(string("list"), list_topic_cb);
-  ros::ServiceServer ss_del = pnh.advertiseService(string("delete"), del_topic_cb);
+  ros::ServiceServer ss_select = mux_nh.advertiseService(string("select"), sel_srv_cb);
+  ros::ServiceServer ss_add = mux_nh.advertiseService(string("add"), add_topic_cb);
+  ros::ServiceServer ss_list = mux_nh.advertiseService(string("list"), list_topic_cb);
+  ros::ServiceServer ss_del = mux_nh.advertiseService(string("delete"), del_topic_cb);
   ros::spin();
   for (list<struct sub_info_t>::iterator it = g_subs.begin();
        it != g_subs.end();

--- a/tools/topic_tools/src/mux.cpp
+++ b/tools/topic_tools/src/mux.cpp
@@ -299,18 +299,18 @@ int main(int argc, char **argv)
   g_node = &n;
   g_output_topic = args[1];
   // Put our API into the "mux" namespace, which the user should usually remap
-  ros::NodeHandle mux_nh("mux"), pnh("~");
+  ros::NodeHandle pnh("~");
   pnh.getParam("lazy", g_lazy);
 
   // Latched publisher for selected input topic name
-  g_pub_selected = mux_nh.advertise<std_msgs::String>(string("selected"), 1, true);
+  g_pub_selected = pnh.advertise<std_msgs::String>(string("selected"), 1, true);
 
   for (size_t i = 0; i < topics.size(); i++)
   {
     struct sub_info_t sub_info;
     sub_info.msg = new ShapeShifter;
     sub_info.topic_name = ros::names::resolve(topics[i]);
-    sub_info.sub = new ros::Subscriber(n.subscribe<ShapeShifter>(sub_info.topic_name, 10, boost::bind(in_cb, _1, sub_info.msg)));
+    sub_info.sub = new ros::Subscriber(g_node->subscribe<ShapeShifter>(sub_info.topic_name, 10, boost::bind(in_cb, _1, sub_info.msg)));
 
     g_subs.push_back(sub_info);
   }
@@ -320,12 +320,12 @@ int main(int argc, char **argv)
   g_pub_selected.publish(t);
 
   // Backward compatibility
-  ros::ServiceServer ss = n.advertiseService(g_output_topic + string("_select"), sel_srv_cb_dep);
+  ros::ServiceServer ss = pnh.advertiseService(g_output_topic + string("_select"), sel_srv_cb_dep);
   // New service
-  ros::ServiceServer ss_select = mux_nh.advertiseService(string("select"), sel_srv_cb);
-  ros::ServiceServer ss_add = mux_nh.advertiseService(string("add"), add_topic_cb);
-  ros::ServiceServer ss_list = mux_nh.advertiseService(string("list"), list_topic_cb);
-  ros::ServiceServer ss_del = mux_nh.advertiseService(string("delete"), del_topic_cb);
+  ros::ServiceServer ss_select = pnh.advertiseService(string("select"), sel_srv_cb);
+  ros::ServiceServer ss_add = pnh.advertiseService(string("add"), add_topic_cb);
+  ros::ServiceServer ss_list = pnh.advertiseService(string("list"), list_topic_cb);
+  ros::ServiceServer ss_del = pnh.advertiseService(string("delete"), del_topic_cb);
   ros::spin();
   for (list<struct sub_info_t>::iterator it = g_subs.begin();
        it != g_subs.end();

--- a/tools/topic_tools/srv/DemuxAdd.srv
+++ b/tools/topic_tools/srv/DemuxAdd.srv
@@ -1,0 +1,2 @@
+string topic
+---

--- a/tools/topic_tools/srv/DemuxDelete.srv
+++ b/tools/topic_tools/srv/DemuxDelete.srv
@@ -1,0 +1,3 @@
+string topic
+---
+

--- a/tools/topic_tools/srv/DemuxList.srv
+++ b/tools/topic_tools/srv/DemuxList.srv
@@ -1,0 +1,2 @@
+---
+string[] topics

--- a/tools/topic_tools/srv/DemuxSelect.srv
+++ b/tools/topic_tools/srv/DemuxSelect.srv
@@ -1,0 +1,3 @@
+string topic
+---
+string prev_topic


### PR DESCRIPTION
I was missing a Demux tool. So I brought the old code back to life.
While working on that, I also fixed the service-servers of the Mux tool, so more than one Mux can be used.

Code is tested for hydro. But I think it can also be merged into newer versions. As I have no newer version running, I could not test. ==> Would be nice, if someone could do that.

If my request gets merged, I am happy to update the ROS WIKI page.
