### PR TITLE
This is the pull request for the patch of issue #548 and the already existing PR #418

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -444,7 +444,7 @@ class Node(object):
         :param remap_args: list of [(from, to)] remapping arguments, ``[(str, str)]``
         :param env_args: list of [(key, value)] of
         additional environment vars to set for node, ``[(str, str)]``
-        :param output: where to log output to, either Node, 'screen' or 'log', ``str``
+        :param output: where to log output to, 'screen', 'log' or both, ``str``
         :param cwd: current working directory of node, either 'node', 'ROS_HOME'. Default: ROS_HOME, ``str``
         :param launch_prefix: launch command/arguments to prepend to node executable arguments, ``str``
         :param required: node is required to stay running (launch fails if node dies), ``bool``
@@ -485,8 +485,8 @@ class Node(object):
             raise ValueError("package must be non-empty")
         if not len(self.type.strip()):
             raise ValueError("type must be non-empty")
-        if not self.output in ['log', 'screen', None]:
-            raise ValueError("output must be one of 'log', 'screen'")
+        if not self.output in ['log', 'screen', 'both', None]:
+            raise ValueError("output must be one of 'log', 'screen' or 'both'")
         if not self.cwd in ['ROS_HOME', 'node', None]:
             raise ValueError("cwd must be one of 'ROS_HOME', 'node'")
         

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -424,13 +424,14 @@ class Node(object):
                  'remap_args', 'env_args',\
                  'process_name', 'output', 'cwd',
                  'launch_prefix', 'required',
-                 'filename']
+                 'filename', 'max_logfile_size', 'logfile_count']
 
     def __init__(self, package, node_type, name=None, namespace='/', \
                  machine_name=None, args='', \
                  respawn=False, respawn_delay=0.0, \
                  remap_args=None,env_args=None, output=None, cwd=None, \
-                 launch_prefix=None, required=False, filename='<unknown>'):
+                 launch_prefix=None, required=False, filename='<unknown>', \
+                 max_logfile_size=None, logfile_count=2):
         """
         :param package: node package name, ``str``
         :param node_type: node type, ``str``
@@ -448,7 +449,10 @@ class Node(object):
         :param launch_prefix: launch command/arguments to prepend to node executable arguments, ``str``
         :param required: node is required to stay running (launch fails if node dies), ``bool``
         :param filename: name of file Node was parsed from, ``str``
-
+        :param max_logfile_size: Maximum Size (in bytes) of the node's logfile. 0 mean unlimitted (default value),
+        this value must >= 0``int``
+        :param logfile_count: If max_logfile_size > 0, and logfile_count > 0, the system will save old log files by
+        appending the extensions .1, .2 etc... This is an optional parameter, default value is 2.
         :raises: :exc:`ValueError` If parameters do not validate
         """        
 
@@ -498,7 +502,14 @@ class Node(object):
         # configuration property
         self.machine = None
 
-        
+        # if we output to a screen, we ignore log file size arguments,
+        # else we must store them as a member value for using them later.
+        if self.output == 'screen':
+            self.max_logfile_size = None
+            self.logfile_count = None
+        else:
+            self.max_logfile_size = max_logfile_size
+            self.logfile_count = logfile_count
         
     def xmltype(self):
         return 'node'
@@ -523,6 +534,8 @@ class Node(object):
             ('name', name_str),
             ('launch-prefix', self.launch_prefix),
             ('required', self.required),
+            ('max_logfile_size', self.max_logfile_size),
+            ('logfile_count', self.logfile_count),
             ]
 
     #TODO: unify with to_remote_xml using a filter_fn

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -49,7 +49,10 @@ from roslaunch.core import *
 from roslaunch.node_args import create_local_process_args
 from roslaunch.pmon import Process, FatalProcessLaunch
 
+import threading
+
 import logging
+from logging import handlers
 _logger = logging.getLogger("roslaunch")
 
 _TIMEOUT_SIGINT  = 15.0 #seconds
@@ -137,7 +140,25 @@ def create_node_process(run_id, node, master_uri):
     _logger.debug('process[%s]: returning LocalProcess wrapper')
     return LocalProcess(run_id, node.package, name, args, env, log_output, \
             respawn=node.respawn, respawn_delay=node.respawn_delay, \
-            required=node.required, cwd=node.cwd)
+            required=node.required, cwd=node.cwd, max_logfile_size=node.max_logfile_size,\
+            logfile_count=node.logfile_count)
+
+
+def stream_reader(stream, level, logger, popen):
+    while popen.poll() is None:
+        line = stream.readline()
+        if level == logging.INFO:
+            logger.info('%s', line.strip())
+        elif level == logging.ERROR:
+            logger.error('%s', line.strip())
+    #logger.handlers[0].flush()
+    #logger.handlers[0].close()
+    # it may be some data into th stream at the end of the process :
+    #line = stream.read()
+    #if level == logging.INFO:
+    #    logger.info('%s', line.strip())
+    #elif level == logging.ERROR:
+    #     logger.error('%s', line.strip())
 
 
 class LocalProcess(Process):
@@ -147,7 +168,7 @@ class LocalProcess(Process):
     
     def __init__(self, run_id, package, name, args, env, log_output,
             respawn=False, respawn_delay=0.0, required=False, cwd=None,
-            is_node=True):
+            is_node=True, max_logfile_size=None, logfile_count=None):
         """
         @param run_id: unique run ID for this roslaunch. Used to
           generate log directory location. run_id may be None if this
@@ -171,6 +192,10 @@ class LocalProcess(Process):
         @type  cwd: str
         @param is_node: (optional) if True, process is ROS node and accepts ROS node command-line arguments. Default: True
         @type  is_node: False
+        @param max_logfile_size: (optional) Maximum Size (in bytes) of the node's logfile. 0 mean unlimitted (default value),
+        this value must >= 0``int``
+        @param logfile_count: (optional) If max_logfile_size > 0, and logfile_count > 0, the system will save old log
+        files by appending the extensions .1, .2 etc... This is an optional parameter, default value is 2.
         """    
         super(LocalProcess, self).__init__(package, name, args, env,
                 respawn, respawn_delay, required)
@@ -183,6 +208,10 @@ class LocalProcess(Process):
         self.log_dir = None
         self.pid = -1
         self.is_node = is_node
+        self.max_logfile_size = max_logfile_size
+        self.logfile_count = logfile_count
+        self.logThreadError = None
+        self.logThreadInfo = None
 
     # NOTE: in the future, info() is going to have to be sufficient for relaunching a process
     def get_info(self):
@@ -223,7 +252,7 @@ class LocalProcess(Process):
         # open in append mode
         # note: logfileerr: disabling in favor of stderr appearing in the console.
         # will likely reinstate once roserr/rosout is more properly used.
-        logfileout = logfileerr = None
+        logger = None
         logfname = self._log_name()
         
         if self.log_output:
@@ -232,9 +261,29 @@ class LocalProcess(Process):
                 mode = 'a'
             else:
                 mode = 'w'
-            logfileout = open(outf, mode)
+            # we create a logger, and we add to it :
+            logger = logging.getLogger(self.package+'.'+self.name)
+            # we don't propagate logs into the hierarchy. If we do it, when the node will be killed, some unwanted
+            # stdout will be displayed on the console...
+            logger.propagate = False
+            if self.max_logfile_size:
+                # a rotating file handler if max_logfile_size was set by user in XML launch file.
+                hdlr_out = logging.handlers.RotatingFileHandler(outf, mode=mode, maxBytes=self.max_logfile_size,
+                                                                backupCount=self.logfile_count)
+                if is_child_mode():
+                    hdlr_err = logging.handlers.RotatingFileHandler(errf, mode=mode, maxBytes=self.max_logfile_size,
+                                                                    backupCount=self.logfile_count)
+            else:
+                # a simple file to have the same behaviour as before :
+                hdlr_out = logging.FileHandler(outf, mode=mode)
+                if is_child_mode():
+                    hdlr_err = logging.FileHandler(errf, mode=mode)
+
+            hdlr_out.setLevel(logging.INFO)
+            logger.addHandler(hdlr_out)
             if is_child_mode():
-                logfileerr = open(errf, mode)
+                hdlr_err.setLevel(logging.ERROR)
+                logger.addHandler(hdlr_err)
 
         # #986: pass in logfile name to node
         node_log_file = log_dir
@@ -243,7 +292,7 @@ class LocalProcess(Process):
             self.args = _cleanup_remappings(self.args, '__log:=')
             self.args.append("__log:=%s"%os.path.join(log_dir, "%s.log"%(logfname)))
 
-        return logfileout, logfileerr
+        return logger
 
     def start(self):
         """
@@ -264,15 +313,24 @@ class LocalProcess(Process):
             full_env = self.env
 
             # _configure_logging() can mutate self.args
+            process_logger = None
             try:
-                logfileout, logfileerr = self._configure_logging()
+                process_logger = self._configure_logging()
             except Exception as e:
                 _logger.error(traceback.format_exc())
                 printerrlog("[%s] ERROR: unable to configure logging [%s]"%(self.name, str(e)))
                 # it's not safe to inherit from this process as
                 # rostest changes stdout to a StringIO, which is not a
                 # proper file.
+                #logfileout, logfileerr = subprocess.PIPE, subprocess.PIPE
+
+            #if we must log into a file (so process_logger exists) :
+            if process_logger:
+                # stdout and stderr must of subprocess must be redirected to a pipe
                 logfileout, logfileerr = subprocess.PIPE, subprocess.PIPE
+            else:
+                # stdout and stderr must of subprocess must be displayed on the screen.
+                logfileout, logfileerr = None, None
 
             if self.cwd == 'node':
                 cwd = os.path.dirname(self.args[0])
@@ -302,7 +360,18 @@ Please make sure that all the executables in this command exist and have
 executable permission. This is often caused by a bad launch-prefix."""%(e.strerror, ' '.join(self.args)))
                 else:
                     raise FatalProcessLaunch("unable to launch [%s]: %s"%(' '.join(self.args), e.strerror))
-                
+
+            # we redirect subprocess output to proper loglevel in a dedicated thread :
+            if logfileout:
+                self.logThreadInfo = threading.Thread(target=stream_reader, args=(self.popen.stdout, logging.INFO,
+                                                                                  process_logger, self.popen))
+                self.logThreadInfo.start()
+
+            if logfileerr:
+                self.logThreadError = threading.Thread(target=stream_reader, args=(self.popen.stderr, logging.ERROR,
+                                                                                   process_logger, self.popen))
+                self.logThreadError.start()
+
             self.started = True
             # Check that the process is either still running (poll returns
             # None) or that it completed successfully since when we
@@ -418,6 +487,12 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
                 _logger.info("process[%s]: SIGINT killed with return value %s", self.name, retcode)
                 
         finally:
+            if self.logThreadError:
+                _logger.info("process[%s]: Joining log Error thread")
+                self.logThreadError.join()
+            if self.logThreadInfo:
+                _logger.info("process[%s]: Joining log Info thread")
+                self.logThreadInfo.join()
             self.popen = None
 
     def _stop_win32(self, errors):
@@ -485,6 +560,10 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
             else:
                 _logger.info("process[%s]: SIGINT killed with return value %s", self.name, retcode)
         finally:
+            if self.logThreadError:
+                self.logThreadError.join()
+            if self.logThreadInfo:
+                self.logThreadInfo.join()
             self.popen = None
 			
     def stop(self, errors=None):

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -174,6 +174,24 @@ class TestXmlLoader(unittest.TestCase):
         except roslaunch.xmlloader.XmlParseException:
             pass
 
+    def test_thatLogFileSizeAreParsedAsPositiveInteger(self):
+        loader = roslaunch.xmlloader.XmlLoader()
+        mock = RosLaunchMock()
+        loader.load(os.path.join(self.xml_dir, 'test-valid-logfile-size.xml'), mock)
+        self.assert_(mock.nodes)
+        for node in mock.nodes:
+            if(node.name == 'toto_0'):
+                self.assert_(isinstance(node.max_logfile_size, int))
+                self.assertEqual(node.max_logfile_size, 0)
+            elif(node.name=='toto_1000'):
+                self.assert_(isinstance(node.max_logfile_size, int))
+                self.assertEqual(node.max_logfile_size, 1000)
+        try:
+            loader.load(os.path.join(self.xml_dir, 'test-invalid-logfile-size.xml'), mock)
+            self.fail('invalid log file size was not catched by positive_integer parser !')
+        except roslaunch.xmlloader.XmlParseException:
+            pass
+
     def test_params_invalid(self):
         tests = ['test-params-invalid-%s.xml'%i for i in range(1, 6)]
         loader = roslaunch.xmlloader.XmlLoader()

--- a/tools/roslaunch/test/xml/test-invalid-logfile-size.xml
+++ b/tools/roslaunch/test/xml/test-invalid-logfile-size.xml
@@ -1,0 +1,3 @@
+<launch>
+ <node pkg="toto" name="toto" type="toto" max_logfile_size="-1"/>
+</launch>

--- a/tools/roslaunch/test/xml/test-node-valid.xml
+++ b/tools/roslaunch/test/xml/test-node-valid.xml
@@ -77,6 +77,7 @@
   <!-- TODO remap args test -->
 
   <node name="n30" pkg="package" type="test_launch_prefix" launch-prefix="xterm -e gdb --args" />
-  
+ 
+  <node name="n31" pkg="package" type="logfile_size_tester" max_logfile_size="100" logfile_count="2"/>  
 </launch>
 

--- a/tools/roslaunch/test/xml/test-valid-logfile-size.xml
+++ b/tools/roslaunch/test/xml/test-valid-logfile-size.xml
@@ -1,0 +1,4 @@
+<launch>
+ <node type="toto" pkg="toto" name="toto_1000" max_logfile_size="1000"/>
+ <node type="toto" pkg="toto" name="toto_0" max_logfile_size="0"/>
+</launch>


### PR DESCRIPTION
I propose to patch roslaunch to redirect stdout and stderr of the node subprocess in a python.logging.logger object that will be created with a RotatingFile handler. Parameters of this RotatingFile handlers are "maximum log file size" and "maximum log file count". These paramters will be two new attributes of the XML tag "node".

As suggested by dirk-thomas, I did a "cherry pick" of the feature introduced by PR #418 . With the use of logging.logger this was quite fastforward...

As I said in the commit comments I added some unit test, and I did some tests by hand because I don't find an "easy" way to build automatic unit test for file Rotation etc ...

I am open to any comments ...
