### PR TITLE
Added missing header needed for Android

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -45,6 +45,9 @@
   #include <sys/types.h>
   #include <sys/uio.h>
   #include <unistd.h>
+#elif defined(__ANDROID__)
+  // For readv() and writev() on ANDROID
+  #include <sys/uio.h>
 #endif
 
 namespace ros


### PR DESCRIPTION
This enables the use of readv() and writev() on Android.
