### PR TITLE
Added a parameter to setPeriod to enable changing a Timer's period while taking into account the current cycle's elapsed time

### DIFF
--- a/clients/roscpp/include/ros/timer.h
+++ b/clients/roscpp/include/ros/timer.h
@@ -67,8 +67,9 @@ public:
 
   /**
    * \brief Set the period of this timer
+   * \param reset Whether to reset the timer. If true, timer ignores elapsed time and next cb occurs at now()+period
    */
-  void setPeriod(const Duration& period);
+  void setPeriod(const Duration& period, bool reset=true);
 
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void*)1 : (void*)0; }
@@ -99,7 +100,7 @@ private:
 
     bool isValid();
     bool hasPending();
-    void setPeriod(const Duration& period);
+    void setPeriod(const Duration& period, bool reset=true);
 
     void start();
     void stop();

--- a/clients/roscpp/include/ros/wall_timer.h
+++ b/clients/roscpp/include/ros/wall_timer.h
@@ -67,8 +67,9 @@ public:
 
   /**
    * \brief Set the period of this timer
+   * \param reset Whether to reset the timer. If true, timer ignores elapsed time and next cb occurs at now()+period
    */
-  void setPeriod(const WallDuration& period);
+  void setPeriod(const WallDuration& period, bool reset=true);
 
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void*)1 : (void*)0; }
@@ -99,7 +100,7 @@ private:
 
     bool isValid();
     bool hasPending();
-    void setPeriod(const WallDuration& period);
+    void setPeriod(const WallDuration& period, bool reset=true);
 
     void start();
     void stop();

--- a/clients/roscpp/src/libros/timer.cpp
+++ b/clients/roscpp/src/libros/timer.cpp
@@ -82,10 +82,10 @@ bool Timer::Impl::hasPending()
   return TimerManager<Time, Duration, TimerEvent>::global().hasPending(timer_handle_);
 }
 
-void Timer::Impl::setPeriod(const Duration& period)
+void Timer::Impl::setPeriod(const Duration& period, bool reset)
 {
   period_ = period;
-  TimerManager<Time, Duration, TimerEvent>::global().setPeriod(timer_handle_, period);
+  TimerManager<Time, Duration, TimerEvent>::global().setPeriod(timer_handle_, period, reset);
 }
 
 Timer::Timer(const TimerOptions& ops)
@@ -134,11 +134,11 @@ bool Timer::hasPending()
   return false;
 }
 
-void Timer::setPeriod(const Duration& period)
+void Timer::setPeriod(const Duration& period, bool reset)
 {
   if (impl_)
   {
-    impl_->setPeriod(period);
+    impl_->setPeriod(period, reset);
   }
 }
 

--- a/clients/roscpp/src/libros/wall_timer.cpp
+++ b/clients/roscpp/src/libros/wall_timer.cpp
@@ -81,10 +81,10 @@ bool WallTimer::Impl::hasPending()
   return TimerManager<WallTime, WallDuration, WallTimerEvent>::global().hasPending(timer_handle_);
 }
 
-void WallTimer::Impl::setPeriod(const WallDuration& period)
+void WallTimer::Impl::setPeriod(const WallDuration& period, bool reset)
 {
   period_ = period;
-  TimerManager<WallTime, WallDuration, WallTimerEvent>::global().setPeriod(timer_handle_, period);
+  TimerManager<WallTime, WallDuration, WallTimerEvent>::global().setPeriod(timer_handle_, period, reset);
 }
 
 
@@ -134,11 +134,11 @@ bool WallTimer::hasPending()
   return false;
 }
 
-void WallTimer::setPeriod(const WallDuration& period)
+void WallTimer::setPeriod(const WallDuration& period, bool reset)
 {
   if (impl_)
   {
-    impl_->setPeriod(period);
+    impl_->setPeriod(period, reset);
   }
 }
 


### PR DESCRIPTION
Currently, when you call setPeriod for a Timer, it starts the new cycle at the time setPeriod is called. So the next time the callback function is called will be current_elapsed_time + new_period_time. In my research project, it would be extremely useful for me to able to change the period for a Timer and have that change take effect on the immediate next cycle, rather than "starting over" each time I call setPeriod.

In terms of code changes, I just added a parameter to setPeriod to indicate whether or not you want the Timer to "reset". I put in a default value of true so any existing code using that function should not be affected.
