### PR TITLE
rosconsole format for rospy

### DIFF
--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -60,7 +60,7 @@ def configure_logging(logname, level=logging.INFO, filename=None, env=None):
 
     logname = logname or 'unknown'
     log_dir = rospkg.get_log_dir(env=env)
-
+    
     # if filename is not explicitly provided, generate one using logname
     if not filename:
         log_filename = os.path.join(log_dir, '%s-%s.log'%(logname, os.getpid()))
@@ -99,7 +99,7 @@ def configure_logging(logname, level=logging.INFO, filename=None, env=None):
         sys.stderr.write("WARNING: cannot load logging configuration file, logging is disabled\n")
         logging.getLogger(logname).setLevel(logging.CRITICAL)
         return log_filename
-
+    
     # pass in log_filename as argument to pylogging.conf
     os.environ['ROS_LOG_FILENAME'] = log_filename
     # #3625: disabling_existing_loggers=False
@@ -112,7 +112,7 @@ def makedirs_with_parent_perms(p):
     (existing) parent directory. This is useful for logging, where a
     root process sometimes has to log in the user's space.
     :param p: directory to create, ``str``
-    """
+    """    
     p = os.path.abspath(p)
     parent = os.path.dirname(p)
     # recurse upwards, checking to make sure we haven't reached the
@@ -127,7 +127,7 @@ def makedirs_with_parent_perms(p):
         if s.st_uid != s2.st_uid or s.st_gid != s2.st_gid:
             os.chown(p, s.st_uid, s.st_gid)
         if s.st_mode != s2.st_mode:
-            os.chmod(p, s.st_mode)
+            os.chmod(p, s.st_mode)    
 
 _logging_to_rospy_names = {
     'DEBUG': ('DEBUG', '\033[32m'),
@@ -162,11 +162,8 @@ class RosStreamHandler(logging.Handler):
             msg = msg.replace('${file}', str(record.pathname))
             msg = msg.replace('${line}', str(record.lineno))
             msg = msg.replace('${function}', str(record.funcName))
-            try:
-                from rospy import get_name
-                msg = msg.replace('${node}', get_name())
-            except ImportError:
-                msg = msg.replace('${node}', 'unavailable')
+            from rospy import get_name
+            msg = msg.replace('${node}', get_name())
             if self._get_time is not None and not self._is_wallclock():
                 msg += ' [%f]' % self._get_time()
             msg += '\n'

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -60,7 +60,7 @@ def configure_logging(logname, level=logging.INFO, filename=None, env=None):
 
     logname = logname or 'unknown'
     log_dir = rospkg.get_log_dir(env=env)
-    
+
     # if filename is not explicitly provided, generate one using logname
     if not filename:
         log_filename = os.path.join(log_dir, '%s-%s.log'%(logname, os.getpid()))
@@ -99,7 +99,7 @@ def configure_logging(logname, level=logging.INFO, filename=None, env=None):
         sys.stderr.write("WARNING: cannot load logging configuration file, logging is disabled\n")
         logging.getLogger(logname).setLevel(logging.CRITICAL)
         return log_filename
-    
+
     # pass in log_filename as argument to pylogging.conf
     os.environ['ROS_LOG_FILENAME'] = log_filename
     # #3625: disabling_existing_loggers=False
@@ -112,7 +112,7 @@ def makedirs_with_parent_perms(p):
     (existing) parent directory. This is useful for logging, where a
     root process sometimes has to log in the user's space.
     :param p: directory to create, ``str``
-    """    
+    """
     p = os.path.abspath(p)
     parent = os.path.dirname(p)
     # recurse upwards, checking to make sure we haven't reached the
@@ -127,7 +127,7 @@ def makedirs_with_parent_perms(p):
         if s.st_uid != s2.st_uid or s.st_gid != s2.st_gid:
             os.chown(p, s.st_uid, s.st_gid)
         if s.st_mode != s2.st_mode:
-            os.chmod(p, s.st_mode)    
+            os.chmod(p, s.st_mode)
 
 _logging_to_rospy_names = {
     'DEBUG': ('DEBUG', '\033[32m'),
@@ -162,8 +162,11 @@ class RosStreamHandler(logging.Handler):
             msg = msg.replace('${file}', str(record.pathname))
             msg = msg.replace('${line}', str(record.lineno))
             msg = msg.replace('${function}', str(record.funcName))
-            from rospy import get_name
-            msg = msg.replace('${node}', get_name())
+            try:
+                from rospy import get_name
+                msg = msg.replace('${node}', get_name())
+            except ImportError:
+                msg = msg.replace('${node}', 'unavailable')
             if self._get_time is not None and not self._is_wallclock():
                 msg += ' [%f]' % self._get_time()
             msg += '\n'

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -156,7 +156,7 @@ class RosStreamHandler(logging.Handler):
             msg = os.environ['ROSCONSOLE_FORMAT']
             msg = msg.replace('${severity}', level)
             msg = msg.replace('${message}', str(record.getMessage()))
-            msg = msg.replace('${time}', str(time.time()))
+            msg = msg.replace('${walltime}', '%f' % time.time())
             msg = msg.replace('${thread}', str(record.thread))
             msg = msg.replace('${logger}', str(record.name))
             msg = msg.replace('${file}', str(record.pathname))
@@ -164,11 +164,15 @@ class RosStreamHandler(logging.Handler):
             msg = msg.replace('${function}', str(record.funcName))
             try:
                 from rospy import get_name
-                msg = msg.replace('${node}', get_name())
+                node_name = get_name()
             except ImportError:
-                msg = msg.replace('${node}', 'unavailable')
+                node_name = '<unknown_node_name>'
+            msg = msg.replace('${node}', node_name)
             if self._get_time is not None and not self._is_wallclock():
-                msg += ' [%f]' % self._get_time()
+                t = self._get_time()
+            else:
+                t = time.time()
+            msg = msg.replace('${time}', '%f' % t)
             msg += '\n'
         else:
             msg = '[%s] [WallTime: %f]' % (level, time.time())

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -162,8 +162,11 @@ class RosStreamHandler(logging.Handler):
             msg = msg.replace('${file}', str(record.pathname))
             msg = msg.replace('${line}', str(record.lineno))
             msg = msg.replace('${function}', str(record.funcName))
-            from rospy import get_name
-            msg = msg.replace('${node}', get_name())
+            try:
+                from rospy import get_name
+                msg = msg.replace('${node}', get_name())
+            except ImportError:
+                msg = msg.replace('${node}', 'unavailable')
             if self._get_time is not None and not self._is_wallclock():
                 msg += ' [%f]' % self._get_time()
             msg += '\n'


### PR DESCRIPTION
quick & dirty solution for issue:
https://github.com/ros/ros_comm/issues/517

Since in python it uses [logging module](https://docs.python.org/2/library/logging.html) and in C++ it uses [log4cxx](http://logging.apache.org/log4cxx/index.html), I could not find 1 to 1 translation for some outputs. For example, `${thread}` and `${logger}` does not match well with that of C++.

Also I was not sure if this file was a good place to write this functionality. @dirk-thomas recommended to check out [this file](https://github.com/ros/ros_comm/blob/fab4840ef79f5334bcd043e057a1909183842159/clients/rospy/src/rospy/core.py#L119) but this file was easier to make change. Let me know if you have suggestions,
