### PR TITLE
roslaunch option to log to both: screen and logfile

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -434,7 +434,7 @@ class Node(object):
         :param remap_args: list of [(from, to)] remapping arguments, ``[(str, str)]``
         :param env_args: list of [(key, value)] of
         additional environment vars to set for node, ``[(str, str)]``
-        :param output: where to log output to, either Node, 'screen' or 'log', ``str``
+        :param output: where to log output to, 'screen', 'log' or both, ``str``
         :param cwd: current working directory of node, either 'node', 'ROS_HOME'. Default: ROS_HOME, ``str``
         :param launch_prefix: launch command/arguments to prepend to node executable arguments, ``str``
         :param required: node is required to stay running (launch fails if node dies), ``bool``
@@ -471,8 +471,8 @@ class Node(object):
             raise ValueError("package must be non-empty")
         if not len(self.type.strip()):
             raise ValueError("type must be non-empty")
-        if not self.output in ['log', 'screen', None]:
-            raise ValueError("output must be one of 'log', 'screen'")
+        if not self.output in ['log', 'screen', 'both', None]:
+            raise ValueError("output must be one of 'log', 'screen' or 'both'")
         if not self.cwd in ['ROS_HOME', 'node', None]:
             raise ValueError("cwd must be one of 'ROS_HOME', 'node'")
         

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -434,7 +434,7 @@ class Node(object):
         :param remap_args: list of [(from, to)] remapping arguments, ``[(str, str)]``
         :param env_args: list of [(key, value)] of
         additional environment vars to set for node, ``[(str, str)]``
-        :param output: where to log output to, 'screen', 'log' or both, ``str``
+        :param output: where to log output to, 'screen', 'log' or 'both', ``str``
         :param cwd: current working directory of node, either 'node', 'ROS_HOME'. Default: ROS_HOME, ``str``
         :param launch_prefix: launch command/arguments to prepend to node executable arguments, ``str``
         :param required: node is required to stay running (launch fails if node dies), ``bool``

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -90,7 +90,7 @@ def create_master_process(run_id, type_, ros_root, port):
     _logger.info("process[master]: launching with args [%s]"%args)
     log_output = False
     screen_output = True
-    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, screen_output, None)
+    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, None, screen_output=screen_output)
 
 def create_node_process(run_id, node, master_uri):
     """
@@ -139,7 +139,7 @@ def create_node_process(run_id, node, master_uri):
     log_output = node.output != 'screen'
     screen_output = node.output != 'log'
     _logger.debug('process[%s]: returning LocalProcess wrapper')
-    return LocalProcess(run_id, node.package, name, args, env, log_output, screen_output, respawn=node.respawn, required=node.required, cwd=node.cwd)
+    return LocalProcess(run_id, node.package, name, args, env, log_output, respawn=node.respawn, required=node.required, cwd=node.cwd, screen_output=screen_output)
 
 
 class LocalProcess(Process):
@@ -147,7 +147,7 @@ class LocalProcess(Process):
     Process launched on local machine
     """
     
-    def __init__(self, run_id, package, name, args, env, log_output, screen_output, respawn=False, required=False, cwd=None, is_node=True):
+    def __init__(self, run_id, package, name, args, env, log_output, respawn=False, required=False, cwd=None, is_node=True, screen_output=False):
         """
         @param run_id: unique run ID for this roslaunch. Used to
           generate log directory location. run_id may be None if this
@@ -163,14 +163,14 @@ class LocalProcess(Process):
         @type  env: {str : str}
         @param log_output: if True, log output streams of process
         @type  log_output: bool
-        @param screen_output: if True, show process output on screen
-        @type  screen_output: bool
         @param respawn: respawn process if it dies (default is False)
         @type  respawn: bool
         @param cwd: working directory of process, or None
         @type  cwd: str
         @param is_node: (optional) if True, process is ROS node and accepts ROS node command-line arguments. Default: True
         @type  is_node: False
+        @param screen_output: if True, show process output on screen
+        @type  screen_output: bool
         """    
         super(LocalProcess, self).__init__(package, name, args, env, respawn, required)
         self.run_id = run_id

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -559,8 +559,7 @@ def _tee(infile, *files):
                 if not f is None:
                     f.write(line)
                     f.flush()
-        if not f is None:
-            infile.close()
+        infile.close()
     t = threading.Thread(target=fanout, args=(infile,)+files)
     t.daemon = True
     t.start()


### PR DESCRIPTION
Replaces PR #413

For output = both
-> stdout will be written to screen and logfileout
-> stderr will be redirected to stdout, this will keep temporal order between out and err intact on screen and log file, but err messages will be written with out messages to logfileout.
-> no stderr log file

For output = log
-> stdout will be written to logfileout
-> stderr will be written to screen and logfileerr
-> temporal order not intact, but doesn't matter because files are separated and only err messages are shown on screen

For output = screen
-> stays as is, no multiplexing is needed
