### PR TITLE
Add rosconsole command to change logger levels from command line

### DIFF
--- a/tools/rosconsole/CMakeLists.txt
+++ b/tools/rosconsole/CMakeLists.txt
@@ -121,3 +121,8 @@ if(CATKIN_ENABLE_TESTING)
     target_link_libraries(${PROJECT_NAME}-thread_test ${PROJECT_NAME})
   endif()
 endif()
+
+catkin_python_setup()
+
+catkin_install_python(PROGRAMS scripts/rosconsole
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/tools/rosconsole/CMakeLists.txt
+++ b/tools/rosconsole/CMakeLists.txt
@@ -123,6 +123,3 @@ if(CATKIN_ENABLE_TESTING)
 endif()
 
 catkin_python_setup()
-
-catkin_install_python(PROGRAMS scripts/rosconsole
-  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/tools/rosconsole/scripts/rosconsole
+++ b/tools/rosconsole/scripts/rosconsole
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+import rosconsole
+rosconsole.main()

--- a/tools/rosconsole/setup.py
+++ b/tools/rosconsole/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['rosconsole'],
+    package_dir={'': 'src'},
+    scripts=['scripts/rosconsole'],
+    requires=['genmsg', 'genpy', 'roslib', 'rospkg']
+)
+
+setup(**d)

--- a/tools/rosconsole/src/rosconsole/__init__.py
+++ b/tools/rosconsole/src/rosconsole/__init__.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 
-# make sure we aren't using floor division
-from __future__ import division, print_function
-
 NAME = 'rosconsole'
 
 import os

--- a/tools/rosconsole/src/rosconsole/__init__.py
+++ b/tools/rosconsole/src/rosconsole/__init__.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+
+# make sure we aren't using floor division
+from __future__ import division, print_function
+
+NAME = 'rosconsole'
+
+import os
+import sys
+import socket
+
+from .logger_level_service_caller import LoggerLevelServiceCaller, ROSConsoleException
+
+import rosgraph
+import rospy
+
+def error(status, msg):
+    sys.stderr.write("%s: error: %s\n" % (NAME, msg))
+    sys.exit(status)
+
+def _get_cmd_list_optparse(args):
+    from optparse import OptionParser
+
+    usage = "usage: %prog list <node>\n"
+    parser = OptionParser(usage=usage, prog=NAME)
+
+    return parser
+
+def _rosconsole_cmd_list(argv):
+
+    args = argv[2:]
+    parser = _get_cmd_list_optparse(args)
+    (options, args) = parser.parse_args(args)
+
+    if not args:
+        parser.error("you must specify a node to list loggers")
+    elif len(args) > 1:
+        parser.error("you may only specify one node to list")
+
+    logger_level = LoggerLevelServiceCaller()
+
+    loggers = logger_level.get_loggers(args[0])
+
+    output = '\n'.join(loggers)
+    print(output)
+
+def _get_cmd_set_optparse(args):
+    from optparse import OptionParser
+
+    usage = "usage: %prog get <node> <logger> <level>\n"
+    usage += "\n <level> must be one of [" + ', '.join(LoggerLevelServiceCaller().get_levels()) + "]"
+    parser = OptionParser(usage=usage, prog=NAME)
+
+    return parser
+
+def _rosconsole_cmd_set(argv):
+
+    args = argv[2:]
+    parser = _get_cmd_set_optparse(args)
+    (options, args) = parser.parse_args(args)
+
+    if len(args) < 3:
+        parser.error("you must specify a node, a logger and a level")
+
+    logger_level = LoggerLevelServiceCaller()
+
+    loggers = logger_level.get_loggers(args[0])
+
+    if args[1] not in logger_level._current_levels:
+        error(2, "node " + args[0]+ " does not contain logger " + args[1])
+
+    if args[2] not in map(str.lower, logger_level.get_levels()):
+        parser.error("invalid level")
+
+    logger_level.send_logger_change_message(args[0], args[1], args[2])
+
+def _get_cmd_get_optparse(args):
+    from optparse import OptionParser
+
+    usage = "usage: %prog get <node> <logger>\n"
+    parser = OptionParser(usage=usage, prog=NAME)
+
+    return parser
+
+def _rosconsole_cmd_get(argv):
+
+    args = argv[2:]
+    parser = _get_cmd_get_optparse(args)
+    (options, args) = parser.parse_args(args)
+
+    if len(args) < 2:
+        parser.error("you must specify a node and a logger")
+
+    logger_level = LoggerLevelServiceCaller()
+
+    loggers = logger_level.get_loggers(args[0])
+
+    if args[1] not in logger_level._current_levels:
+        error(2, "node " + args[0]+ " does not contain logger " + args[1])
+
+    print(logger_level._current_levels[args[1]])
+
+
+def _fullusage():
+    print("""rosconsole is a command-line tool for configuring the logger level of ROS nodes.
+
+Commands:
+\trosconsole get\tdisplay level for a logger
+\trosconsole list\tlist loggers for a node
+\trosconsole set\tset level for a logger
+
+Type rosconsole <command> -h for more detailed usage, e.g. 'rosconsole list -h'
+""")
+    sys.exit(getattr(os, 'EX_USAGE', 1))
+
+def main(argv=None):
+    if argv is None:
+        argv=sys.argv
+    # filter out remapping arguments in case we are being invoked via roslaunch
+    argv = rospy.myargv(argv)
+
+    # process argv
+    if len(argv) == 1:
+        _fullusage()
+
+    try:
+        command = argv[1]
+        if command == 'get':
+            _rosconsole_cmd_get(argv)
+        elif command == 'list':
+            _rosconsole_cmd_list(argv)
+        elif command == 'set':
+            _rosconsole_cmd_set(argv)
+        else:
+            _fullusage()
+    except socket.error as e:
+        error(1, "Network communication failed. Most likely failed to communicate with master.\n")
+    except rosgraph.MasterException as e:
+        # mainly for invalid master URI/rosgraph.masterapi
+        error(1, str(e))
+    except ROSConsoleException as e:
+        error(1, str(e))
+    except KeyboardInterrupt: pass
+    except rospy.ROSInterruptException: pass

--- a/tools/rosconsole/src/rosconsole/__init__.py
+++ b/tools/rosconsole/src/rosconsole/__init__.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python
 
-NAME = 'rosconsole'
-
 import os
 import sys
 import socket
 
-from .logger_level_service_caller import LoggerLevelServiceCaller, ROSConsoleException
-
-import rosgraph
 import rospy
+import rosgraph
+
+from .logger_level_service_caller import LoggerLevelServiceCaller
+from .logger_level_service_caller import ROSConsoleException
+
+NAME = 'rosconsole'
+
 
 def error(status, msg):
     sys.stderr.write("%s: error: %s\n" % (NAME, msg))
     sys.exit(status)
+
 
 def _get_cmd_list_optparse(args):
     from optparse import OptionParser
@@ -22,6 +25,7 @@ def _get_cmd_list_optparse(args):
     parser = OptionParser(usage=usage, prog=NAME)
 
     return parser
+
 
 def _rosconsole_cmd_list(argv):
 
@@ -41,14 +45,17 @@ def _rosconsole_cmd_list(argv):
     output = '\n'.join(loggers)
     print(output)
 
+
 def _get_cmd_set_optparse(args):
     from optparse import OptionParser
 
     usage = "usage: %prog get <node> <logger> <level>\n"
-    usage += "\n <level> must be one of [" + ', '.join(LoggerLevelServiceCaller().get_levels()) + "]"
+    levels = ', '.join(LoggerLevelServiceCaller().get_levels())
+    usage += "\n <level> must be one of [" + levels + "]"
     parser = OptionParser(usage=usage, prog=NAME)
 
     return parser
+
 
 def _rosconsole_cmd_set(argv):
 
@@ -64,12 +71,13 @@ def _rosconsole_cmd_set(argv):
     loggers = logger_level.get_loggers(args[0])
 
     if args[1] not in logger_level._current_levels:
-        error(2, "node " + args[0]+ " does not contain logger " + args[1])
+        error(2, "node " + args[0] + " does not contain logger " + args[1])
 
     if args[2] not in map(str.lower, logger_level.get_levels()):
         parser.error("invalid level")
 
     logger_level.send_logger_change_message(args[0], args[1], args[2])
+
 
 def _get_cmd_get_optparse(args):
     from optparse import OptionParser
@@ -78,6 +86,7 @@ def _get_cmd_get_optparse(args):
     parser = OptionParser(usage=usage, prog=NAME)
 
     return parser
+
 
 def _rosconsole_cmd_get(argv):
 
@@ -93,7 +102,7 @@ def _rosconsole_cmd_get(argv):
     loggers = logger_level.get_loggers(args[0])
 
     if args[1] not in logger_level._current_levels:
-        error(2, "node " + args[0]+ " does not contain logger " + args[1])
+        error(2, "node " + args[0] + " does not contain logger " + args[1])
 
     print(logger_level._current_levels[args[1]])
 
@@ -110,9 +119,10 @@ Type rosconsole <command> -h for more detailed usage, e.g. 'rosconsole list -h'
 """)
     sys.exit(getattr(os, 'EX_USAGE', 1))
 
+
 def main(argv=None):
     if argv is None:
-        argv=sys.argv
+        argv = sys.argv
 
     argv = rospy.myargv(argv)
 
@@ -137,5 +147,7 @@ def main(argv=None):
         error(1, str(e))
     except ROSConsoleException as e:
         error(1, str(e))
-    except KeyboardInterrupt: pass
-    except rospy.ROSInterruptException: pass
+    except KeyboardInterrupt:
+        pass
+    except rospy.ROSInterruptException:
+        pass

--- a/tools/rosconsole/src/rosconsole/__init__.py
+++ b/tools/rosconsole/src/rosconsole/__init__.py
@@ -113,7 +113,7 @@ Type rosconsole <command> -h for more detailed usage, e.g. 'rosconsole list -h'
 def main(argv=None):
     if argv is None:
         argv=sys.argv
-    # filter out remapping arguments in case we are being invoked via roslaunch
+
     argv = rospy.myargv(argv)
 
     # process argv

--- a/tools/rosconsole/src/rosconsole/logger_level_service_caller.py
+++ b/tools/rosconsole/src/rosconsole/logger_level_service_caller.py
@@ -82,7 +82,7 @@ class LoggerLevelServiceCaller(object):
         try:
             service = rosservice.get_service_class_by_name(servicename)
         except rosservice.ROSServiceException as e:
-            raise ROSConsoleException("node %s doesn't exist or doesn't support logger query" % node)
+            raise ROSConsoleException("node %s doesn't exist or doesn't support query" % node)
 
         request = service._request_class()
         proxy = rospy.ServiceProxy(str(servicename), service)
@@ -105,7 +105,7 @@ class LoggerLevelServiceCaller(object):
         :param logger: name of the logger to change, ''str''
         :param level: name of the level to change, ''str''
         :returns: True if the response is valid, ''bool''
-        :returns: False if the request raises an exception or would not change the cached state, ''bool''
+        :returns: False if the request raises an exception or would not change the state, ''bool''
         """
         servicename = node + '/set_logger_level'
         if self._current_levels[logger].lower() == level.lower():

--- a/tools/rosconsole/src/rosconsole/logger_level_service_caller.py
+++ b/tools/rosconsole/src/rosconsole/logger_level_service_caller.py
@@ -1,0 +1,125 @@
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2012, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rosnode
+import rospy
+import rosservice
+
+
+class ROSConsoleException(Exception):
+    """
+    Base exception class of rosconsole-related errors
+    """
+    pass
+
+
+class LoggerLevelServiceCaller(object):
+    """
+    Handles service calls for getting lists of nodes and loggers
+    Also handles sending requests to change logger levels
+    """
+    def __init__(self):
+        pass
+
+    def get_levels(self):
+        return ['Debug', 'Info', 'Warn', 'Error', 'Fatal']
+
+    def get_loggers(self, node):
+        self._refresh_loggers(node)
+        return self._current_loggers
+
+    def get_node_names(self):
+        """
+        Gets a list of available services via a ros service call.
+        :returns: a list of all nodes that provide the set_logger_level service, ''list(str)''
+        """
+        set_logger_level_nodes = []
+        nodes = rosnode.get_node_names()
+        for name in sorted(nodes):
+            for service in rosservice.get_service_list(name):
+                if service == name + '/set_logger_level':
+                    set_logger_level_nodes.append(name)
+        return set_logger_level_nodes
+
+    def _refresh_loggers(self, node):
+        """
+        Stores a list of loggers available for passed in node
+        :param node: name of the node to query, ''str''
+        :raises: :exc:`ROSTopicException` If topic type cannot be determined or loaded
+        """
+        self._current_loggers = []
+        self._current_levels = {}
+        servicename = node + '/get_loggers'
+        try:
+            service = rosservice.get_service_class_by_name(servicename)
+        except rosservice.ROSServiceException as e:
+            raise ROSConsoleException("node %s doesn't exist or doesn't support logger query" % node)
+
+        request = service._request_class()
+        proxy = rospy.ServiceProxy(str(servicename), service)
+        try:
+            response = proxy(request)
+        except rospy.ServiceException as e:
+            raise ROSConsoleException("node %s logger request failed" % node)
+
+        if response._slot_types[0] == 'roscpp/Logger[]':
+            for logger in getattr(response, response.__slots__[0]):
+                self._current_loggers.append(getattr(logger, 'name'))
+                self._current_levels[getattr(logger, 'name')] = getattr(logger, 'level')
+        else:
+            raise ROSConsoleException(repr(response))
+
+    def send_logger_change_message(self, node, logger, level):
+        """
+        Sends a logger level change request to 'node'.
+        :param node: name of the node to chaange, ''str''
+        :param logger: name of the logger to change, ''str''
+        :param level: name of the level to change, ''str''
+        :returns: True if the response is valid, ''bool''
+        :returns: False if the request raises an exception or would not change the cached state, ''bool''
+        """
+        servicename = node + '/set_logger_level'
+        if self._current_levels[logger].lower() == level.lower():
+            return False
+
+        service = rosservice.get_service_class_by_name(servicename)
+        request = service._request_class()
+        setattr(request, 'logger', logger)
+        setattr(request, 'level', level)
+        proxy = rospy.ServiceProxy(str(servicename), service)
+        try:
+            proxy(request)
+            self._current_levels[logger] = level.upper()
+        except rospy.ServiceException as e:
+            raise ROSConsoleException("node %s logger request failed" % node)
+
+        return True


### PR DESCRIPTION
There is only the rqt_logger_level command for changing the logger
level for node. If you are doing remote work without an X session, you
have to send service commands directly or change the logger
configuration. This command line tool allows you to query and set the
logger level.
