### PR TITLE
Fix: TCPROS header validation crash when `callerid` header is not set

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -581,9 +581,10 @@ class TCPROSTransport(Transport):
         for required in ['md5sum', 'type']:
             if not required in header:
                 raise TransportInitError("header missing required field [%s]"%required)
-        self.md5sum = header['md5sum']
-        self.callerid_pub = header['callerid']
         self.type = header['type']
+        self.md5sum = header['md5sum']
+        if 'callerid' in header:
+            self.callerid_pub = header['callerid']
         if header.get('latching', '0') == '1':
             self.is_latched = True
 


### PR DESCRIPTION
Pull request by issue https://github.com/ros/ros_comm/issues/522
