### PR TITLE
On Android fd_set is defined on sys/select.h

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -6,6 +6,9 @@
 #include <math.h>
 #include <errno.h>
 #include <sys/timeb.h>
+#if defined (__ANDROID__)
+#include <sys/select.h>
+#endif
 
 #if defined(_WINDOWS)
 # include <winsock2.h>


### PR DESCRIPTION
When compiling on Android, compiler cannot find ´fd_set´. Including this header fixes the issue.
