### PR TITLE
Fix test_roslz4 when catkin_add_gtest fails

### DIFF
--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -53,5 +53,7 @@ install(DIRECTORY include/${PROJECT_NAME}
 # Testing
 if (CATKIN_ENABLE_TESTING)
   catkin_add_gtest(test_roslz4 test/roslz4_test.cpp)
-  target_link_libraries(test_roslz4 roslz4 ${catkin_LIBRARIES})
+  if (TARGET test_roslz4)
+    target_link_libraries(test_roslz4 roslz4 ${catkin_LIBRARIES})
+  endif()
 endif()


### PR DESCRIPTION
Without this fix I've got:

-- +++ processing catkin package: 'roscpp_serialization'
-- ==> add_subdirectory(roscpp_core/roscpp_serialization)
-- +++ processing catkin package: 'rosunit'
-- ==> add_subdirectory(ros/rosunit)
-- +++ processing catkin package: 'roslz4'
-- ==> add_subdirectory(ros_comm/roslz4)
CMake Warning at catkin/cmake/test/gtest.cmake:29 (message):
  skipping gtest 'test_roslz4' in project 'roslz4'
Call Stack (most recent call first):
  ros_comm/roslz4/CMakeLists.txt:56 (catkin_add_gtest)

CMake Error at ros_comm/roslz4/CMakeLists.txt:57 (target_link_libraries):
  Cannot specify link libraries for target "test_roslz4" which is not built
  by this project.

-- Configuring incomplete, errors occurred!
Invoking "cmake" failed

Since catkin skip the target (missing gtest?) target is not create thus target_link_library won't work (no target)...
ps: I'm trying to build rosbag_storage on ubuntu x86_64 14.04 indigo
$ mkdir rosbag && cd rosbag
$ rosinstall_generator rosbag_storage --rosdistro indigo --deps --wet-only --tar > indigo-rosbag_storage-wet.rosinstall
$ wstool init -j8 src indigo-rosbag_storage-wet.rosinstall
$ ./src/catkin/bin/catkin_make
