### PR TITLE
Possibility to add multiple tests with different arguments

### DIFF
--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -38,9 +38,8 @@ function(add_rostest file)
 
   string(REPLACE "/" "_" _testname ${_testname})
   if(ARGN) # inserting parameters in name, if set
-    string(REPLACE ";" "__" argnstring "${ARGN}")
-    string(REGEX REPLACE "ARGS" "" argnstring ${argnstring})
-    string(REPLACE ":=" "_" argnstring ${argnstring})
+    string(REGEX REPLACE "[;:=.]|ARGS" "_" argnstring "${ARGN}")
+    string(REPLACE " " "-" argnstring "${argnstring}")
     string(REPLACE "." "_" _testname ${_testname})
     set(_testname "${_testname}_${argnstring}.test")
     message("-- Added testname WITH arguments: ${_testname}")

--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -37,13 +37,13 @@ function(add_rostest file)
   rostest__strip_prefix(_testname "${PROJECT_BINARY_DIR}/")
 
   string(REPLACE "/" "_" _testname ${_testname})
-  if(ARGN) # inserting parameters in name, if set
+  if(_rostest_ARGS) # inserting parameters in name, if set
     string(REGEX REPLACE "[;:=.]|ARGS" "_" argnstring "${ARGN}")
     string(REPLACE " " "-" argnstring "${argnstring}")
     string(REPLACE "." "_" _testname ${_testname})
     set(_testname "${_testname}_${argnstring}.test")
     message("-- Added testname WITH arguments: ${_testname}")
-  endif(ARGN)
+  endif(_rostest_ARGS)
 
   get_filename_component(_output_name ${_testname} NAME_WE)
   set(_output_name "${_output_name}.xml")

--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -37,6 +37,15 @@ function(add_rostest file)
   rostest__strip_prefix(_testname "${PROJECT_BINARY_DIR}/")
 
   string(REPLACE "/" "_" _testname ${_testname})
+  if(ARGN) # inserting parameters in name, if set
+    string(REPLACE ";" "__" argnstring "${ARGN}")
+    string(REGEX REPLACE "ARGS" "" argnstring ${argnstring})
+    string(REPLACE ":=" "_" argnstring ${argnstring})
+    string(REPLACE "." "_" _testname ${_testname})
+    set(_testname "${_testname}_${argnstring}.test")
+    message("-- Added testname WITH arguments: ${_testname}")
+  endif(ARGN)
+
   get_filename_component(_output_name ${_testname} NAME_WE)
   set(_output_name "${_output_name}.xml")
   set(cmd "${ROSTEST_EXE} --pkgdir=${PROJECT_SOURCE_DIR} --package=${PROJECT_NAME} --results-filename ${_output_name} ${_file_name} ${_rostest_ARGS}")


### PR DESCRIPTION
I needed to add multiple tests with different arguments in one CMakeLists.txt. This led to a conflict as these had the same target name, due to the identical test-file-name. This includes arguments to the target name, if those are stated.
