### PR TITLE
roslaunch option to log to both: screen and logfile

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -472,7 +472,7 @@ class Node(object):
         if not len(self.type.strip()):
             raise ValueError("type must be non-empty")
         if not self.output in ['log', 'screen', 'both', None]:
-            raise ValueError("output must be one of 'log', 'screen'")
+            raise ValueError("output must be one of 'log', 'screen' or 'both'")
         if not self.cwd in ['ROS_HOME', 'node', None]:
             raise ValueError("cwd must be one of 'ROS_HOME', 'node'")
         

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -471,7 +471,7 @@ class Node(object):
             raise ValueError("package must be non-empty")
         if not len(self.type.strip()):
             raise ValueError("type must be non-empty")
-        if not self.output in ['log', 'screen', None]:
+        if not self.output in ['log', 'screen', 'both', None]:
             raise ValueError("output must be one of 'log', 'screen'")
         if not self.cwd in ['ROS_HOME', 'node', None]:
             raise ValueError("cwd must be one of 'ROS_HOME', 'node'")


### PR DESCRIPTION
Fix for issue #409

I added a new ouput value `both` which sends stdout and stderr to both screen and file. it uses subprocess.pipe and threading.

Also includes the following fix:

on http://wiki.ros.org/roslaunch/XML/node#Attributes it says that:

If 'log', the stdout/stderr output will be sent to a log file in $ROS_HOME/log, and stderr will continue to be sent to screen.

but stderr was only sent to screen, not to logfile. now stderr will be sent to both screen and log, while stdout only goes to log.
