### PR TITLE
support large bagfiles (>2GB) on 32-bit systems in rosbag_storage

### DIFF
--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -14,6 +14,9 @@ catkin_package(
   DEPENDS console_bridge Boost
 )
 
+# Support large bags (>2GB) on 32-bit systems
+add_definitions(-D_FILE_OFFSET_BITS=64)
+
 include_directories(include ${catkin_INCLUDE_DIRS} ${console_bridge_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${BZIP2_INCLUDE_DIR})
 add_definitions(${BZIP2_DEFINITIONS})
 


### PR DESCRIPTION
The "-D_FILE_OFFSET_BITS=64" is set for rosbag, but is missing for rosbag_storage (which was factored out after fuerte).
This should fix issue #464.
