### PR TITLE
Add option DEPENDENCIES to add_rostest function

### DIFF
--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -15,7 +15,7 @@ function(add_rostest file)
   set(ROSTEST_EXE "${rostest_DIR}/../../../@(CATKIN_GLOBAL_BIN_DESTINATION)/rostest")
 @[end if]@
 
-  cmake_parse_arguments(_rostest "" "WORKING_DIRECTORY" "ARGS" ${ARGN})
+  cmake_parse_arguments(_rostest "" "WORKING_DIRECTORY" "ARGS;DEPENDENCIES" ${ARGN})
 
   # Check that the file exists, #1621
   set(_file_name _file_name-NOTFOUND)
@@ -53,7 +53,7 @@ function(add_rostest file)
   get_filename_component(_output_name ${_testname} NAME_WE)
   set(_output_name "${_output_name}.xml")
   set(cmd "${ROSTEST_EXE} --pkgdir=${PROJECT_SOURCE_DIR} --package=${PROJECT_NAME} --results-filename ${_output_name} ${_file_name} ${_rostest_ARGS}")
-  catkin_run_tests_target("rostest" ${_testname} "rostest-${_output_name}" COMMAND ${cmd} WORKING_DIRECTORY ${_rostest_WORKING_DIRECTORY})
+  catkin_run_tests_target("rostest" ${_testname} "rostest-${_output_name}" COMMAND ${cmd} WORKING_DIRECTORY ${_rostest_WORKING_DIRECTORY} DEPENDENCIES ${_rostest_DEPENDENCIES})
 endfunction()
 
 #


### PR DESCRIPTION
Discussion about this feature initially started at #546.

@wjwwood suggested that `add_rostest()` should have an option so that it could store the automatically generated target in a variable, in order to be used later by the user. I found that this was not possible, because `add_rostest()` computes a fraction of the underlying target that finally gets created by a call to a helper function, `catkin_run_tests_target()`, provided by the `catkin` package. The `_testname` that `add_rostest()` computes gets prefixed by various strings like `run_tests_${PROJECT_NAME}` or `run_tests_${PROJECT_NAME}_${type}`, so `add_rostest()` has no information about the the underlying target.
- https://github.com/ros/ros_comm/blob/indigo-devel/tools/rostest/cmake/rostest-extras.cmake.em#L34-51
- https://github.com/ros/catkin/blob/indigo-devel/cmake/test/tests.cmake#L92-144

@dirk-thomas suggested that the user should be able to pass a custom target name. This could be done the same way `catkin_add_gtest()` does, defining a custom target (passed by the user) as the target of the executable and calling the `catkin_run_tests_target()` to produce a target in the form of `run_tests_${PROJECT_NAME}_${type}...`, defining dependencies between the two targets.

https://github.com/ros/catkin/blob/indigo-devel/cmake/test/gtest.cmake#L25-59

In order to implement either of the suggestions, we need to change the `catkin_run_tests_target()` function, since it actually deals with the underlying targets.

My suggestion is to just add an option to `add_rostest()` to define dependencies and pass these dependencies to `catkin_run_tests_target()` as it can define dependencies between the targets that creates and user defined dependencies.

I can not imagine a use case where the user would need the target name, except for defining dependencies, since there is no executable or library to build. In my mind this solution addresses all potential use cases but of course I could be wrong.

If that PR gets merged I could add some documentation [here](http://docs.ros.org/indigo/api/catkin/html/howto/format2/rostest_configuration.html). Also as a note, the option to define rostests with multiple arguments is not documented anywhere, so could add that too.
