### PR TITLE
Introduce auto-reconnect logic for persistent services that lose connection

### DIFF
--- a/clients/roscpp/src/libros/service_client.cpp
+++ b/clients/roscpp/src/libros/service_client.cpp
@@ -210,4 +210,24 @@ std::string ServiceClient::getService()
   return "";
 }
 
+bool ServiceClient::tryToReconnect(ros::Duration timeout) {
+  if (impl_)
+  {
+    // wait for service to become availabile and reconnect
+    waitForExistence(timeout);
+    if (exists())
+    {
+      impl_->server_link_ = ServiceManager::instance()->createServiceServerLink(impl_->name_, impl_->persistent_, impl_->service_md5sum_, impl_->service_md5sum_, impl_->header_values_);
+
+      // make sure we have a connection
+      if (isValid())
+      {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 }


### PR DESCRIPTION
Allows users to pass an optional two flags to have persistent services automatically attempt to reconnect. Default behavior remains unchanged.

See https://github.com/ros/ros_comm/issues/416
