### PR TITLE
Pause playback for topics

### DIFF
--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -90,6 +90,7 @@ struct ROSBAG_DECL PlayerOptions
 
     std::vector<std::string> bags;
     std::vector<std::string> topics;
+    std::vector<std::string> pausetopics;
 };
 
 
@@ -182,6 +183,8 @@ private:
     ros::NodeHandle node_handle_;
 
     bool paused_;
+
+    bool pause_for_topics_;
 
     ros::WallTime paused_time_;
 

--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -90,7 +90,7 @@ struct ROSBAG_DECL PlayerOptions
 
     std::vector<std::string> bags;
     std::vector<std::string> topics;
-    std::vector<std::string> pausetopics;
+    std::vector<std::string> pause_topics;
 };
 
 

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -59,7 +59,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       ("keep-alive,k", "keep alive past end of bag (useful for publishing latched topics)")
       ("try-future-version", "still try to open a bag file, even if the version is not known to the player")
       ("topics", po::value< std::vector<std::string> >()->multitoken(), "topics to play back")
-      ("pausetopics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
+      ("pause_topics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
       ("bags", po::value< std::vector<std::string> >(), "bag files to play back from");
     
     po::positional_options_description p;
@@ -125,13 +125,13 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
         opts.topics.push_back(*i);
     }
 
-    if (vm.count("pausetopics"))
+    if (vm.count("pause_topics"))
     {
-      std::vector<std::string> pausetopics = vm["pausetopics"].as< std::vector<std::string> >();
-      for (std::vector<std::string>::iterator i = pausetopics.begin();
-           i != pausetopics.end();
+      std::vector<std::string> pause_topics = vm["pause_topics"].as< std::vector<std::string> >();
+      for (std::vector<std::string>::iterator i = pause_topics.begin();
+           i != pause_topics.end();
            i++)
-        opts.pausetopics.push_back(*i);
+        opts.pause_topics.push_back(*i);
     }
 
     if (vm.count("bags"))

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -59,6 +59,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       ("keep-alive,k", "keep alive past end of bag (useful for publishing latched topics)")
       ("try-future-version", "still try to open a bag file, even if the version is not known to the player")
       ("topics", po::value< std::vector<std::string> >()->multitoken(), "topics to play back")
+      ("pausetopics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
       ("bags", po::value< std::vector<std::string> >(), "bag files to play back from");
     
     po::positional_options_description p;
@@ -122,6 +123,15 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
            i != topics.end();
            i++)
         opts.topics.push_back(*i);
+    }
+
+    if (vm.count("pausetopics"))
+    {
+      std::vector<std::string> pausetopics = vm["pausetopics"].as< std::vector<std::string> >();
+      for (std::vector<std::string>::iterator i = pausetopics.begin();
+           i != pausetopics.end();
+           i++)
+        opts.pausetopics.push_back(*i);
     }
 
     if (vm.count("bags"))

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -310,8 +310,8 @@ void Player::doPublish(MessageInstance const& m) {
 
     if (pause_for_topics_)
     {
-        for (std::vector<std::string>::iterator i = options_.pausetopics.begin();
-             i != options_.pausetopics.end();
+        for (std::vector<std::string>::iterator i = options_.pause_topics.begin();
+             i != options_.pause_topics.end();
              i++)
         {
             if (topic == *i)

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -102,6 +102,7 @@ void PlayerOptions::check() {
 Player::Player(PlayerOptions const& options) :
     options_(options),
     paused_(false),
+    pause_for_topics_(false),
     terminal_modified_(false)
 {
 }
@@ -307,6 +308,20 @@ void Player::doPublish(MessageInstance const& m) {
       return;
     }
 
+    if (pause_for_topics_)
+    {
+        for (std::vector<std::string>::iterator i = options_.pausetopics.begin();
+             i != options_.pausetopics.end();
+             i++)
+        {
+            if (topic == *i)
+            {
+                paused_ = true;
+                paused_time_ = ros::WallTime::now();
+            }
+        }
+    }
+
     while ((paused_ || !time_publisher_.horizonReached()) && node_handle_.ok())
     {
         bool charsleftorpaused = true;
@@ -346,6 +361,9 @@ void Player::doPublish(MessageInstance const& m) {
                     printTime();
                     return;
                 }
+                break;
+            case 't':
+                pause_for_topics_ = !pause_for_topics_;
                 break;
             case EOF:
                 if (paused_)

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -171,6 +171,18 @@ def handle_topics(option, opt_str, value, parser):
     del parser.rargs[:len(topics)]
 
 
+def handle_pausetopics(option, opt_str, value, parser):
+    pausetopics = []
+    for arg in parser.rargs:
+        if arg[:2] == "--" and len(arg) > 2:
+            break
+        if arg[:1] == "-" and len(arg) > 1:
+            break
+        pausetopics.append(arg)
+    parser.values.pausetopics.extend(pausetopics)
+    del parser.rargs[:len(pausetopics)]
+
+
 def play_cmd(argv):
     parser = optparse.OptionParser(usage="rosbag play BAGFILE1 [BAGFILE2 BAGFILE3 ...]",
                                    description="Play back the contents of one or more bag files in a time-synchronized fashion.")
@@ -189,6 +201,7 @@ def play_cmd(argv):
     parser.add_option("-k", "--keep-alive",   dest="keep_alive", default=False, action="store_true", help="keep alive past end of bag (useful for publishing latched topics)")
     parser.add_option("--try-future-version", dest="try_future", default=False, action="store_true", help="still try to open a bag file, even if the version number is not known to the player")
     parser.add_option("--topics", dest="topics", default=[],  callback=handle_topics, action="callback", help="topics to play back")
+    parser.add_option("--pausetopics", dest="pausetopics", default=[],  callback=handle_pausetopics, action="callback", help="topics to pause on during playback")
     parser.add_option("--bags",  help="bags files to play back from")
 
     (options, args) = parser.parse_args(argv)
@@ -221,7 +234,13 @@ def play_cmd(argv):
         cmd.extend(['--skip-empty', str(options.skip_empty)])
 
     if options.topics:
-        cmd.extend(['--topics'] + options.topics + ['--bags'])
+        cmd.extend(['--topics'] + options.topics)
+
+    if options.pausetopics:
+        cmd.extend(['--pausetopics'] + options.pausetopics)
+
+    if options.bags:
+        cmd.extend(["--bags", str(options.bags)])
 
     cmd.extend(args)
     # Better way of handling it than os.execv

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -171,16 +171,16 @@ def handle_topics(option, opt_str, value, parser):
     del parser.rargs[:len(topics)]
 
 
-def handle_pausetopics(option, opt_str, value, parser):
-    pausetopics = []
+def handle_pause_topics(option, opt_str, value, parser):
+    pause_topics = []
     for arg in parser.rargs:
         if arg[:2] == "--" and len(arg) > 2:
             break
         if arg[:1] == "-" and len(arg) > 1:
             break
-        pausetopics.append(arg)
-    parser.values.pausetopics.extend(pausetopics)
-    del parser.rargs[:len(pausetopics)]
+        pause_topics.append(arg)
+    parser.values.pause_topics.extend(pause_topics)
+    del parser.rargs[:len(pause_topics)]
 
 
 def play_cmd(argv):
@@ -201,7 +201,7 @@ def play_cmd(argv):
     parser.add_option("-k", "--keep-alive",   dest="keep_alive", default=False, action="store_true", help="keep alive past end of bag (useful for publishing latched topics)")
     parser.add_option("--try-future-version", dest="try_future", default=False, action="store_true", help="still try to open a bag file, even if the version number is not known to the player")
     parser.add_option("--topics", dest="topics", default=[],  callback=handle_topics, action="callback", help="topics to play back")
-    parser.add_option("--pausetopics", dest="pausetopics", default=[],  callback=handle_pausetopics, action="callback", help="topics to pause on during playback")
+    parser.add_option("--pause_topics", dest="pause_topics", default=[],  callback=handle_pause_topics, action="callback", help="topics to pause on during playback")
     parser.add_option("--bags",  help="bags files to play back from")
 
     (options, args) = parser.parse_args(argv)
@@ -236,8 +236,8 @@ def play_cmd(argv):
     if options.topics:
         cmd.extend(['--topics'] + options.topics)
 
-    if options.pausetopics:
-        cmd.extend(['--pausetopics'] + options.pausetopics)
+    if options.pause_topics:
+        cmd.extend(['--pause_topics'] + options.pause_topics)
 
     if options.bags:
         cmd.extend(["--bags", str(options.bags)])


### PR DESCRIPTION
Added support for pausing when specified topics are about to be published. Can be turned on and off during playback.

It would be a nice feature of rosbag play if you had the ability to pause when specific topics are published. This way you could let a bag run until a particular sensor reading occurs and then see what the immediate effect of that data is on the rest of the system.
