### PR TITLE
Support roslaunch XML on stdin.

### DIFF
--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -111,7 +111,10 @@ def write_pid_file(options_pid_fn, options_core, port):
 def _get_optparse():
     from optparse import OptionParser
 
-    parser = OptionParser(usage="usage: %prog [options] [package] <filename> [arg_name:=value...]", prog=NAME)
+    usage = "usage: %prog [options] [package] <filename> [arg_name:=value...]\n"
+    usage += "       %prog [options] <filename> [<filename>...] [arg_name:=value...]\n\n"
+    usage += "If <filename> is a single dash ('-'), launch XML is read from standard input."
+    parser = OptionParser(usage=usage, prog=NAME)
     parser.add_option("--files",
                       dest="file_list", default=False, action="store_true",
                       help="Print list files loaded by launch file, including launch file itself")

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -274,7 +274,7 @@ def main(argv=sys.argv):
             # #1491 change terminal name
             if not options.disable_title:
                 rlutil.change_terminal_name(args, options.core)
-
+            
             # Read roslaunch string from stdin when - is passed as launch filename.
             roslaunch_strs = []
             if args == ['-']:

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -67,7 +67,7 @@ class ROSLaunchParent(object):
     and then starting up any remote processes. The __main__ method
     delegates most of runtime to ROSLaunchParent.
 
-    This must be called from the Python Main thread due to signal registration.
+    This must be called from the Python Main thread due to signal registration.    
     """
 
     def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -67,10 +67,11 @@ class ROSLaunchParent(object):
     and then starting up any remote processes. The __main__ method
     delegates most of runtime to ROSLaunchParent.
 
-    This must be called from the Python Main thread due to signal registration.    
+    This must be called from the Python Main thread due to signal registration.
     """
 
-    def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None, verbose=False, force_screen=False, is_rostest=False):
+    def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,
+            verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None):
         """
         @param run_id: UUID of roslaunch session
         @type  run_id: str
@@ -101,6 +102,7 @@ class ROSLaunchParent(object):
         self.process_listeners = process_listeners
         
         self.roslaunch_files = roslaunch_files
+        self.roslaunch_strs = roslaunch_strs
         self.is_core = is_core
         self.is_rostest = is_rostest
         self.port = port
@@ -118,7 +120,8 @@ class ROSLaunchParent(object):
         self.config = self.runner = self.server = self.pm = self.remote_runner = None
 
     def _load_config(self):
-        self.config = roslaunch.config.load_config_default(self.roslaunch_files, self.port, verbose=self.verbose)
+        self.config = roslaunch.config.load_config_default(self.roslaunch_files, self.port,
+                roslaunch_strs=self.roslaunch_strs, verbose=self.verbose)
 
         # #2370 (I really want to move this logic outside of parent)
         if self.force_screen:

--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -97,7 +97,7 @@ def resolve_launch_arguments(args):
         except rospkg.ResourceNotFound:
             pass
     # try to resolve launch file
-    if resolved_args is None and os.path.isfile(args[0]):
+    if resolved_args is None and (args[0] == '-' or os.path.isfile(args[0])):
         resolved_args = [args[0]] + args[1:]
     # raise if unable to resolve
     if resolved_args is None:


### PR DESCRIPTION
This addresses #472.

My apologies for the whitespace modifications; if you feel strongly, I can revise the PR to reverse them. pep8 hates trailing whitespace, so my editor is set to strip it on save. Functionally, I believe this where it needs to be. Some example tests:

``` bash
$ roslaunch
Usage: roslaunch [options] [package] <filename> [arg_name:=value...]

roslaunch: error: you must specify at least one input file

$ roslaunch -
... logging to /home/administrator/.ros/log/edd1c682-1272-11e4-8714-001c42910917/roslaunch-vm-precise2-3063.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

Passed '-' as file argument, attempting to read roslaunch XML from stdin.
^CTraceback (most recent call last):
  File "/home/administrator/roslaunch_ws/devel/bin/roslaunch", line 5, in <module>
    exec(fh.read())
  File "<string>", line 35, in <module>
  File "<string>", line 279, in main
KeyboardInterrupt

$ roslaunch foo
[foo] is not a launch file name
The traceback for the exception was written to the log file

$ roslaunch rosserial_server socket.launch
[ launch occurs successfully ]

$ echo '<blah></blah>' | roslaunch -
... logging to /home/administrator/.ros/log/35e04d4a-1273-11e4-bb24-001c42910917/roslaunch-vm-precise2-3250.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

Passed '-' as file argument, attempting to read roslaunch XML from stdin.
... 14 bytes read successfully.

... loading XML
Launch string: <blah></blah>

Exception: Invalid roslaunch XML syntax: no root <launch> tag
The traceback for the exception was written to the log file

$ echo '<launch><node pkg="rosserial_server" type="socket_node" name="foo" /></launch>' | roslaunch -
... logging to /home/administrator/.ros/log/50488b34-1273-11e4-8288-001c42910917/roslaunch-vm-precise2-3262.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

Passed '-' as file argument, attempting to read roslaunch XML from stdin.
... 79 bytes read successfully.

... loading XML
Added node of type [rosserial_server/socket_node] in namespace [/]
started roslaunch server http://vm-precise2:53924/
[ launch continues successfully ]
```

I've avoided modifying the `--help` output to mention this functionality, since it's a bit esoteric and the command-line help should stay simple and focused. I'll add a comment to the roslaunch wiki page once we're merged.
