### PR TITLE
roscpp: handle queue lengths of multiple publishers on the same topic better

### DIFF
--- a/clients/roscpp/include/ros/forwards.h
+++ b/clients/roscpp/include/ros/forwards.h
@@ -103,10 +103,12 @@ struct SubscriberCallbacks
   SubscriberCallbacks(const SubscriberStatusCallback& connect = SubscriberStatusCallback(),
                       const SubscriberStatusCallback& disconnect = SubscriberStatusCallback(),
                       const VoidConstPtr& tracked_object = VoidConstPtr(),
-                      CallbackQueueInterface* callback_queue = 0)
+                      CallbackQueueInterface* callback_queue = 0,
+                      unsigned int queue_size = 0)
   : connect_(connect)
   , disconnect_(disconnect)
   , callback_queue_(callback_queue)
+  , queue_size_(queue_size)
   {
     has_tracked_object_ = false;
     if (tracked_object)
@@ -121,6 +123,9 @@ struct SubscriberCallbacks
   bool has_tracked_object_;
   VoidConstWPtr tracked_object_;
   CallbackQueueInterface* callback_queue_;
+
+  // Keep track of requested queue size per callback
+  uint32_t queue_size_;
 };
 typedef boost::shared_ptr<SubscriberCallbacks> SubscriberCallbacksPtr;
 

--- a/clients/roscpp/include/ros/publication.h
+++ b/clients/roscpp/include/ros/publication.h
@@ -73,7 +73,7 @@ public:
   /**
    * \brief returns the max queue size of this publication
    */
-  inline size_t getMaxQueue() { return max_queue_; }
+  size_t getMaxQueue();
   /**
    * \brief Get the accumulated stats for this publication
    */
@@ -168,6 +168,8 @@ private:
 
   typedef std::vector<SubscriberCallbacksPtr> V_Callback;
   V_Callback callbacks_;
+
+  // Also protects max_queue_, since it depends on the registered callbacks
   boost::mutex callbacks_mutex_;
 
   V_SubscriberLink subscriber_links_;

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -296,7 +296,7 @@ Publisher NodeHandle::advertise(AdvertiseOptions& ops)
   }
 
   SubscriberCallbacksPtr callbacks(new SubscriberCallbacks(ops.connect_cb, ops.disconnect_cb, 
-							   ops.tracked_object, ops.callback_queue));
+							   ops.tracked_object, ops.callback_queue, ops.queue_size));
 
   if (TopicManager::instance()->advertise(ops, callbacks))
   {

--- a/clients/roscpp/src/libros/publication.cpp
+++ b/clients/roscpp/src/libros/publication.cpp
@@ -103,6 +103,7 @@ void Publication::addCallbacks(const SubscriberCallbacksPtr& callbacks)
   boost::mutex::scoped_lock lock(callbacks_mutex_);
 
   callbacks_.push_back(callbacks);
+  max_queue_ += callbacks->queue_size_;
 
   // Add connect callbacks for all current subscriptions if this publisher wants them
   if (callbacks->connect_ && callbacks->callback_queue_)
@@ -122,6 +123,7 @@ void Publication::addCallbacks(const SubscriberCallbacksPtr& callbacks)
 void Publication::removeCallbacks(const SubscriberCallbacksPtr& callbacks)
 {
   boost::mutex::scoped_lock lock(callbacks_mutex_);
+  max_queue_ -= callbacks->queue_size_;
 
   V_Callback::iterator it = std::find(callbacks_.begin(), callbacks_.end(), callbacks);
   if (it != callbacks_.end())
@@ -356,6 +358,12 @@ size_t Publication::getNumCallbacks()
 {
   boost::mutex::scoped_lock lock(callbacks_mutex_);
   return callbacks_.size();
+}
+
+size_t Publication::getMaxQueue()
+{
+  boost::mutex::scoped_lock lock(callbacks_mutex_);
+  return max_queue_;
 }
 
 uint32_t Publication::incrementSequence()

--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -193,11 +193,15 @@ void TransportSubscriberLink::enqueueMessage(const SerializedMessage& m, bool se
       if (!queue_full_)
       {
         ROS_DEBUG("Outgoing queue full for topic [%s].  "
-               "Discarding oldest message\n",
-               topic_.c_str());
+               "Discarding oldest %d message(s)\n",
+               topic_.c_str(), (int)outbox_.size() - max_queue + 1);
       }
 
-      outbox_.pop(); // toss out the oldest thing in the queue to make room for us
+      while((int)outbox_.size() >= max_queue)
+      {
+        // toss out the oldest thing in the queue to make room for us
+        outbox_.pop();
+      }
       queue_full_ = true;
     }
     else

--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -66,6 +66,7 @@ add_rostest(launch/pubsub_once.xml)
 # Publish a bunch of messages back to back
 add_rostest(launch/pubsub_n_fast.xml)
 add_rostest(launch/pubsub_n_fast_udp.xml)
+add_rostest(launch/pubsub_multiple.xml)
 
 # Publish a bunch of empty messages
 add_rostest(launch/pubsub_empty.xml)

--- a/test/test_roscpp/test/launch/pubsub_multiple.xml
+++ b/test/test_roscpp/test/launch/pubsub_multiple.xml
@@ -1,0 +1,6 @@
+<launch>
+  <node pkg="test_roscpp" type="test_roscpp-publish_multiple" name="publish_multiple" args="1000 1 1"/>
+  <test test-name="pubsub_n_fast" pkg="test_roscpp"
+  type="test_roscpp-subscribe_n_fast" args="tcp 1000 10.0"/>
+</launch>
+

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -50,6 +50,9 @@ target_link_libraries(${PROJECT_NAME}-subscribe_unsubscribe_repeatedly ${catkin_
 add_executable(${PROJECT_NAME}-publish_constantly EXCLUDE_FROM_ALL publish_constantly.cpp)
 target_link_libraries(${PROJECT_NAME}-publish_constantly ${catkin_LIBRARIES})
 
+add_executable(${PROJECT_NAME}-publish_multiple EXCLUDE_FROM_ALL publish_multiple.cpp)
+target_link_libraries(${PROJECT_NAME}-publish_multiple ${catkin_LIBRARIES})
+
 add_executable(${PROJECT_NAME}-param_update_test EXCLUDE_FROM_ALL param_update_test.cpp)
 target_link_libraries(${PROJECT_NAME}-param_update_test ${catkin_LIBRARIES})
 
@@ -227,6 +230,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-publish_unadvertise
     ${PROJECT_NAME}-subscribe_unsubscribe_repeatedly
     ${PROJECT_NAME}-publish_constantly
+    ${PROJECT_NAME}-publish_multiple
     ${PROJECT_NAME}-param_update_test
     ${PROJECT_NAME}-real_time_test
     ${PROJECT_NAME}-sim_time_test
@@ -291,6 +295,7 @@ add_dependencies(${PROJECT_NAME}-subscribe_unsubscribe ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-publish_unadvertise ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-subscribe_unsubscribe_repeatedly ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-publish_constantly ${PROJECT_NAME}_gencpp)
+add_dependencies(${PROJECT_NAME}-publish_multiple ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-param_update_test ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-real_time_test ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-sim_time_test ${PROJECT_NAME}_gencpp)

--- a/test/test_roscpp/test/src/publish_multiple.cpp
+++ b/test/test_roscpp/test/src/publish_multiple.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Author: Brian Gerkey, Max Schwarz <max.schwarz@uni-bonn.de> */
+
+/*
+ * Publish a message from multiple publishers on the same topic
+ */
+
+#include <string>
+#include <cstdio>
+#include <time.h>
+#include <stdlib.h>
+
+#include "ros/ros.h"
+#include <test_roscpp/TestArray.h>
+
+void connectCallback(const ros::SingleSubscriberPublisher &pub, int msg_count, int min_size, int max_size)
+{
+  test_roscpp::TestArray msg;
+  for(int i = 0; i < msg_count; i++)
+  {
+    msg.counter = i;
+    int j = min_size + (int) ((max_size - min_size) * (rand() / (RAND_MAX + 1.0)));
+    msg.float_arr.resize(j);
+    ROS_INFO("published message %d (%d bytes)\n",
+             msg.counter, ros::serialization::Serializer<test_roscpp::TestArray>::serializedLength(msg));
+    pub.publish(msg);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "publish_multiple");
+  ros::NodeHandle nh;
+
+  if(argc != 4)
+  {
+    fprintf(stderr, "Usage: publish_multiple <count> <min_size> <max_size>\n");
+    return 1;
+  }
+  int count = atoi(argv[1]);
+  int min_size = atoi(argv[2]);
+  int max_size = atoi(argv[3]);
+
+  ros::Publisher pub1 = nh.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", 1);
+  ros::Publisher pub2 = nh.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", count, boost::bind(&connectCallback, _1, count, min_size, max_size));
+
+  ros::spin();
+
+  return 0;
+}


### PR DESCRIPTION
Currently, all `ros::Publisher` on a single topic share a message queue with the length of the queue determined by the first publisher. On advertising, `TopicManager` tries to find a previous `Publication` for the advertised topic and only adds the callbacks to it, discarding any other options the caller provided (see [here](https://github.com/ros/ros_comm/blob/c4acde3171368313ad72c559f1d8f0035217f23a/clients/roscpp/src/libros/topic_manager.cpp#L355)).

There are often cases in which this behavior does not make sense. Each "advertiser" of the topic probably provides a reasonable queue length for **his** messages. So the internal queue length of `Publication` should probably be the **sum** of all requested queue lengths.

This PR currently contains a unit test for that case (which currently fails). If you agree that the current behavior is not desired, I will try to bring in a patch for discussion.
