### PR TITLE
workaround for issue #474

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -40,6 +40,7 @@ from __future__ import print_function
 
 import itertools
 import sys
+import re
 import traceback
 import logging
 
@@ -419,6 +420,8 @@ class XmlLoader(loader.Loader):
                     # strip leading ~, which is optional/inferred
                     pkey = pkey[1:]
                 pkey = param_ns.ns + pkey
+                for remap in remap_context.remap_args():
+                    pkey = re.sub('^/?'+remap[0], remap[1],pkey)
                 ros_config.add_param(Param(pkey, p.value), verbose=verbose)
                     
             if not is_test:

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -205,6 +205,9 @@ class TestXmlLoader(unittest.TestCase):
         self.assertEquals("a child namespace parameter 1", param_d['/wg/wgchildparam'], p.value)
         self.assertEquals("a child namespace parameter 2", param_d['/wg2/wg2childparam1'], p.value)
         self.assertEquals("a child namespace parameter 3", param_d['/wg2/wg2childparam2'], p.value)
+        self.assertEquals("a remap namespace parameter 1", param_d['/node_rosparam_remapped1/wg/remapparam1'], p.value)
+        self.assertEquals("a remap namespace parameter 2", param_d['/node_rosparam_remapped2/wg/remapparam2'], p.value)
+        self.assertEquals("a remap namespace parameter 3", param_d['/node_rosparam_remapped2/wg/node_rosparam1/remapparam3'], p.value)
 
         try:
             from xmlrpc.client import Binary

--- a/tools/roslaunch/test/xml/test-params-valid.xml
+++ b/tools/roslaunch/test/xml/test-params-valid.xml
@@ -25,6 +25,19 @@
     <param name="wg2childparam2" value="a child namespace parameter 3" />  
   </group>
 
+  <!-- you can set parameters in remapped namespaces -->
+  <node pkg="package" type="test_base" name="node_rosparam1">
+    <remap from="node_rosparam1" to="/node_rosparam_remapped1" />
+    <param name="wg/remapparam1" value="a remap namespace parameter 1" />  
+    <arg name="~param1_name" value="p1" />
+  </node>
+  <remap from="/node_rosparam1" to="/node_rosparam_remapped1" />
+  <remap from="/node_rosparam2" to="/node_rosparam_remapped2" />
+  <node pkg="package" type="test_base" name="node_rosparam2">
+    <param name="wg/remapparam2" value="a remap namespace parameter 2" />  
+    <param name="wg/node_rosparam1/remapparam3" value="a remap namespace parameter 3" />  
+  </node>
+
   <!-- upload the contents of a file as a param -->
   <param name="configfile" textfile="$(find roslaunch)/resources/example.launch" />
   <!-- upload the contents of a file as base64 binary as a param -->


### PR DESCRIPTION
this is workaround for issue #474
However I wrote this patch without knowing what is the expected behavior of using grooup/remap/param , is there any specification on this?

> The roslaunch wiki page contains all the information available.

yes, but it is not explicitly written that remap changes node name but not affect param , so if you remap node name like follows:

```
<launch>
  <remap from="/joy" to="/joy_remap"/>
  <node pkg="joy" type="joy_node" name="joy" output="screen">
    <param name="dev" type="string" value="/dev/input/js1" />
  </node>
</launch>
```

you have to change param name setting as 

```
    <param name="/joy_remap/dev" type="string" value="/dev/input/js1" />
```
