### PR TITLE
Make rostest use a random master port

### DIFF
--- a/tools/rostest/scripts/rostest
+++ b/tools/rostest/scripts/rostest
@@ -31,23 +31,6 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import socket
-import time
 from rostest import rostestmain
-
-message_printed = False
-while True:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        s.bind(('127.0.0.1', 22421))  # choose port close to test roscore
-        break
-    except socket.error as e:
-        if e.errno != socket.errno.EADDRINUSE:
-            raise
-        if not message_printed:
-            print('Another rostest instance is currently running, waiting until it finished...')
-            message_printed = True
-        time.sleep(0.25)
-        continue
 
 rostestmain()

--- a/tools/rostest/src/rostest/rostest_parent.py
+++ b/tools/rostest/src/rostest/rostest_parent.py
@@ -44,14 +44,16 @@ import roslaunch.xmlloader
 
 import roslaunch.parent
 
+from rosmaster.master import Master
+
 class ROSTestLaunchParent(roslaunch.parent.ROSLaunchParent):
 
-    def __init__(self, config, roslaunch_files, port):
+    def __init__(self, config, roslaunch_files):
         if config is None:
             raise Exception("config not initialized")
         # we generate a run_id for each test
         run_id = roslaunch.core.generate_run_id()
-        super(ROSTestLaunchParent, self).__init__(run_id, roslaunch_files, is_core=True, port=port, is_rostest=True)
+        super(ROSTestLaunchParent, self).__init__(run_id, roslaunch_files, is_core=False, is_rostest=True)
         self.config = config
         
     def _load_config(self):
@@ -63,6 +65,9 @@ class ROSTestLaunchParent(roslaunch.parent.ROSLaunchParent):
         initializes self.config and xmlrpc infrastructure
         """
         self._start_infrastructure()
+        self.master = Master(port=0)
+        self.master.start()
+        self.config.master.uri = self.master.uri
         self._init_runner()
 
     def tearDown(self):

--- a/tools/rostest/src/rostest/runner.py
+++ b/tools/rostest/src/rostest/runner.py
@@ -47,8 +47,6 @@ from rostest.rostestutil import createXMLRunner, printSummary, printRostestSumma
 from rostest.rostest_parent import ROSTestLaunchParent
 import rosunit.junitxml
 
-_DEFAULT_TEST_PORT = 22422
-
 # NOTE: ignoring Python style guide as unittest is sadly written with Java-like camel casing
 
 _results = rosunit.junitxml.Result('rostest', 0, 0, 0)
@@ -192,7 +190,7 @@ def setUp(self):
     # new test_parent for each run. we are a bit inefficient as it would be possible to
     # reuse the roslaunch base infrastructure for each test, but the roslaunch code
     # is not abstracted well enough yet
-    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file], port=_DEFAULT_TEST_PORT)
+    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file])
     
     printlog("setup[%s] run_id[%s] starting", self.test_file, self.test_parent.run_id)
 
@@ -224,7 +222,7 @@ def createUnitTest(pkg, test_file):
     @type  test_file: str
     """
     # parse the config to find the test files
-    config = roslaunch.parent.load_config_default([test_file], _DEFAULT_TEST_PORT)
+    config = roslaunch.parent.load_config_default([test_file], None)
 
     # pass in config to class as a property so that test_parent can be initialized
     classdict = { 'setUp': setUp, 'tearDown': tearDown, 'config': config,


### PR DESCRIPTION
Opening #466 against indigo

Modify rostest so that it uses the rosmaster API to start an in-process master with a random port number, and then use the resulting master URI for the following launches.

This allows me to run tests in parallel (with the appropriate make -j flag), and speeds up tests on my quad-core machine by a factor of 3.5.

This fixes #141
