### PR TITLE
Added option to specify the minimum disk space at which recording is stopped

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -106,6 +106,8 @@ struct ROSBAG_DECL RecorderOptions
     uint32_t        max_size;
     ros::Duration   max_duration;
     std::string     node;
+    unsigned long long   min_space;
+    std::string     min_space_str;
 
     std::vector<std::string> topics;
 };

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -87,27 +87,27 @@ struct ROSBAG_DECL RecorderOptions
 {
     RecorderOptions();
 
-    bool            trigger;
-    bool            record_all;
-    bool            regex;
-    bool            do_exclude;
-    bool            quiet;
-    bool            append_date;
-    bool            snapshot;
-    bool            verbose;
-    CompressionType compression;
-    std::string     prefix;
-    std::string     name;
-    boost::regex    exclude_regex;
-    uint32_t        buffer_size;
-    uint32_t        chunk_size;
-    uint32_t        limit;
-    bool            split;
-    uint32_t        max_size;
-    ros::Duration   max_duration;
-    std::string     node;
-    unsigned long long   min_space;
-    std::string     min_space_str;
+    bool               trigger;
+    bool               record_all;
+    bool               regex;
+    bool               do_exclude;
+    bool               quiet;
+    bool               append_date;
+    bool               snapshot;
+    bool               verbose;
+    CompressionType    compression;
+    std::string        prefix;
+    std::string        name;
+    boost::regex       exclude_regex;
+    uint32_t           buffer_size;
+    uint32_t           chunk_size;
+    uint32_t           limit;
+    bool               split;
+    uint32_t           max_size;
+    ros::Duration      max_duration;
+    std::string        node;
+    unsigned long long min_space;
+    std::string        min_space_str;
 
     std::vector<std::string> topics;
 };

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -149,7 +149,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
         // Sane default values, just in case
         opts.min_space_str = "1G";
         opts.min_space = value;
-        if (sscanf(ms.c_str()," %lld%c",&value,&mul)>0) {
+        if (sscanf(ms.c_str(), " %lld%c", &value, &mul) > 0) {
             opts.min_space_str = ms; 
             switch (mul) {
                 case 'G':
@@ -169,7 +169,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
                     break;
             }
         }
-        ROS_DEBUG("Rosbag using minimum space of %lld bytes, or %s",opts.min_space,opts.min_space_str.c_str());
+        ROS_DEBUG("Rosbag using minimum space of %lld bytes, or %s", opts.min_space, opts.min_space_str.c_str());
     }
     if (vm.count("bz2") && vm.count("lz4"))
     {

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -58,6 +58,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("buffsize,b", po::value<int>()->default_value(256), "Use an internal buffer of SIZE MB (Default: 256)")
       ("chunksize", po::value<int>()->default_value(768), "Set chunk size of message data, in KB (Default: 768. Advanced)")
       ("limit,l", po::value<int>()->default_value(0), "Only record NUM messages on each topic")
+      ("min-space,L", po::value<std::string>()->default_value("1G"), "Minimum allowed space on recording device (use G,M,k multipliers)")
       ("bz2,j", "use BZ2 compression")
       ("lz4", "use LZ4 compression")
       ("split", po::value<int>()->implicit_value(0), "Split the bag file and continue recording when maximum size or maximum duration reached.")
@@ -139,6 +140,38 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     if (vm.count("limit"))
     {
       opts.limit = vm["limit"].as<int>();
+    }
+    if (vm.count("min-space"))
+    {
+        std::string ms = vm["min-space"].as<std::string>();
+        long long int value=0;
+        char mul=0; 
+        sscanf(ms.c_str()," %lld%c",&value,&mul);
+        if (value) {
+            opts.min_space_str = ms; 
+            switch (mul) {
+                case 'G':
+                case 'g':
+                    opts.min_space = value * 1073741824ull;
+                    break;
+                case 'M':
+                case 'm':
+                    opts.min_space = value * 1048576ull;
+                    break;
+                case 'K':
+                case 'k':
+                    opts.min_space = value * 1024ull;
+                    break;
+                default:
+                    opts.min_space = value;
+                    break;
+            }
+        } else {
+            value = 1073741824ull;
+            opts.min_space_str = "1G";
+            opts.min_space = value;
+        }
+        // ROS_INFO("Rosbag using minimum space of %lld bytes, or %s",opts.min_space,opts.min_space_str.c_str());
     }
     if (vm.count("bz2") && vm.count("lz4"))
     {

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -144,10 +144,12 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     if (vm.count("min-space"))
     {
         std::string ms = vm["min-space"].as<std::string>();
-        long long int value=0;
+        long long int value=1073741824ull;
         char mul=0; 
-        sscanf(ms.c_str()," %lld%c",&value,&mul);
-        if (value) {
+        // Sane default values, just in case
+        opts.min_space_str = "1G";
+        opts.min_space = value;
+        if (sscanf(ms.c_str()," %lld%c",&value,&mul)>0) {
             opts.min_space_str = ms; 
             switch (mul) {
                 case 'G':
@@ -166,12 +168,8 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
                     opts.min_space = value;
                     break;
             }
-        } else {
-            value = 1073741824ull;
-            opts.min_space_str = "1G";
-            opts.min_space = value;
         }
-        // ROS_INFO("Rosbag using minimum space of %lld bytes, or %s",opts.min_space,opts.min_space_str.c_str());
+        ROS_DEBUG("Rosbag using minimum space of %lld bytes, or %s",opts.min_space,opts.min_space_str.c_str());
     }
     if (vm.count("bz2") && vm.count("lz4"))
     {

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -616,7 +616,7 @@ bool Recorder::checkDisk() {
         writing_enabled_ = false;
         return false;
     }
-    else if (free_space < 5*options_.min_space)
+    else if (free_space < 5 * options_.min_space)
     {
         ROS_WARN("Less than 5 x %s of space free on disk with %s.", options_.min_space_str.c_str(), bag_.getFileName().c_str());
     }
@@ -644,7 +644,7 @@ bool Recorder::checkDisk() {
         writing_enabled_ = false;
         return false;
     }
-    else if (info.available < 5*options_.min_space)
+    else if (info.available < 5 * options_.min_space)
     {
         ROS_WARN("Less than 5 x %s of space free on disk with %s.", options_.min_space_str.c_str(), bag_.getFileName().c_str());
         writing_enabled_ = true;

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -610,15 +610,15 @@ bool Recorder::checkDisk() {
     }
     unsigned long long free_space = 0;
     free_space = (unsigned long long) (fiData.f_bsize) * (unsigned long long) (fiData.f_bavail);
-    if (free_space < 1073741824ull)
+    if (free_space < options_.min_space)
     {
-        ROS_ERROR("Less than 1GB of space free on disk with %s.  Disabling recording.", bag_.getFileName().c_str());
+        ROS_ERROR("Less than %s of space free on disk with %s.  Disabling recording.", options_.min_space_str.c_str(), bag_.getFileName().c_str());
         writing_enabled_ = false;
         return false;
     }
-    else if (free_space < 5368709120ull)
+    else if (free_space < 5*options_.min_space)
     {
-        ROS_WARN("Less than 5GB of space free on disk with %s.", bag_.getFileName().c_str());
+        ROS_WARN("Less than 5 x %s of space free on disk with %s.", options_.min_space_str.c_str(), bag_.getFileName().c_str());
     }
     else
     {
@@ -638,15 +638,15 @@ bool Recorder::checkDisk() {
         writing_enabled_ = false;
         return false;
     }
-    if ( info.available < 1073741824ull)
+    if ( info.available < options_.min_space)
     {
-        ROS_ERROR("Less than 1GB of space free on disk with %s.  Disabling recording.", bag_.getFileName().c_str());
+        ROS_ERROR("Less than %s of space free on disk with %s.  Disabling recording.", options_.min_space_str.c_str(), bag_.getFileName().c_str());
         writing_enabled_ = false;
         return false;
     }
-    else if (info.available < 5368709120ull)
+    else if (info.available < 5*options_.min_space)
     {
-        ROS_WARN("Less than 5GB of space free on disk with %s.", bag_.getFileName().c_str());
+        ROS_WARN("Less than 5 x %s of space free on disk with %s.", options_.min_space_str.c_str(), bag_.getFileName().c_str());
         writing_enabled_ = true;
     }
     else


### PR DESCRIPTION
We record on a small-ish disk (10GB available) and we've been bitten several time by the hard-coded 1GB limit at which recording stops. On our system, is is 10% of the capacity that is lost. This option makes this parameter manually configurable for a given system.
