### PR TITLE
disable service_deadlock test

### DIFF
--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -92,7 +92,8 @@ add_rostest(launch/pubsub_unadv.xml)
 # Call a service
 add_rostest(launch/service_call.xml)
 
-add_rostest(launch/service_deadlock.xml)
+# disabling the test again since it does not work realiable
+#add_rostest(launch/service_deadlock.xml)
 
 add_rostest(launch/service_exception.xml)
 


### PR DESCRIPTION
@esteve @tfoote @wjwwood FYI

I anyone would like to look into it please go ahead and reenable the test again when it is working reliable. I simply can't spend any more time on this.
