### PR TITLE
Respawn delay

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -426,7 +426,8 @@ class Node(object):
                  'filename']
 
     def __init__(self, package, node_type, name=None, namespace='/', \
-                 machine_name=None, args='', respawn=False, respawn_delay=0.0, \
+                 machine_name=None, args='', \
+                 respawn=False, respawn_delay=0.0, \
                  remap_args=None,env_args=None, output=None, cwd=None, \
                  launch_prefix=None, required=False, filename='<unknown>'):
         """
@@ -620,7 +621,8 @@ class Test(Node):
         to what it was initialized with, though the properties are the same
         """
         attrs = Node.xmlattrs(self)
-        attrs = [(a, v) for (a, v) in attrs if a not in ['respawn', 'respawn_delay']]
+        attrs = [(a, v) for (a, v) in attrs if a not in ['respawn', \
+                                                         'respawn_delay']]
         attrs.append(('test-name', self.test_name))
 
         if self.retry:

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -419,13 +419,14 @@ class Node(object):
     """
     __slots__ = ['package', 'type', 'name', 'namespace', \
                  'machine_name', 'machine', 'args', 'respawn', \
+                 'respawn_delay', \
                  'remap_args', 'env_args',\
                  'process_name', 'output', 'cwd',
                  'launch_prefix', 'required',
                  'filename']
 
     def __init__(self, package, node_type, name=None, namespace='/', \
-                 machine_name=None, args='', respawn=False, \
+                 machine_name=None, args='', respawn=False, respawn_delay=0.0, \
                  remap_args=None,env_args=None, output=None, cwd=None, \
                  launch_prefix=None, required=False, filename='<unknown>'):
         """
@@ -436,6 +437,7 @@ class Node(object):
         :param machine_name: name of machine to run node on, ``str``
         :param args: argument string to pass to node executable, ``str``
         :param respawn: if True, respawn node if it dies, ``bool``
+        :param respawn: if respawn is True, respawn node after delay, ``float``
         :param remap_args: list of [(from, to)] remapping arguments, ``[(str, str)]``
         :param env_args: list of [(key, value)] of
         additional environment vars to set for node, ``[(str, str)]``
@@ -454,6 +456,7 @@ class Node(object):
         self.namespace = rosgraph.names.make_global_ns(namespace or '/')
         self.machine_name = machine_name or None
         self.respawn = respawn
+        self.respawn_delay = respawn_delay
         self.args = args or ''
         self.remap_args = remap_args or []
         self.env_args = env_args or []        
@@ -514,6 +517,7 @@ class Node(object):
             ('output', self.output),
             ('cwd', cwd_str), 
             ('respawn', self.respawn), #not valid on <test>
+            ('respawn_delay', self.respawn_delay), #not valid on <test>
             ('name', name_str),
             ('launch-prefix', self.launch_prefix),
             ('required', self.required),
@@ -616,7 +620,7 @@ class Test(Node):
         to what it was initialized with, though the properties are the same
         """
         attrs = Node.xmlattrs(self)
-        attrs = [(a, v) for (a, v) in attrs if a != 'respawn']
+        attrs = [(a, v) for (a, v) in attrs if a not in ['respawn', 'respawn_delay']]
         attrs.append(('test-name', self.test_name))
 
         if self.retry:

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -518,7 +518,7 @@ class Node(object):
             ('output', self.output),
             ('cwd', cwd_str), 
             ('respawn', self.respawn), #not valid on <test>
-            ('respawn_delay', self.respawn_delay), #not valid on <test>
+            ('respawn_delay', self.respawn_delay), # not valid on <test>
             ('name', name_str),
             ('launch-prefix', self.launch_prefix),
             ('required', self.required),

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -135,7 +135,7 @@ def create_node_process(run_id, node, master_uri):
     # default for node.output not set is 'log'
     log_output = node.output != 'screen'
     _logger.debug('process[%s]: returning LocalProcess wrapper')
-    return LocalProcess(run_id, node.package, name, args, env, log_output, respawn=node.respawn, required=node.required, cwd=node.cwd)
+    return LocalProcess(run_id, node.package, name, args, env, log_output, respawn=node.respawn, respawn_delay=node.respawn_delay, required=node.required, cwd=node.cwd)
 
 
 class LocalProcess(Process):
@@ -143,7 +143,7 @@ class LocalProcess(Process):
     Process launched on local machine
     """
     
-    def __init__(self, run_id, package, name, args, env, log_output, respawn=False, required=False, cwd=None, is_node=True):
+    def __init__(self, run_id, package, name, args, env, log_output, respawn=False, respawn_delay=0.0, required=False, cwd=None, is_node=True):
         """
         @param run_id: unique run ID for this roslaunch. Used to
           generate log directory location. run_id may be None if this
@@ -161,12 +161,14 @@ class LocalProcess(Process):
         @type  log_output: bool
         @param respawn: respawn process if it dies (default is False)
         @type  respawn: bool
+        @param respawn_delay: respawn process after a delay
+        @type  respawn_delay: float
         @param cwd: working directory of process, or None
         @type  cwd: str
         @param is_node: (optional) if True, process is ROS node and accepts ROS node command-line arguments. Default: True
         @type  is_node: False
         """    
-        super(LocalProcess, self).__init__(package, name, args, env, respawn, required)
+        super(LocalProcess, self).__init__(package, name, args, env, respawn, respawn_delay, required)
         self.run_id = run_id
         self.popen = None
         self.log_output = log_output

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -178,7 +178,6 @@ class LocalProcess(Process):
         self.log_dir = None
         self.pid = -1
         self.is_node = is_node
-        self.time_of_death = None
 
     # NOTE: in the future, info() is going to have to be sufficient for relaunching a process
     def get_info(self):
@@ -300,7 +299,6 @@ executable permission. This is often caused by a bad launch-prefix."""%(msg, ' '
                     raise FatalProcessLaunch("unable to launch [%s]: %s"%(' '.join(self.args), msg))
                 
             self.started = True
-            self.time_of_death = None
             # Check that the process is either still running (poll returns
             # None) or that it completed successfully since when we
             # launched it above (poll returns the return code, 0).
@@ -335,18 +333,6 @@ executable permission. This is often caused by a bad launch-prefix."""%(msg, ' '
                 self.time_of_death = time.time()
             return False
         return True
-
-    def should_respawn(self):
-        """
-        @return: False if process should not respawn
-                 floating point seconds until respawn otherwise
-        """
-        if not self.respawn:
-            return False
-        if self.time_of_death is None:
-            if self.is_alive():
-                return False
-        return (self.time_of_death+self.respawn_delay) - time.time()
 
     def get_exit_description(self):
         """

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -135,7 +135,9 @@ def create_node_process(run_id, node, master_uri):
     # default for node.output not set is 'log'
     log_output = node.output != 'screen'
     _logger.debug('process[%s]: returning LocalProcess wrapper')
-    return LocalProcess(run_id, node.package, name, args, env, log_output, respawn=node.respawn, respawn_delay=node.respawn_delay, required=node.required, cwd=node.cwd)
+    return LocalProcess(run_id, node.package, name, args, env, log_output, \
+            respawn=node.respawn, respawn_delay=node.respawn_delay, \
+            required=node.required, cwd=node.cwd)
 
 
 class LocalProcess(Process):
@@ -143,7 +145,9 @@ class LocalProcess(Process):
     Process launched on local machine
     """
     
-    def __init__(self, run_id, package, name, args, env, log_output, respawn=False, respawn_delay=0.0, required=False, cwd=None, is_node=True):
+    def __init__(self, run_id, package, name, args, env, log_output,
+            respawn=False, respawn_delay=0.0, required=False, cwd=None,
+            is_node=True):
         """
         @param run_id: unique run ID for this roslaunch. Used to
           generate log directory location. run_id may be None if this
@@ -168,7 +172,8 @@ class LocalProcess(Process):
         @param is_node: (optional) if True, process is ROS node and accepts ROS node command-line arguments. Default: True
         @type  is_node: False
         """    
-        super(LocalProcess, self).__init__(package, name, args, env, respawn, respawn_delay, required)
+        super(LocalProcess, self).__init__(package, name, args, env,
+                respawn, respawn_delay, required)
         self.run_id = run_id
         self.popen = None
         self.log_output = log_output

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -246,7 +246,7 @@ class Process(object):
         if self.time_of_death is None:
             if self.is_alive():
                 return False
-        return (self.time_of_death+self.respawn_delay) - time.time()
+        return (self.time_of_death + self.respawn_delay) - time.time()
 
     def stop(self, errors=None):
         """
@@ -560,7 +560,7 @@ class ProcessMonitor(Thread):
                     if not p.is_alive():
                         logger.debug("Process[%s] has died, respawn=%s, required=%s, exit_code=%s",
                                 p.name,
-                                "True(%f)"%p.respawn_delay if p.respawn else p.respawn,
+                                "True(%f)" % p.respawn_delay if p.respawn else p.respawn,
                                 p.required, p.exit_code)
                         exit_code_str = p.get_exit_description()
                         if p.required:
@@ -609,8 +609,8 @@ class ProcessMonitor(Thread):
                 try:
                     if self.is_shutdown:
                         break
-                    if r.should_respawn()<=0.0:
-                        printlog("[%s] restarting process"%r.name)
+                    if r.should_respawn() <= 0.0:
+                        printlog("[%s] restarting process" % r.name)
                         # stop process, don't accumulate errors
                         r.stop([])
                         r.start()

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -587,7 +587,7 @@ class ProcessMonitor(Thread):
             for d in dead:
                 try:
                     if d.should_respawn():
-                        respawn.append( d )
+                        respawn.append(d)
                     else:
                         self.unregister(d)
                         # stop process, don't accumulate errors
@@ -616,7 +616,7 @@ class ProcessMonitor(Thread):
                         r.start()
                     else:
                         # not ready yet, keep it around
-                        _respawn.append( r )
+                        _respawn.append(r)
                 except:
                     traceback.print_exc()
                     logger.error("Restart failed %s",traceback.format_exc())

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -330,7 +330,9 @@ class XmlLoader(loader.Loader):
 
         return test_name, time_limit, retry
         
-    NODE_ATTRS = ['pkg', 'type', 'machine', 'name', 'args', 'output', 'respawn', 'respawn_delay', 'cwd', NS, CLEAR_PARAMS, 'launch-prefix', 'required']
+    NODE_ATTRS = ['pkg', 'type', 'machine', 'name', 'args', 'output', \
+            'respawn', 'respawn_delay', 'cwd', NS, CLEAR_PARAMS, \
+            'launch-prefix', 'required']
     TEST_ATTRS = NODE_ATTRS + ['test-name','time-limit', 'retry']
     
     @ifunless
@@ -371,9 +373,10 @@ class XmlLoader(loader.Loader):
             pkg, node_type = self.reqd_attrs(tag, context, ('pkg', 'type'))
             
             # optional attributes
-            machine, args, output, respawn, respawn_delay, cwd, launch_prefix, required = \
-                     self.opt_attrs(tag, context, ('machine', 'args', 'output',
-                         'respawn', 'respawn_delay', 'cwd', 'launch-prefix', 'required'))
+            machine, args, output, respawn, respawn_delay, cwd, launch_prefix, \
+                    required = self.opt_attrs(tag, context, ('machine', 'args',
+                        'output', 'respawn', 'respawn_delay', 'cwd',
+                        'launch-prefix', 'required'))
             if tag.hasAttribute('machine') and not len(machine.strip()):
                 raise XmlParseException("<node> 'machine' must be non-empty: [%s]"%machine)
             if not machine and default_machine:
@@ -420,7 +423,8 @@ class XmlLoader(loader.Loader):
                     
             if not is_test:
                 return Node(pkg, node_type, name=name, namespace=child_ns.ns, machine_name=machine, 
-                            args=args, respawn=respawn, respawn_delay=respawn_delay,
+                            args=args, respawn=respawn,
+                            respawn_delay=respawn_delay,
                             remap_args=remap_context.remap_args(), env_args=env_context.env_args,
                             output=output, cwd=cwd, launch_prefix=launch_prefix,
                             required=required, filename=context.filename)

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -383,7 +383,7 @@ class XmlLoader(loader.Loader):
                 machine = default_machine.name
             # validate respawn, required
             required, respawn = [_bool_attr(*rr) for rr in ((required, False, 'required'),\
-                                                            (respawn, False, 'respawn'))]
+                                                                (respawn, False, 'respawn'))]
             respawn_delay = _float_attr(respawn_delay, 0.0, 'respawn_delay')
 
             # each node gets its own copy of <remap> arguments, which

--- a/tools/roslaunch/test/unit/test_roslaunch_core.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_core.py
@@ -83,8 +83,11 @@ def test_Node():
     assert n.package == 'package'
     assert n.type == 'node_type'
     assert n.xmltype() == 'node'
-    assert n.xmlattrs() == [('pkg', 'package'), ('type', 'node_type'),
-            ('machine', None), ('ns', '/'), ('args', ''), ('output', None), ('cwd', None), ('respawn', False), ('respawn_delay', 0.0), ('name', None), ('launch-prefix', None), ('required', False)], n.xmlattrs()
+    assert n.xmlattrs() == ([('pkg', 'package'), ('type', 'node_type'),
+            ('machine', None), ('ns', '/'), ('args', ''), ('output', None),
+            ('cwd', None), ('respawn', False), ('respawn_delay', 0.0),
+            ('name', None), ('launch-prefix', None), ('required', False)],
+            n.xmlattrs())
     assert n.output == None
 
     #tripwire for now

--- a/tools/roslaunch/test/unit/test_roslaunch_core.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_core.py
@@ -83,11 +83,11 @@ def test_Node():
     assert n.package == 'package'
     assert n.type == 'node_type'
     assert n.xmltype() == 'node'
-    assert n.xmlattrs() == ([('pkg', 'package'), ('type', 'node_type'),
+    assert n.xmlattrs() == [('pkg', 'package'), ('type', 'node_type'),
             ('machine', None), ('ns', '/'), ('args', ''), ('output', None),
             ('cwd', None), ('respawn', False), ('respawn_delay', 0.0),
-            ('name', None), ('launch-prefix', None), ('required', False)],
-            n.xmlattrs())
+            ('name', None), ('launch-prefix', None), ('required', False)], \
+            n.xmlattrs()
     assert n.output == None
 
     #tripwire for now

--- a/tools/roslaunch/test/unit/test_roslaunch_core.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_core.py
@@ -83,7 +83,8 @@ def test_Node():
     assert n.package == 'package'
     assert n.type == 'node_type'
     assert n.xmltype() == 'node'
-    assert n.xmlattrs() == [('pkg', 'package'), ('type', 'node_type'), ('machine', None), ('ns', '/'), ('args', ''), ('output', None), ('cwd', None), ('respawn', False), ('name', None), ('launch-prefix', None), ('required', False)], n.xmlattrs()
+    assert n.xmlattrs() == [('pkg', 'package'), ('type', 'node_type'),
+            ('machine', None), ('ns', '/'), ('args', ''), ('output', None), ('cwd', None), ('respawn', False), ('respawn_delay', 0.0), ('name', None), ('launch-prefix', None), ('required', False)], n.xmlattrs()
     assert n.output == None
 
     #tripwire for now

--- a/tools/roslaunch/test/unit/test_roslaunch_pmon.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_pmon.py
@@ -465,8 +465,8 @@ class TestRoslaunchPmon(unittest.TestCase):
         self.failIf(p3.spawn_count < 2, "process did not respawn")
 
         self.failIf(p4.respawn_interval < p4.respawn_delay,
-                "Respawn delay not respected: %s %s"%(p4.respawn_interval,
-                                                      p4.respawn_delay))
+                "Respawn delay not respected: %s %s" % (p4.respawn_interval,
+                                                        p4.respawn_delay))
 
         # retest assumptions
         self.failIf(pmon.procs)

--- a/tools/roslaunch/test/unit/test_roslaunch_pmon.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_pmon.py
@@ -116,19 +116,21 @@ class ProcessMock(roslaunch.pmon.Process):
         self.stopped = False
     def stop(self, errors):
         self.stopped = True
-        
+
 class RespawnOnceProcessMock(ProcessMock):
     def __init__(self, package, name, args, env, respawn=False):
         super(ProcessMock, self).__init__(package, name, args, env, respawn)
         self.spawn_count = 0
 
     def is_alive(self):
+        self.time_of_death = time.time()
         return False
     
     def start(self):
         self.spawn_count += 1
         if self.spawn_count > 1:
             self.respawn = False
+        self.time_of_death = None
 
 ## Test roslaunch.server
 class TestRoslaunchPmon(unittest.TestCase):

--- a/tools/roslaunch/test/unit/test_roslaunch_pmon.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_pmon.py
@@ -137,12 +137,13 @@ class TestRoslaunchPmon(unittest.TestCase):
         self.pmon = roslaunch.pmon.ProcessMonitor()
 
     ## test all apis of Process instance. part coverage/sanity test
-    def _test_Process(self, p, package, name, args, env, respawn):
+    def _test_Process(self, p, package, name, args, env, respawn, respawn_delay):
         self.assertEquals(package, p.package)
         self.assertEquals(name, p.name)
         self.assertEquals(args, p.args)        
         self.assertEquals(env, p.env)  
         self.assertEquals(respawn, p.respawn)
+        self.assertEquals(respawn_delay, p.respawn_delay)
         self.assertEquals(0, p.spawn_count)        
         self.assertEquals(None, p.exit_code)
         self.assert_(p.get_exit_description())
@@ -154,6 +155,7 @@ class TestRoslaunchPmon(unittest.TestCase):
         self.assertEquals(args, info['args'])        
         self.assertEquals(env, info['env'])  
         self.assertEquals(respawn, info['respawn'])
+        self.assertEquals(respawn_delay, info['respawn_delay'])
         self.assertEquals(0, info['spawn_count'])        
         self.failIf('exit_code' in info)
 
@@ -184,14 +186,16 @@ class TestRoslaunchPmon(unittest.TestCase):
         args = [time.time(), time.time(), time.time()]
         env = { 'key': time.time(), 'key2': time.time() } 
 
-        p = Process(package, name, args, env)
-        self._test_Process(p, package, name, args, env, False)
-        p = Process(package, name, args, env, True)
-        self._test_Process(p, package, name, args, env, True) 
-        p = Process(package, name, args, env, False)
-        self._test_Process(p, package, name, args, env, False) 
+        p = Process(package, name, args, env, 0.0)
+        self._test_Process(p, package, name, args, env, False, 0.0)
+        p = Process(package, name, args, env, True, 0.0)
+        self._test_Process(p, package, name, args, env, True, 0.0)
+        p = Process(package, name, args, env, False, 0.0)
+        self._test_Process(p, package, name, args, env, False, 0.0)
+        p = Process(package, name, args, env, True, 1.0)
+        self._test_Process(p, package, name, args, env, True, 1.0)
         
-    def _test_DeadProcess(self, p0, package, name, args, env, respawn):
+    def _test_DeadProcess(self, p0, package, name, args, env, respawn, respawn_delay):
         from roslaunch.pmon import DeadProcess
         p0.exit_code = -1
         dp = DeadProcess(p0)
@@ -200,6 +204,7 @@ class TestRoslaunchPmon(unittest.TestCase):
         self.assertEquals(args, dp.args)        
         self.assertEquals(env, dp.env)  
         self.assertEquals(respawn, dp.respawn)
+        self.assertEquals(respawn_delay, dp.respawn_delay)
         self.assertEquals(0, dp.spawn_count)        
         self.assertEquals(-1, dp.exit_code)
         self.failIf(dp.is_alive())
@@ -211,6 +216,7 @@ class TestRoslaunchPmon(unittest.TestCase):
         self.assertEquals(info0['args'], info['args'])        
         self.assertEquals(info0['env'], info['env'])  
         self.assertEquals(info0['respawn'], info['respawn'])
+        self.assertEquals(info0['respawn_delay'], info['respawn_delay'])
         self.assertEquals(0, info['spawn_count'])        
 
         try:
@@ -245,12 +251,14 @@ class TestRoslaunchPmon(unittest.TestCase):
         args = [time.time(), time.time(), time.time()]
         env = { 'key': time.time(), 'key2': time.time() } 
 
-        p = Process(package, name, args, env)
-        self._test_DeadProcess(p, package, name, args, env, False)
-        p = Process(package, name, args, env, True)
-        self._test_DeadProcess(p, package, name, args, env, True) 
-        p = Process(package, name, args, env, False)
-        self._test_DeadProcess(p, package, name, args, env, False) 
+        p = Process(package, name, args, env, 0.0)
+        self._test_DeadProcess(p, package, name, args, env, False, 0.0)
+        p = Process(package, name, args, env, True, 0.0)
+        self._test_DeadProcess(p, package, name, args, env, True, 0.0)
+        p = Process(package, name, args, env, False, 0.0)
+        self._test_DeadProcess(p, package, name, args, env, False, 0.0)
+        p = Process(package, name, args, env, True, 1.0)
+        self._test_DeadProcess(p, package, name, args, env, True, 1.0)
 
     def test_start_shutdown_process_monitor(self):
         def failer():

--- a/tools/roslaunch/test/unit/test_roslaunch_pmon.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_pmon.py
@@ -118,7 +118,7 @@ class ProcessMock(roslaunch.pmon.Process):
         self.stopped = True
 
 class RespawnOnceProcessMock(ProcessMock):
-    def __init__(self, package, name, args, env, respawn=False):
+    def __init__(self, package, name, args, env, respawn=True):
         super(ProcessMock, self).__init__(package, name, args, env, respawn)
         self.spawn_count = 0
 
@@ -436,6 +436,8 @@ class TestRoslaunchPmon(unittest.TestCase):
         pmon.run()
         
         self.failIf(marker.marked, "pmon had to be externally killed")        
+
+        self.failIf(p3.spawn_count < 2, "process did not respawn")
 
         # retest assumptions
         self.failIf(pmon.procs)

--- a/tools/roslaunch/test/unit/test_roslaunch_pmon.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_pmon.py
@@ -133,8 +133,10 @@ class RespawnOnceProcessMock(ProcessMock):
         self.time_of_death = None
 
 class RespawnOnceWithDelayProcessMock(ProcessMock):
-    def __init__(self, package, name, args, env, respawn=True, respawn_delay=1.0):
-        super(ProcessMock, self).__init__(package, name, args, env, respawn, respawn_delay=respawn_delay)
+    def __init__(self, package, name, args, env, respawn=True,
+            respawn_delay=1.0):
+        super(ProcessMock, self).__init__(package, name, args, env, respawn,
+                respawn_delay=respawn_delay)
         self.spawn_count = 0
         self.respawn_interval = None
 
@@ -215,7 +217,8 @@ class TestRoslaunchPmon(unittest.TestCase):
         p = Process(package, name, args, env, True, 1.0)
         self._test_Process(p, package, name, args, env, True, 1.0)
         
-    def _test_DeadProcess(self, p0, package, name, args, env, respawn, respawn_delay):
+    def _test_DeadProcess(self, p0, package, name, args, env, respawn,
+            respawn_delay):
         from roslaunch.pmon import DeadProcess
         p0.exit_code = -1
         dp = DeadProcess(p0)
@@ -461,7 +464,9 @@ class TestRoslaunchPmon(unittest.TestCase):
 
         self.failIf(p3.spawn_count < 2, "process did not respawn")
 
-        self.failIf(p4.respawn_interval < p4.respawn_delay, "Respawn delay not respected: %s %s"%(p4.respawn_interval, p4.respawn_delay))
+        self.failIf(p4.respawn_interval < p4.respawn_delay,
+                "Respawn delay not respected: %s %s"%(p4.respawn_interval,
+                                                      p4.respawn_delay))
 
         # retest assumptions
         self.failIf(pmon.procs)

--- a/tools/roslaunch/test/unit/test_roslaunch_remote.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_remote.py
@@ -44,55 +44,57 @@ class TestRoslaunchRemote(unittest.TestCase):
         # these are fairly brittle tests, but need to make sure there aren't regressions here
         Node = roslaunch.core.Node
         n = Node('pkg1', 'type1')
-        self.assertEquals('<node pkg="pkg1" type="type1" ns="/" args="" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg1" type="type1" ns="/" args="" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
         n = Node('pkg2', 'type2', namespace="/ns2/")
-        self.assertEquals('<node pkg="pkg2" type="type2" ns="/ns2/" args="" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg2" type="type2" ns="/ns2/" args="" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
         # machine_name should be a noop for remote xml
         n = Node('pkg3', 'type3', namespace="/ns3/", machine_name="machine3")
-        self.assertEquals('<node pkg="pkg3" type="type3" ns="/ns3/" args="" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg3" type="type3" ns="/ns3/" args="" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
 
         # test args
         n = Node('pkg4', 'type4', args="arg4a arg4b")
-        self.assertEquals('<node pkg="pkg4" type="type4" ns="/" args="arg4a arg4b" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg4" type="type4" ns="/" args="arg4a arg4b" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
         # test respawn
         n = Node('pkg5', 'type5', respawn=True)
-        self.assertEquals('<node pkg="pkg5" type="type5" ns="/" args="" respawn="True" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg5" type="type5" ns="/" args="" respawn="True" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
+        n = Node('pkg5', 'type5', respawn=True, respawn_delay=1.0)
+        self.assertEquals('<node pkg="pkg5" type="type5" ns="/" args="" respawn="True" respawn_delay="1.0" required="False">\n</node>', n.to_remote_xml())
         n = Node('pkg6', 'type6', respawn=False)
-        self.assertEquals('<node pkg="pkg6" type="type6" ns="/" args="" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg6" type="type6" ns="/" args="" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
         # test remap_args
         n = Node('pkg6', 'type6', remap_args=[('from6a', 'to6a'), ('from6b', 'to6b')])
-        self.assertEquals("""<node pkg="pkg6" type="type6" ns="/" args="" respawn="False" required="False">
+        self.assertEquals("""<node pkg="pkg6" type="type6" ns="/" args="" respawn="False" respawn_delay="0.0" required="False">
   <remap from="from6a" to="to6a" />
   <remap from="from6b" to="to6b" />
 </node>""", n.to_remote_xml())
         # test env args
         n = Node('pkg7', 'type7', env_args=[('key7a', 'val7a'), ('key7b', 'val7b')])
-        self.assertEquals("""<node pkg="pkg7" type="type7" ns="/" args="" respawn="False" required="False">
+        self.assertEquals("""<node pkg="pkg7" type="type7" ns="/" args="" respawn="False" respawn_delay="0.0" required="False">
   <env name="key7a" value="val7a" />
   <env name="key7b" value="val7b" />
 </node>""", n.to_remote_xml())
         # test cwd        
         n = Node('pkg8', 'type8', cwd='ROS_HOME')
-        self.assertEquals('<node pkg="pkg8" type="type8" ns="/" args="" cwd="ROS_HOME" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg8" type="type8" ns="/" args="" cwd="ROS_HOME" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
         n = Node('pkg9', 'type9', cwd='node')
-        self.assertEquals('<node pkg="pkg9" type="type9" ns="/" args="" cwd="node" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg9" type="type9" ns="/" args="" cwd="node" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
         # test output
         n = Node('pkg10', 'type10', output='screen')
-        self.assertEquals('<node pkg="pkg10" type="type10" ns="/" args="" output="screen" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg10" type="type10" ns="/" args="" output="screen" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
         n = Node('pkg11', 'type11', output='log')
-        self.assertEquals('<node pkg="pkg11" type="type11" ns="/" args="" output="log" respawn="False" required="False">\n</node>', n.to_remote_xml())
+        self.assertEquals('<node pkg="pkg11" type="type11" ns="/" args="" output="log" respawn="False" respawn_delay="0.0" required="False">\n</node>', n.to_remote_xml())
 
         # test launch-prefix
         n = Node('pkg12', 'type12', launch_prefix='xterm -e')
-        self.assertEquals('<node pkg="pkg12" type="type12" ns="/" args="" respawn="False" launch-prefix="xterm -e" required="False">\n</node>', n.to_remote_xml()) 
+        self.assertEquals('<node pkg="pkg12" type="type12" ns="/" args="" respawn="False" respawn_delay="0.0" launch-prefix="xterm -e" required="False">\n</node>', n.to_remote_xml())
 
         # test required
         n = Node('pkg13', 'type13', required=True)
-        self.assertEquals('<node pkg="pkg13" type="type13" ns="/" args="" respawn="False" required="True">\n</node>', n.to_remote_xml())        
+        self.assertEquals('<node pkg="pkg13" type="type13" ns="/" args="" respawn="False" respawn_delay="0.0" required="True">\n</node>', n.to_remote_xml())
         
         #test everything
         n = Node('pkg20', 'type20', namespace="/ns20/", machine_name="foo", remap_args=[('from20a', 'to20a'), ('from20b', 'to20b')], env_args=[('key20a', 'val20a'), ('key20b', 'val20b')], output="screen", cwd="ROS_HOME", respawn=True, args="arg20a arg20b", launch_prefix="nice", required=False)
-        self.assertEquals("""<node pkg="pkg20" type="type20" ns="/ns20/" args="arg20a arg20b" output="screen" cwd="ROS_HOME" respawn="True" launch-prefix="nice" required="False">
+        self.assertEquals("""<node pkg="pkg20" type="type20" ns="/ns20/" args="arg20a arg20b" output="screen" cwd="ROS_HOME" respawn="True" respawn_delay="0.0" launch-prefix="nice" required="False">
   <remap from="from20a" to="to20a" />
   <remap from="from20b" to="to20b" />
   <env name="key20a" value="val20a" />


### PR DESCRIPTION
Sometimes, especially for hardware drivers, it helps to pause before restarting a failed node.

This branch adds a configurable delay to the roslaunch respawn feature. If the delay is left unspecified, it defaults to 0, giving the same behavior as before. The value is configured in the node tag:
<node
     name="myname"
     pkg="flaky_hardware"
     type="unreliable_node"
    respawn="True"
    respawn_delay="5.0"
/>
respawn_delay has units seconds.
