### PR TITLE
test_roscpp: added unit test for calling zombie services, see #434

### DIFF
--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -329,13 +329,12 @@ void Connection::drop(DropReason reason)
     {
       dropped_ = true;
       did_drop = true;
-
-      drop_signal_(shared_from_this(), reason);
     }
   }
 
   if (did_drop)
   {
+    drop_signal_(shared_from_this(), reason);
     transport_->close();
   }
 }

--- a/clients/roscpp/src/libros/service_manager.cpp
+++ b/clients/roscpp/src/libros/service_manager.cpp
@@ -263,11 +263,15 @@ ServiceServerLinkPtr ServiceManager::createServiceServerLink(const std::string& 
   }
 
   TransportTCPPtr transport(new TransportTCP(&poll_manager_->getPollSet()));
+
+  // Make sure to initialize the connection *before* transport->connect()
+  // is called, otherwise we might miss a connect error (see #434).
+  ConnectionPtr connection(new Connection());
+  connection_manager_->addConnection(connection);
+  connection->initialize(transport, false, HeaderReceivedFunc());
+
   if (transport->connect(serv_host, serv_port))
   {
-    ConnectionPtr connection(new Connection());
-    connection_manager_->addConnection(connection);
-
     ServiceServerLinkPtr client(new ServiceServerLink(service, persistent, request_md5sum, response_md5sum, header_values));
 
     {
@@ -275,7 +279,6 @@ ServiceServerLinkPtr ServiceManager::createServiceServerLink(const std::string& 
       service_server_links_.push_back(client);
     }
 
-    connection->initialize(transport, false, HeaderReceivedFunc());
     client->initialize(connection);
 
     return client;

--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -98,6 +98,8 @@ add_rostest(launch/service_exception.xml)
 
 add_rostest(launch/service_call_unadv.xml)
 
+add_rostest(launch/service_call_zombie.xml)
+
 # Repeatedly call ros::init() and ros::fini()
 add_rostest(launch/multiple_init_fini.xml)
 

--- a/test/test_roscpp/test/launch/service_call_zombie.xml
+++ b/test/test_roscpp/test/launch/service_call_zombie.xml
@@ -1,0 +1,6 @@
+<launch>
+  <node name="dying_service" pkg="test_roscpp" type="test_roscpp-service_adv_zombie"/>
+  <test test-name="service_call_zombie" pkg="test_roscpp" type="test_roscpp-service_call_zombie" time-limit="30"/>
+</launch>
+
+

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -71,6 +71,9 @@ target_link_libraries(${PROJECT_NAME}-service_adv_unadv ${GTEST_LIBRARIES} ${cat
 add_executable(${PROJECT_NAME}-service_call EXCLUDE_FROM_ALL service_call.cpp)
 target_link_libraries(${PROJECT_NAME}-service_call ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 
+add_executable(${PROJECT_NAME}-service_call_zombie EXCLUDE_FROM_ALL service_call_zombie.cpp)
+target_link_libraries(${PROJECT_NAME}-service_call_zombie ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+
 add_executable(${PROJECT_NAME}-service_deadlock EXCLUDE_FROM_ALL service_deadlock.cpp)
 target_link_libraries(${PROJECT_NAME}-service_deadlock ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME}-service_deadlock std_srvs_gencpp)
@@ -81,7 +84,6 @@ target_link_libraries(${PROJECT_NAME}-service_call_repeatedly ${catkin_LIBRARIES
 add_executable(${PROJECT_NAME}-service_exception EXCLUDE_FROM_ALL service_exception.cpp)
 target_link_libraries(${PROJECT_NAME}-service_exception ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME}-service_exception std_srvs_gencpp)
-
 
 # Repeatedly call ros::init()
 add_executable(${PROJECT_NAME}-multiple_init_fini EXCLUDE_FROM_ALL multiple_init_fini.cpp)
@@ -101,6 +103,10 @@ target_link_libraries(${PROJECT_NAME}-service_adv_a ${GTEST_LIBRARIES} ${catkin_
 
 add_executable(${PROJECT_NAME}-service_wait_a_adv_b EXCLUDE_FROM_ALL service_wait_a_adv_b.cpp)
 target_link_libraries(${PROJECT_NAME}-service_wait_a_adv_b ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+
+# Zombie (node crashed) service
+add_executable(${PROJECT_NAME}-service_adv_zombie EXCLUDE_FROM_ALL service_adv_zombie.cpp)
+target_link_libraries(${PROJECT_NAME}-service_adv_zombie ${catkin_LIBRARIES})
 
 add_executable(${PROJECT_NAME}-service_call_expect_b EXCLUDE_FROM_ALL service_call_expect_b.cpp)
 target_link_libraries(${PROJECT_NAME}-service_call_expect_b ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
@@ -227,6 +233,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-service_adv
     ${PROJECT_NAME}-service_adv_unadv
     ${PROJECT_NAME}-service_call
+    ${PROJECT_NAME}-service_call_zombie
     ${PROJECT_NAME}-service_deadlock
     ${PROJECT_NAME}-service_exception
     ${PROJECT_NAME}-service_call_repeatedly
@@ -234,6 +241,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-inspection
     ${PROJECT_NAME}-service_adv_multiple
     ${PROJECT_NAME}-service_adv_a
+    ${PROJECT_NAME}-service_adv_zombie
     ${PROJECT_NAME}-service_wait_a_adv_b
     ${PROJECT_NAME}-service_call_expect_b
     ${PROJECT_NAME}-name_remapping
@@ -289,6 +297,7 @@ add_dependencies(${PROJECT_NAME}-sim_time_test ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_adv ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_adv_unadv ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_call ${PROJECT_NAME}_gencpp)
+add_dependencies(${PROJECT_NAME}-service_call_zombie ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_deadlock ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_exception ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_call_repeatedly ${PROJECT_NAME}_gencpp)
@@ -298,6 +307,7 @@ add_dependencies(${PROJECT_NAME}-service_adv_multiple ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_adv_a ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_wait_a_adv_b ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-service_call_expect_b ${PROJECT_NAME}_gencpp)
+add_dependencies(${PROJECT_NAME}-service_adv_zombie ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-name_remapping ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-name_remapping_with_ns ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-namespaces ${PROJECT_NAME}_gencpp)

--- a/test/test_roscpp/test/src/service_adv_zombie.cpp
+++ b/test/test_roscpp/test/src/service_adv_zombie.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2014 Max Schwarz <max.schwarz@uni-bonn.de>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Advertise a service, then crash horribly and leaving a "zombie service"
+// behind. Needed for service_call_zombie test.
+
+#include <ros/ros.h>
+#include <test_roscpp/TestStringString.h>
+
+#include <stdlib.h>
+
+bool srvCallback(test_roscpp::TestStringString::Request  &req,
+                 test_roscpp::TestStringString::Response &res)
+{
+  res.str = "B";
+  return true;
+}
+
+int main(int argc, char** argv)
+{
+	ros::init(argc, argv, "dying_node");
+
+	ros::NodeHandle nh;
+	ros::ServiceServer srv = nh.advertiseService("phantom_service", srvCallback);
+
+	// Allow for some time for registering on the master
+	for(int i = 0; i < 10; ++i)
+	{
+		ros::spinOnce();
+		usleep(100*1000);
+	}
+
+	// Exit immediately without calling any atexit hooks
+	_Exit(0);
+}

--- a/test/test_roscpp/test/src/service_call_zombie.cpp
+++ b/test/test_roscpp/test/src/service_call_zombie.cpp
@@ -47,7 +47,7 @@
 TEST(SrvCall, callPhantomService)
 {
   ros::NodeHandle nh;
-  for(int i = 0; i < 1000; ++i)
+  for(int i = 0; i < 200; ++i)
   {
     ros::ServiceClient handle = nh.serviceClient<test_roscpp::TestStringString>("phantom_service");
 

--- a/test/test_roscpp/test/src/service_call_zombie.cpp
+++ b/test/test_roscpp/test/src/service_call_zombie.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2014 Max Schwarz
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * Call a service which does not exist anymore.
+ */
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "ros/ros.h"
+#include "ros/time.h"
+#include "ros/service.h"
+#include "ros/connection.h"
+#include "ros/service_client.h"
+#include <test_roscpp/TestStringString.h>
+
+#include <stdio.h>
+
+TEST(SrvCall, callPhantomService)
+{
+  ros::NodeHandle nh;
+  for(int i = 0; i < 1000; ++i)
+  {
+    ros::ServiceClient handle = nh.serviceClient<test_roscpp::TestStringString>("phantom_service");
+
+    test_roscpp::TestStringString::Request req;
+    test_roscpp::TestStringString::Request res;
+    ASSERT_FALSE(handle.call(req, res));
+  }
+}
+
+int
+main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::init(argc, argv, "service_call");
+  ros::NodeHandle nh;
+
+  sleep(10);
+
+  int ret = RUN_ALL_TESTS();
+
+  return ret;
+}


### PR DESCRIPTION
Zombie services are left behind by crashed nodes. Currently roscpp can
lock up when you call such a zombie service. This adds a unit test (which currently fails).

See #434 for details.
