### PR TITLE
add specific exception for time jumping backwards

### DIFF
--- a/clients/rospy/src/rospy/exceptions.py
+++ b/clients/rospy/src/rospy/exceptions.py
@@ -61,6 +61,15 @@ class ROSInterruptException(ROSException, KeyboardInterrupt):
     """    
     pass
 
+class ROSTimeMovedBackwardsException(ROSInterruptException): 
+    """
+    Exception if time moved backwards
+    """
+    def __init__(self, time):
+        self.time = time
+        """The amount of time in seconds."""
+        super(ROSTimeMovedBackwardsException, self).__init__("ROS time moved backwards")
+
 class ROSInternalException(Exception):
     """
     Base class for exceptions that are internal to the ROS system

--- a/test/test_rospy/test/unit/test_rospy_exceptions.py
+++ b/test/test_rospy/test/unit/test_rospy_exceptions.py
@@ -62,3 +62,16 @@ class TestRospyExceptions(unittest.TestCase):
             raise ROSInterruptException("test")
         except KeyboardInterrupt:
             pass
+
+    def test_ROSTimeMovedBackwardsException(self):
+        from rospy.exceptions import ROSTimeMovedBackwardsException, ROSInterruptException
+        try:
+            raise ROSTimeMovedBackwardsException(1.0)
+        except ROSInterruptException as e:
+            # ensure the message is not changed, because old code may check it
+            self.assertEqual("ROS time moved backwards", e.message)
+        try:
+            time = 1.0
+            raise ROSTimeMovedBackwardsException(time)
+        except ROSTimeMovedBackwardsException as e:
+            self.assertEqual(time, e.time)


### PR DESCRIPTION
reason: ROS shutdown and time jumps should be distinguishable.
ROSTimeMovedBackwardsException inherits from ROSInterruptException
to preserve the API.
fixes #485
