### PR TITLE
Fixed bug when ifa_addr is NULL

### DIFF
--- a/clients/roscpp/src/libros/transport/transport.cpp
+++ b/clients/roscpp/src/libros/transport/transport.cpp
@@ -79,6 +79,8 @@ Transport::Transport()
   }
   for (ifaddrs *ifa = ifaddr; ifa; ifa = ifa->ifa_next)
   {
+    if(NULL == ifa->ifa_addr)
+      continue; // ifa_addr can be NULL
     int family = ifa->ifa_addr->sa_family;
     if (family != AF_INET && family != AF_INET6)
       continue; // we're only looking for IP addresses


### PR DESCRIPTION
For example where the interface is socketcan.
