### PR TITLE
protect against add_connection leak on already closed SubImpl

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -261,8 +261,9 @@ class TCPROSHandler(rospy.impl.transport.ProtocolHandler):
         if sub.add_connection(conn): #pass tcp connection to handler
             return 1, "Connected topic[%s]. Transport impl[%s]"%(resolved_name, conn.__class__.__name__), dest_port
         else:
+            # _SubscriberImpl already closed or duplicate subscriber created
             conn.close()
-            return 0, "ERROR: Race condition failure: duplicate topic subscriber [%s] was created"%(resolved_name), 0
+            return 0, "ERROR: Race condition failure creating topic subscriber [%s]"%(resolved_name), 0
 
     def supports(self, protocol):
         """

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -374,6 +374,10 @@ class _TopicImpl(object):
         """
         rospyinfo("topic[%s] adding connection to [%s], count %s"%(self.resolved_name, c.endpoint_id, len(self.connections)))
         with self.c_lock:
+            # protect against race condition adding connection to closed sub
+            if self.closed:
+                return False
+
             # c_lock is to make add_connection thread-safe, but we
             # still make a copy of self.connections so that the rest of the
             # code can use self.connections in an unlocked manner


### PR DESCRIPTION
Protect against race condition where a new `TCPROSTransport`
connection is created and added to a `_SubscriberImpl` that is
already closed. Checks and returns False if closed so transport
creator can shutdown socket connection. Fixes issue #544.
