### PR TITLE
implement ROS_IP=localhost behavior for roscpp, and for outbound rospy connections

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(roscpp
   src/libros/node_handle.cpp
   src/libros/connection_manager.cpp
   src/libros/file_log.cpp
+  src/libros/transport/transport.cpp
   src/libros/transport/transport_udp.cpp
   src/libros/transport/transport_tcp.cpp
   src/libros/subscriber_link.cpp

--- a/clients/roscpp/include/ros/transport/transport.h
+++ b/clients/roscpp/include/ros/transport/transport.h
@@ -141,6 +141,11 @@ protected:
    */
   bool isHostAllowed(const std::string &host);
 
+  /**
+   * \brief returns true if this transport is only allowed to talk to localhost
+   */
+  bool isOnlyLocalhostAllowed() { return only_localhost_allowed_; }
+
 private:
   bool only_localhost_allowed_;
   std::vector<std::string> allowed_hosts_;

--- a/clients/roscpp/include/ros/transport/transport.h
+++ b/clients/roscpp/include/ros/transport/transport.h
@@ -39,6 +39,7 @@
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <vector>
 
 namespace ros
 {
@@ -54,7 +55,7 @@ class Header;
 class Transport : public boost::enable_shared_from_this<Transport>
 {
 public:
-  Transport() {}
+  Transport();
   virtual ~Transport() {}
 
   /**
@@ -134,8 +135,18 @@ protected:
   Callback disconnect_cb_;
   Callback read_cb_;
   Callback write_cb_;
+
+  /**
+   * \brief returns true if the transport is allowed to connect to the host passed to it.
+   */
+  bool isHostAllowed(const std::string &host);
+
+private:
+  bool only_localhost_allowed_;
+  std::vector<std::string> allowed_hosts_;
 };
 
 }
 
 #endif // ROSCPP_TRANSPORT_H
+

--- a/clients/roscpp/include/ros/transport/transport.h
+++ b/clients/roscpp/include/ros/transport/transport.h
@@ -139,12 +139,12 @@ protected:
   /**
    * \brief returns true if the transport is allowed to connect to the host passed to it.
    */
-  bool isHostAllowed(const std::string &host);
+  bool isHostAllowed(const std::string &host) const;
 
   /**
    * \brief returns true if this transport is only allowed to talk to localhost
    */
-  bool isOnlyLocalhostAllowed() { return only_localhost_allowed_; }
+  bool isOnlyLocalhostAllowed() const { return only_localhost_allowed_; }
 
 private:
   bool only_localhost_allowed_;

--- a/clients/roscpp/include/ros/transport/transport.h
+++ b/clients/roscpp/include/ros/transport/transport.h
@@ -154,4 +154,3 @@ private:
 }
 
 #endif // ROSCPP_TRANSPORT_H
-

--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -59,8 +59,6 @@ Transport::Transport()
   #endif
   if (ros_hostname_env && !strcmp(ros_hostname_env, "localhost"))
     only_localhost_allowed_ = true;
-  else if (ros_ip_env && !strcmp(ros_ip_env, "localhost"))
-    only_localhost_allowed_ = true;
   else if (ros_ip_env && !strncmp(ros_ip_env, "127.", 4))
     only_localhost_allowed_ = true;
 

--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -96,7 +96,7 @@ Transport::Transport()
   }
 }
 
-bool Transport::isHostAllowed(const std::string &host)
+bool Transport::isHostAllowed(const std::string &host) const
 {
   if (!only_localhost_allowed_)
     return true; // doesn't matter; we'll connect to anybody
@@ -111,7 +111,7 @@ bool Transport::isHostAllowed(const std::string &host)
       return true; // hooray
   }
   ROS_WARN("ROS_HOSTNAME / ROS_IP is set to only allow local connections, so "
-           "a requested connection to %s is being rejected.", host.c_str());
+           "a requested connection to '%s' is being rejected.", host.c_str());
   return false; // sadness
 }
 

--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -1,0 +1,117 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2014, Open Source Robotics Foundation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "ros/transport/transport.h"
+#include "ros/console.h"
+#include <ifaddrs.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+#ifndef NI_MAXHOST
+  #define NI_MAXHOST 1025
+#endif
+
+namespace ros
+{
+
+Transport::Transport()
+: only_localhost_allowed_(false)
+{
+  char *ros_ip_env = NULL, *ros_hostname_env = NULL;
+  #ifdef _MSC_VER
+    _dupenv_s(&ros_ip_env, NULL, "ROS_IP");
+    _dupenv_s(&ros_hostname_env, NULL, "ROS_HOSTNAME");
+  #else
+    ros_ip_env = getenv("ROS_IP");
+    ros_hostname_env = getenv("ROS_HOSTNAME");
+  #endif
+  if (ros_hostname_env && !strcmp(ros_hostname_env, "localhost"))
+    only_localhost_allowed_ = true;
+  else if (ros_ip_env && !strcmp(ros_ip_env, "localhost"))
+    only_localhost_allowed_ = true;
+
+  char our_hostname[256] = {0};
+  gethostname(our_hostname, sizeof(our_hostname)-1);
+  allowed_hosts_.push_back(std::string(our_hostname));
+  allowed_hosts_.push_back("localhost");
+  // for ipv4 loopback, we'll explicitly search for 127.* in isHostAllowed()
+  // now we need to iterate all local interfaces and add their addresses
+  // from the getifaddrs manpage:  (maybe something similar for windows ?) 
+  ifaddrs *ifaddr;
+  if (-1 == getifaddrs(&ifaddr))
+  {
+    ROS_ERROR("getifaddr() failed");
+    return;
+  }
+  for (ifaddrs *ifa = ifaddr; ifa; ifa = ifa->ifa_next)
+  {
+    int family = ifa->ifa_addr->sa_family;
+    if (family != AF_INET && family != AF_INET6)
+      continue; // we're only looking for IP addresses
+    char addr[NI_MAXHOST] = {0};
+    if (getnameinfo(ifa->ifa_addr,
+                    (family == AF_INET) ? sizeof(sockaddr_in)
+                                        : sizeof(sockaddr_in6),
+                    addr, NI_MAXHOST,
+                    NULL, 0, NI_NUMERICHOST))
+    {
+      ROS_ERROR("getnameinfo() failed");
+      continue;
+    }
+    allowed_hosts_.push_back(std::string(addr));
+  }
+}
+
+bool Transport::isHostAllowed(const std::string &host)
+{
+  if (!only_localhost_allowed_)
+    return true; // doesn't matter; we'll connect to anybody
+
+  if (host.length() >= 4 && host.substr(0, 4) == std::string("127."))
+    return true; // ipv4 localhost
+  // now, loop through the list of valid hostnames and see if we find it
+  for (std::vector<std::string>::iterator it = allowed_hosts_.begin(); 
+       it != allowed_hosts_.end(); ++it)
+  {
+    if (host == *it)
+      return true; // hooray
+  }
+  ROS_WARN("ROS_HOSTNAME / ROS_IP is set to only allow local connections, so "
+           "a requested connection to %s is being rejected.", host.c_str());
+  return false; // sadness
+}
+
+}
+

--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -61,6 +61,8 @@ Transport::Transport()
     only_localhost_allowed_ = true;
   else if (ros_ip_env && !strncmp(ros_ip_env, "127.", 4))
     only_localhost_allowed_ = true;
+  else if (ros_ip_env && !strcmp(ros_ip_env, "::1"))
+    only_localhost_allowed_ = true;
 
   char our_hostname[256] = {0};
   gethostname(our_hostname, sizeof(our_hostname)-1);

--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD License)
  *
- *  Copyright (c) 2014, Open Source Robotics Foundation
+ *  Copyright (c) 2014, Open Source Robotics Foundation, Inc.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -104,7 +104,7 @@ bool Transport::isHostAllowed(const std::string &host) const
   if (host.length() >= 4 && host.substr(0, 4) == std::string("127."))
     return true; // ipv4 localhost
   // now, loop through the list of valid hostnames and see if we find it
-  for (std::vector<std::string>::iterator it = allowed_hosts_.begin(); 
+  for (std::vector<std::string>::const_iterator it = allowed_hosts_.begin(); 
        it != allowed_hosts_.end(); ++it)
   {
     if (host == *it)

--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -61,6 +61,8 @@ Transport::Transport()
     only_localhost_allowed_ = true;
   else if (ros_ip_env && !strcmp(ros_ip_env, "localhost"))
     only_localhost_allowed_ = true;
+  else if (ros_ip_env && !strncmp(ros_ip_env, "127.", 4))
+    only_localhost_allowed_ = true;
 
   char our_hostname[256] = {0};
   gethostname(our_hostname, sizeof(our_hostname)-1);

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -384,6 +384,7 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
     return false;
   }
 
+
   if (bind(sock_, (sockaddr *)&server_address_, sa_len_) < 0)
   {
     ROS_ERROR("bind() failed with error [%s]", last_socket_error_string());

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -355,22 +355,14 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
   is_server_ = true;
   accept_cb_ = accept_cb;
 
-  char *ros_ip_env = NULL;
-  #ifdef _MSC_VER
-    _dupenv_s(&ros_ip_env, NULL, "ROS_IP");
-  #else
-    ros_ip_env = getenv("ROS_IP");
-  #endif
-  bool use_loopback = ros_ip_env && !strcmp(ros_ip_env, "localhost");
-  ROS_INFO_COND(use_loopback,
-    "ROS_IP is set to localhost; tcpros is binding to loopback interface");
-
   if (s_use_ipv6_)
   {
     sock_ = socket(AF_INET6, SOCK_STREAM, 0);
     sockaddr_in6 *address = (sockaddr_in6 *)&server_address_;
     address->sin6_family = AF_INET6;
-    address->sin6_addr = use_loopback ? in6addr_loopback : in6addr_any;
+    address->sin6_addr = isOnlyLocalhostAllowed() ? 
+                         in6addr_loopback : 
+                         in6addr_any;
     address->sin6_port = htons(port);
     sa_len_ = sizeof(sockaddr_in6);
   }
@@ -379,7 +371,7 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
     sock_ = socket(AF_INET, SOCK_STREAM, 0);
     sockaddr_in *address = (sockaddr_in *)&server_address_;
     address->sin_family = AF_INET;
-    address->sin_addr.s_addr = use_loopback ? 
+    address->sin_addr.s_addr = isOnlyLocalhostAllowed() ? 
                                htonl(INADDR_LOOPBACK) : 
                                INADDR_ANY;
     address->sin_port = htons(port);

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -211,6 +211,26 @@ void TransportTCP::setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint
 
 bool TransportTCP::connect(const std::string& host, int port)
 {
+  char *ros_ip_env = NULL;
+  #ifdef _MSC_VER
+    _dupenv_s(&ros_ip_env, NULL, "ROS_IP");
+  #else
+    ros_ip_env = getenv("ROS_IP");
+  #endif
+  if (ros_ip_env && !strcmp(ros_ip_env, "localhost"))
+  {
+    // we must verify that the requested connection is to localhost
+    char our_hostname[256] = {0};
+    gethostname(our_hostname, sizeof(our_hostname)-1);
+    if (std::string(our_hostname) != host)
+    {
+      ROS_WARN("ROS_IP is set to localhost (%s), and the requested outbound "
+               "connection is to host %s, so this connection will not be "
+               "allowed.", our_hostname, host.c_str());
+      return false; // adios amigo
+    }
+  }
+
   sock_ = socket(s_use_ipv6_ ? AF_INET6 : AF_INET, SOCK_STREAM, 0);
   connected_host_ = host;
   connected_port_ = port;

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -360,10 +360,11 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
   #endif
   bool use_loopback = ros_ip_env && !strcmp(ros_ip_env, "localhost");
   ROS_INFO_COND(use_loopback,
-                "ROS_IP is set to localhost; binding to loopback interface");
+    "ROS_IP is set to localhost; tcpros is binding to loopback interface");
 
   if (s_use_ipv6_)
   {
+    ROS_INFO("tcpros using ipv6");
     sock_ = socket(AF_INET6, SOCK_STREAM, 0);
     sockaddr_in6 *address = (sockaddr_in6 *)&server_address_;
     address->sin6_family = AF_INET6;
@@ -373,10 +374,13 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
   }
   else
   {
+    ROS_INFO("tcpros using ipv4");
     sock_ = socket(AF_INET, SOCK_STREAM, 0);
     sockaddr_in *address = (sockaddr_in *)&server_address_;
     address->sin_family = AF_INET;
-    address->sin_addr.s_addr = use_loopback ? INADDR_LOOPBACK : INADDR_ANY;
+    address->sin_addr.s_addr = use_loopback ? 
+                               htonl(INADDR_LOOPBACK) : 
+                               INADDR_ANY;
     address->sin_port = htons(port);
     sa_len_ = sizeof(sockaddr_in);
   }

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -352,12 +352,22 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
   is_server_ = true;
   accept_cb_ = accept_cb;
 
+  char *ros_ip_env = NULL;
+  #ifdef _MSC_VER
+    _dupenv_s(&ros_ip_env, NULL, "ROS_IP");
+  #else
+    ros_ip_env = getenv("ROS_IP");
+  #endif
+  bool use_loopback = ros_ip_env && !strcmp(ros_ip_env, "localhost");
+  ROS_INFO_COND(use_loopback,
+                "ROS_IP is set to localhost; binding to loopback interface");
+
   if (s_use_ipv6_)
   {
     sock_ = socket(AF_INET6, SOCK_STREAM, 0);
     sockaddr_in6 *address = (sockaddr_in6 *)&server_address_;
     address->sin6_family = AF_INET6;
-    address->sin6_addr = in6addr_any;
+    address->sin6_addr = use_loopback ? in6addr_loopback : in6addr_any;
     address->sin6_port = htons(port);
     sa_len_ = sizeof(sockaddr_in6);
   }
@@ -366,7 +376,7 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
     sock_ = socket(AF_INET, SOCK_STREAM, 0);
     sockaddr_in *address = (sockaddr_in *)&server_address_;
     address->sin_family = AF_INET;
-    address->sin_addr.s_addr = INADDR_ANY;
+    address->sin_addr.s_addr = use_loopback ? INADDR_LOOPBACK : INADDR_ANY;
     address->sin_port = htons(port);
     sa_len_ = sizeof(sockaddr_in);
   }
@@ -376,7 +386,6 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
     ROS_ERROR("socket() failed with error [%s]", last_socket_error_string());
     return false;
   }
-
 
   if (bind(sock_, (sockaddr *)&server_address_, sa_len_) < 0)
   {

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -222,7 +222,9 @@ bool TransportTCP::connect(const std::string& host, int port)
     // we must verify that the requested connection is to localhost
     char our_hostname[256] = {0};
     gethostname(our_hostname, sizeof(our_hostname)-1);
-    if (std::string(our_hostname) != host)
+    if (host != "127.0.0.1" && 
+        host != "::1" && 
+        std::string(our_hostname) != host)
     {
       ROS_WARN("ROS_IP is set to localhost (%s), and the requested outbound "
                "connection is to host %s, so this connection will not be "

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -248,11 +248,13 @@ bool TransportUDP::createIncoming(int port, bool is_server)
   #endif
   bool use_loopback = ros_ip_env && !strcmp(ros_ip_env, "localhost");
   ROS_INFO_COND(use_loopback,
-                "ROS_IP is set to localhost; binding to loopback interface");
+    "ROS_IP is set to localhost; rosudp is binding to loopback interface");
 
   server_address_.sin_family = AF_INET;
   server_address_.sin_port = htons(port);
-  server_address_.sin_addr.s_addr = use_loopback ? INADDR_LOOPBACK : INADDR_ANY;
+  server_address_.sin_addr.s_addr = use_loopback ? 
+                                    htonl(INADDR_LOOPBACK) :
+                                    INADDR_ANY;
   if (bind(sock_, (sockaddr *)&server_address_, sizeof(server_address_)) < 0)
   {
     ROS_ERROR("bind() failed with error [%s]",  last_socket_error_string());

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -153,7 +153,9 @@ bool TransportUDP::connect(const std::string& host, int port, int connection_id)
     // we must verify that the requested connection is to localhost
     char our_hostname[256] = {0};
     gethostname(our_hostname, sizeof(our_hostname)-1);
-    if (std::string(our_hostname) != host)
+    if (host != "127.0.0.1" && 
+        host != "::1" && 
+        std::string(our_hostname) != host)
     {
       ROS_WARN("ROS_IP is set to localhost (%s), and the requested outbound "
                "connection is to host %s, so this connection will not be "

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -142,27 +142,8 @@ std::string TransportUDP::getTransportInfo()
 
 bool TransportUDP::connect(const std::string& host, int port, int connection_id)
 {
-  char *ros_ip_env = NULL;
-  #ifdef _MSC_VER
-    _dupenv_s(&ros_ip_env, NULL, "ROS_IP");
-  #else
-    ros_ip_env = getenv("ROS_IP");
-  #endif
-  if (ros_ip_env && !strcmp(ros_ip_env, "localhost"))
-  {
-    // we must verify that the requested connection is to localhost
-    char our_hostname[256] = {0};
-    gethostname(our_hostname, sizeof(our_hostname)-1);
-    if (host != "127.0.0.1" && 
-        host != "::1" && 
-        std::string(our_hostname) != host)
-    {
-      ROS_WARN("ROS_IP is set to localhost (%s), and the requested outbound "
-               "connection is to host %s, so this connection will not be "
-               "allowed.", our_hostname, host.c_str());
-      return false; // adios amigo
-    }
-  }
+  if (!isHostAllowed(host))
+    return false; // adios amigo
 
   sock_ = socket(AF_INET, SOCK_DGRAM, 0);
   connection_id_ = connection_id;

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -240,9 +240,19 @@ bool TransportUDP::createIncoming(int port, bool is_server)
     return false;
   }
 
+  char *ros_ip_env = NULL;
+  #ifdef _MSC_VER
+    _dupenv_s(&ros_ip_env, NULL, "ROS_IP");
+  #else
+    ros_ip_env = getenv("ROS_IP");
+  #endif
+  bool use_loopback = ros_ip_env && !strcmp(ros_ip_env, "localhost");
+  ROS_INFO_COND(use_loopback,
+                "ROS_IP is set to localhost; binding to loopback interface");
+
   server_address_.sin_family = AF_INET;
   server_address_.sin_port = htons(port);
-  server_address_.sin_addr.s_addr = INADDR_ANY;
+  server_address_.sin_addr.s_addr = use_loopback ? INADDR_LOOPBACK : INADDR_ANY;
   if (bind(sock_, (sockaddr *)&server_address_, sizeof(server_address_)) < 0)
   {
     ROS_ERROR("bind() failed with error [%s]",  last_socket_error_string());

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -243,19 +243,9 @@ bool TransportUDP::createIncoming(int port, bool is_server)
     return false;
   }
 
-  char *ros_ip_env = NULL;
-  #ifdef _MSC_VER
-    _dupenv_s(&ros_ip_env, NULL, "ROS_IP");
-  #else
-    ros_ip_env = getenv("ROS_IP");
-  #endif
-  bool use_loopback = ros_ip_env && !strcmp(ros_ip_env, "localhost");
-  ROS_INFO_COND(use_loopback,
-    "ROS_IP is set to localhost; rosudp is binding to loopback interface");
-
   server_address_.sin_family = AF_INET;
   server_address_.sin_port = htons(port);
-  server_address_.sin_addr.s_addr = use_loopback ? 
+  server_address_.sin_addr.s_addr = isOnlyLocalhostAllowed() ? 
                                     htonl(INADDR_LOOPBACK) :
                                     INADDR_ANY;
   if (bind(sock_, (sockaddr *)&server_address_, sizeof(server_address_)) < 0)

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -518,7 +518,7 @@ class TCPROSTransport(Transport):
         @type  timeout: float
         @raise TransportInitError: if unable to create connection
         """
-        # first make sure that if ROS_IP=localhost, we will not attempt
+        # first make sure that if ROS_HOSTNAME=localhost, we will not attempt
         # to connect to anything other than localhost
         if ("ROS_HOSTNAME" in os.environ) and (os.environ["ROS_HOSTNAME"] == "localhost"):
           if not rosgraph.network.is_local_address(dest_addr):

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -520,9 +520,9 @@ class TCPROSTransport(Transport):
         """
         # first make sure that if ROS_IP=localhost, we will not attempt
         # to connect to anything other than localhost
-        if ("ROS_IP" in os.environ) and (os.environ["ROS_IP"] == "localhost"):
+        if ("ROS_HOSTNAME" in os.environ) and (os.environ["ROS_HOSTNAME"] == "localhost"):
           if not rosgraph.network.is_local_address(dest_addr):
-            msg = "attempted to connect to non-local host [%s] from a node launched with ROS_IP=localhost." % (dest_addr)
+            msg = "attempted to connect to non-local host [%s] from a node launched with ROS_HOSTNAME=localhost" % (dest_addr)
             logwarn(msg)
             self.close()
             raise TransportInitError(msg)  # bubble up

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -518,6 +518,16 @@ class TCPROSTransport(Transport):
         @type  timeout: float
         @raise TransportInitError: if unable to create connection
         """
+        # first make sure that if ROS_IP=localhost, we will not attempt
+        # to connect to anything other than localhost
+        if ("ROS_IP" in os.environ) and (os.environ["ROS_IP"] == "localhost"):
+          if not rosgraph.network.is_local_address(dest_addr):
+            msg = "attempted to connect to non-local host [%s] from a node launched with ROS_IP=localhost." % (dest_addr)
+            logwarn(msg)
+            self.close()
+            raise TransportInitError(msg)  # bubble up
+ 
+        # now we can proceed with trying to connect.
         try:
             self.endpoint_id = endpoint_id
             self.dest_address = (dest_addr, dest_port)

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -154,7 +154,7 @@ def get_address_override():
             msg = 'invalid ROS_IP (port should not be included)'
             sys.stderr.write(msg + '\n')
             logger.warn(msg)
-        elif ip.find('.') == -1 and ip.find(':') == -1 and ip != 'localhost':
+        elif ip.find('.') == -1 and ip.find(':') == -1:
             msg = 'invalid ROS_IP (must be a valid IPv4 or IPv6 address)'
             sys.stderr.write(msg + '\n')
             logger.warn(msg)

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -154,7 +154,7 @@ def get_address_override():
             msg = 'invalid ROS_IP (port should not be included)'
             sys.stderr.write(msg + '\n')
             logger.warn(msg)
-        elif ip.find('.') == -1 and ip.find(':') == -1:
+        elif ip.find('.') == -1 and ip.find(':') == -1 and ip != 'localhost':
             msg = 'invalid ROS_IP (must be a valid IPv4 or IPv6 address)'
             sys.stderr.write(msg + '\n')
             logger.warn(msg)


### PR DESCRIPTION
The wiki doc for ROS_IP:  http://wiki.ros.org/ROS/EnvironmentVariables    says that setting ROS_IP=localhost will "prevent remote components from being able to talk to your local component." This can be useful in some settings. However, this behavior was previously only implemented for inbound rospy topic connections and services. This pull request implements it for inbound and outbound roscpp connections, and for outbound rospy connections.
