### PR TITLE
Avoid adding a slash if left is empty.

### DIFF
--- a/clients/roscpp/src/libros/names.cpp
+++ b/clients/roscpp/src/libros/names.cpp
@@ -117,6 +117,8 @@ std::string clean(const std::string& name)
 
 std::string append(const std::string& left, const std::string& right)
 {
+  if (left.empty())
+    return right;
   return clean(left + "/" + right);
 }
 


### PR DESCRIPTION
If the string 'left' is empty ros::names::append() inserts a slash in front of 'right', which changes it to a global name. This behaviour is neither documented nor intuitive.
Returning 'right' unchanged in case 'left' is empty removes the issue.
The change may effect existing code, but only if someone knew the behaviour and used it intentionally (IMHO). Otherwise it leads to expected behaviour.
