### PR TITLE
reset 'g_initialized' variable in shutdown routine

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -589,6 +589,7 @@ void shutdown()
 
   g_started = false;
   g_ok = false;
+  g_initialized = false;
   Time::shutdown();
 }
 


### PR DESCRIPTION
Resetting the variable `g_initialized` in shutdown routine.

By this, we can implement a re-initialization with different remapping options (such as `ROS_MASTER_URI`), since then the remap key `__master` is reconsidered.

https://github.com/ros/ros_comm/blob/indigo-devel/clients/roscpp/src/libros/init.cpp#L444

Thus, a simple change of a ros master in code could be done via:

``` c++
ros::shutdown();
std::string new_uri = "http://xxx.xxx.xxx.xxx:11311";
std::map< std::string, std::string > remap;
remap["__master"] = new_uri;
ros::init( remap, "node_name" );
```

While googling I found already existing requests for that:

http://answers.ros.org/question/131546/set-ros_master_uri-directly-in-code/

https://code.ros.org/trac/ros/ticket/3601

Is there any reason for not set this variable to `false`?
