### PR TITLE
fix error handling when publishing on Empty topic

### DIFF
--- a/clients/rospy/src/rospy/msg.py
+++ b/clients/rospy/src/rospy/msg.py
@@ -114,12 +114,12 @@ def args_kwds_to_message(data_class, args, kwds):
             # data_class has fields and that the type matches.  This
             # branch isn't necessary but provides more useful
             # information to users
-            elif isinstance(arg, genpy.Message) and \
-                    (len(data_class._slot_types) == 0 or \
-                         arg._type != data_class._slot_types[0]):
-                raise TypeError("expected [%s] but got [%s]"%(data_class._slot_types[0], arg._type))
-            else:
-                return data_class(*args)
+            elif isinstance(arg, genpy.Message):
+                if len(data_class._slot_types) == 0:
+                    raise TypeError("expected [] but got [%s]"%arg._type)
+                elif arg._type != data_class._slot_types[0]:
+                    raise TypeError("expected [%s] but got [%s]"%(data_class._slot_types[0], arg._type))
+            return data_class(*args)
         else:
             return data_class(*args)
 

--- a/test/test_rospy/CMakeLists.txt
+++ b/test/test_rospy/CMakeLists.txt
@@ -9,6 +9,7 @@ if(CATKIN_ENABLE_TESTING)
     FILES
     ArrayVal.msg
     EmbedTest.msg
+    Empty.msg
     Floats.msg
     HeaderHeaderVal.msg
     HeaderVal.msg

--- a/test/test_rospy/test/unit/test_rospy_msg.py
+++ b/test/test_rospy/test/unit/test_rospy_msg.py
@@ -49,7 +49,7 @@ class TestRospyMsg(unittest.TestCase):
     def test_args_kwds_to_message(self):
         import rospy
         from rospy.msg import args_kwds_to_message
-        from test_rospy.msg import Val
+        from test_rospy.msg import Val, Empty
         
         v = Val('hello world-1')
         d = args_kwds_to_message(Val, (v,), None)
@@ -63,6 +63,10 @@ class TestRospyMsg(unittest.TestCase):
         try:
             args_kwds_to_message(Val, 'hi', val='hello world-3')
             self.fail("should not allow args and kwds")
+        except TypeError: pass
+        try:
+            args_kwds_to_message(Empty, (Val('hola'),), None)
+            self.fail("should raise TypeError when publishing Val msg to Empty topic")
         except TypeError: pass
 
     def test_serialize_message(self):


### PR DESCRIPTION
The bug can be reproduced by the following script:

```
#!/usr/bin/env python
import rospy
from std_msgs.msg import Empty, String

rospy.init_node('talker')
pub = rospy.Publisher('chatter', Empty)
pub.publish(String("hello world"))       # bug!
```

This yielded an IndexError:

```
Traceback (most recent call last):
 File "./nodes/talker.py", line 7, in <module>
   pub.publish(String("hello world"))
 File "/home/martin/ros-hydro-ws/src/ros_comm/clients/rospy/src/rospy/topics.py", line 795, in publish
   data = args_kwds_to_message(self.data_class, args, kwds)
 File "/home/martin/ros-hydro-ws/src/ros_comm/clients/rospy/src/rospy/msg.py", line 120, in args_kwds_to_message
   raise TypeError("expected [%s] but got [%s]"%(data_class._slot_types[0], arg._type))
IndexError: list index out of range
```

With this commit, it correctly produces a TypeError:

```
Traceback (most recent call last):
 File "./nodes/talker.py", line 7, in <module>
   pub.publish(String("hello world"))
 File "/home/martin/ros-hydro-ws/src/ros_comm/clients/rospy/src/rospy/topics.py", line 795, in publish
   data = args_kwds_to_message(self.data_class, args, kwds)
 File "/home/martin/ros-hydro-ws/src/ros_comm/clients/rospy/src/rospy/msg.py", line 119, in args_kwds_to_message
   raise TypeError("expected [] but got [%s]"%arg._type)
TypeError: expected [] but got [std_msgs/String]
```

I also added a test that checks this.
