### PR TITLE
roslz4: Improve py3k compatibility.

### DIFF
--- a/utilities/roslz4/src/roslz4/__init__.py
+++ b/utilities/roslz4/src/roslz4/__init__.py
@@ -30,7 +30,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from _roslz4 import *
+from ._roslz4 import *
 
 def compress(data):
     compressor = LZ4Compressor()


### PR DESCRIPTION
Use explicit relative import, py3.3 and 3.4 refuse to import roslz4 otherwise.

This is trivial and backward compatible, but unfortunately very far from being sufficient for py3k support. I'm filling this to avoid letting it rot in my local tree.
