### PR TITLE
Alternative versions of ros::param::param and ros::NodeHandle::param with return value

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -95,7 +95,7 @@ namespace ros
      * ros::start() and sets the reference count to 1.
      *
      * \param ns Namespace for this NodeHandle.  This acts in addition to any namespace assigned to this ROS node.
-     *           eg. If the node's namespace is "/a" and the namespace passed in here is "b", all 
+     *           eg. If the node's namespace is "/a" and the namespace passed in here is "b", all
      *           topics/services/parameters will be prefixed with "/a/b/"
      * \param remappings Remappings for this NodeHandle.
      * \throws InvalidNameException if the namespace is not a valid graph resource name
@@ -135,7 +135,7 @@ namespace ros
      *
      * This version also lets you pass in name remappings that are specific to this NodeHandle
      *
-     * When a NodeHandle is copied, it inherits the namespace of the NodeHandle being copied, 
+     * When a NodeHandle is copied, it inherits the namespace of the NodeHandle being copied,
      * and increments the reference count of the global node state
      * by 1.
      * \throws InvalidNameException if the namespace is not a valid graph resource name
@@ -167,9 +167,9 @@ namespace ros
      * NodeHandle.  If none has been explicitly set, returns the global
      * queue.
      */
-    CallbackQueueInterface* getCallbackQueue() const 
-    { 
-      return callback_queue_ ? callback_queue_ : (CallbackQueueInterface*)getGlobalCallbackQueue(); 
+    CallbackQueueInterface* getCallbackQueue() const
+    {
+      return callback_queue_ ? callback_queue_ : (CallbackQueueInterface*)getGlobalCallbackQueue();
     }
 
     /**
@@ -267,7 +267,7 @@ namespace ros
      }
 
      MyClass my_class;
-     ros::Publisher pub = handle.advertise<std_msgs::Empty>("my_topic", 1, 
+     ros::Publisher pub = handle.advertise<std_msgs::Empty>("my_topic", 1,
                                                             boost::bind(&MyClass::connectCallback, my_class, _1));
      \endverbatim
      *
@@ -386,7 +386,7 @@ if (sub)  // Enter if subscriber is valid
    *  \throws ConflictingSubscriptionException If this node is already subscribed to the same topic with a different datatype
    */
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M), T* obj, 
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M), T* obj,
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -397,7 +397,7 @@ if (sub)  // Enter if subscriber is valid
 
   /// and the const version
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, T* obj, 
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, T* obj,
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -449,8 +449,8 @@ if (sub)  // Enter if subscriber is valid
    *  \throws ConflictingSubscriptionException If this node is already subscribed to the same topic with a different datatype
    */
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
-                       void(T::*fp)(const boost::shared_ptr<M const>&), T* obj, 
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size,
+                       void(T::*fp)(const boost::shared_ptr<M const>&), T* obj,
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -459,8 +459,8 @@ if (sub)  // Enter if subscriber is valid
     return subscribe(ops);
   }
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
-                       void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj, 
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size,
+                       void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj,
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -513,7 +513,7 @@ if (sub)  // Enter if subscriber is valid
    *  \throws ConflictingSubscriptionException If this node is already subscribed to the same topic with a different datatype
    */
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M), 
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M),
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -524,7 +524,7 @@ if (sub)  // Enter if subscriber is valid
   }
 
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, 
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const,
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -578,8 +578,8 @@ if (sub)  // Enter if subscriber is valid
    *  \throws ConflictingSubscriptionException If this node is already subscribed to the same topic with a different datatype
    */
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
-                       void(T::*fp)(const boost::shared_ptr<M const>&), 
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size,
+                       void(T::*fp)(const boost::shared_ptr<M const>&),
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -589,8 +589,8 @@ if (sub)  // Enter if subscriber is valid
     return subscribe(ops);
   }
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
-                       void(T::*fp)(const boost::shared_ptr<M const>&) const, 
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size,
+                       void(T::*fp)(const boost::shared_ptr<M const>&) const,
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -1129,7 +1129,7 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the service name begins with a tilde, or is an otherwise invalid graph resource name
    */
   template<class MReq, class MRes>
-  ServiceServer advertiseService(const std::string& service, const boost::function<bool(MReq&, MRes&)>& callback, 
+  ServiceServer advertiseService(const std::string& service, const boost::function<bool(MReq&, MRes&)>& callback,
                                  const VoidConstPtr& tracked_object = VoidConstPtr())
   {
     AdvertiseServiceOptions ops;
@@ -1174,7 +1174,7 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the service name begins with a tilde, or is an otherwise invalid graph resource name
    */
   template<class S>
-  ServiceServer advertiseService(const std::string& service, const boost::function<bool(S&)>& callback, 
+  ServiceServer advertiseService(const std::string& service, const boost::function<bool(S&)>& callback,
                                  const VoidConstPtr& tracked_object = VoidConstPtr())
   {
     AdvertiseServiceOptions ops;
@@ -1224,7 +1224,7 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the service name begins with a tilde, or is an otherwise invalid graph resource name
    */
   template<class MReq, class MRes>
-  ServiceClient serviceClient(const std::string& service_name, bool persistent = false, 
+  ServiceClient serviceClient(const std::string& service_name, bool persistent = false,
                               const M_string& header_values = M_string())
   {
     ServiceClientOptions ops;
@@ -1244,7 +1244,7 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the service name begins with a tilde, or is an otherwise invalid graph resource name
    */
   template<class Service>
-  ServiceClient serviceClient(const std::string& service_name, bool persistent = false, 
+  ServiceClient serviceClient(const std::string& service_name, bool persistent = false,
                               const M_string& header_values = M_string())
   {
     ServiceClientOptions ops;
@@ -1297,7 +1297,7 @@ if (service)  // Enter if advertised service is valid
    * \param autostart If true (default), return timer that is already started
    */
   template<class T>
-  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&) const, T* obj, 
+  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&) const, T* obj,
                     bool oneshot = false, bool autostart = true) const
   {
     return createTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
@@ -1317,7 +1317,7 @@ if (service)  // Enter if advertised service is valid
    * \param autostart If true (default), return timer that is already started
    */
   template<class T>
-  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), T* obj, 
+  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), T* obj,
                     bool oneshot = false, bool autostart = true) const
   {
     return createTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
@@ -1339,7 +1339,7 @@ if (service)  // Enter if advertised service is valid
    * \param autostart If true (default), return timer that is already started
    */
   template<class T>
-  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), const boost::shared_ptr<T>& obj, 
+  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), const boost::shared_ptr<T>& obj,
                     bool oneshot = false, bool autostart = true) const
   {
     TimerOptions ops(period, boost::bind(callback, obj.get(), _1), 0);
@@ -1394,7 +1394,7 @@ if (service)  // Enter if advertised service is valid
    * \param autostart If true (default), return timer that is already started
    */
   template<class T>
-  WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&), T* obj, 
+  WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&), T* obj,
                             bool oneshot = false, bool autostart = true) const
   {
     return createWallTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
@@ -1416,8 +1416,8 @@ if (service)  // Enter if advertised service is valid
    * \param oneshot If true, this timer will only fire once
    */
   template<class T>
-  WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&), 
-                            const boost::shared_ptr<T>& obj, 
+  WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&),
+                            const boost::shared_ptr<T>& obj,
                             bool oneshot = false, bool autostart = true) const
   {
     WallTimerOptions ops(period, boost::bind(callback, obj.get(), _1), 0);
@@ -1439,7 +1439,7 @@ if (service)  // Enter if advertised service is valid
    * \param callback The function to call
    * \param oneshot If true, this timer will only fire once
    */
-  WallTimer createWallTimer(WallDuration period, const WallTimerCallback& callback, 
+  WallTimer createWallTimer(WallDuration period, const WallTimerCallback& callback,
                             bool oneshot = false, bool autostart = true) const;
 
   /**
@@ -2018,6 +2018,32 @@ if (service)  // Enter if advertised service is valid
     }
 
     param_val = default_val;
+  }
+
+  /**
+   * \brief Return value from parameter server, or default if unavailable.
+   *
+   * This method tries to retrieve the indicated parameter value from the
+   * parameter server. If the parameter cannot be retrieved, \c default_val
+   * is returned instead.
+   *
+   * \param param_name The key to be searched on the parameter server.
+   *
+   * \param default_val Value to return if the server doesn't contain this
+   * parameter.
+   *
+   * \return The parameter value retrieved from the parameter server, or
+   * \c default_val if unavailable.
+   *
+   * \throws InvalidNameException If the parameter key begins with a tilde,
+   * or is an otherwise invalid graph resource name.
+   */
+  template<typename T>
+  T param(const std::string& param_name, const T& default_val)
+  {
+      T param_val;
+      param(param_name, param_val, default_val);
+      return param_val;
   }
 
   /**

--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -95,7 +95,7 @@ namespace ros
      * ros::start() and sets the reference count to 1.
      *
      * \param ns Namespace for this NodeHandle.  This acts in addition to any namespace assigned to this ROS node.
-     *           eg. If the node's namespace is "/a" and the namespace passed in here is "b", all
+     *           eg. If the node's namespace is "/a" and the namespace passed in here is "b", all 
      *           topics/services/parameters will be prefixed with "/a/b/"
      * \param remappings Remappings for this NodeHandle.
      * \throws InvalidNameException if the namespace is not a valid graph resource name
@@ -135,7 +135,7 @@ namespace ros
      *
      * This version also lets you pass in name remappings that are specific to this NodeHandle
      *
-     * When a NodeHandle is copied, it inherits the namespace of the NodeHandle being copied,
+     * When a NodeHandle is copied, it inherits the namespace of the NodeHandle being copied, 
      * and increments the reference count of the global node state
      * by 1.
      * \throws InvalidNameException if the namespace is not a valid graph resource name
@@ -167,9 +167,9 @@ namespace ros
      * NodeHandle.  If none has been explicitly set, returns the global
      * queue.
      */
-    CallbackQueueInterface* getCallbackQueue() const
-    {
-      return callback_queue_ ? callback_queue_ : (CallbackQueueInterface*)getGlobalCallbackQueue();
+    CallbackQueueInterface* getCallbackQueue() const 
+    { 
+      return callback_queue_ ? callback_queue_ : (CallbackQueueInterface*)getGlobalCallbackQueue(); 
     }
 
     /**
@@ -267,7 +267,7 @@ namespace ros
      }
 
      MyClass my_class;
-     ros::Publisher pub = handle.advertise<std_msgs::Empty>("my_topic", 1,
+     ros::Publisher pub = handle.advertise<std_msgs::Empty>("my_topic", 1, 
                                                             boost::bind(&MyClass::connectCallback, my_class, _1));
      \endverbatim
      *
@@ -386,7 +386,7 @@ if (sub)  // Enter if subscriber is valid
    *  \throws ConflictingSubscriptionException If this node is already subscribed to the same topic with a different datatype
    */
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M), T* obj,
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M), T* obj, 
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -397,7 +397,7 @@ if (sub)  // Enter if subscriber is valid
 
   /// and the const version
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, T* obj,
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, T* obj, 
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -449,8 +449,8 @@ if (sub)  // Enter if subscriber is valid
    *  \throws ConflictingSubscriptionException If this node is already subscribed to the same topic with a different datatype
    */
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size,
-                       void(T::*fp)(const boost::shared_ptr<M const>&), T* obj,
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
+                       void(T::*fp)(const boost::shared_ptr<M const>&), T* obj, 
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -459,8 +459,8 @@ if (sub)  // Enter if subscriber is valid
     return subscribe(ops);
   }
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size,
-                       void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj,
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
+                       void(T::*fp)(const boost::shared_ptr<M const>&) const, T* obj, 
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -513,7 +513,7 @@ if (sub)  // Enter if subscriber is valid
    *  \throws ConflictingSubscriptionException If this node is already subscribed to the same topic with a different datatype
    */
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M),
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M), 
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -524,7 +524,7 @@ if (sub)  // Enter if subscriber is valid
   }
 
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const,
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, void(T::*fp)(M) const, 
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -578,8 +578,8 @@ if (sub)  // Enter if subscriber is valid
    *  \throws ConflictingSubscriptionException If this node is already subscribed to the same topic with a different datatype
    */
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size,
-                       void(T::*fp)(const boost::shared_ptr<M const>&),
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
+                       void(T::*fp)(const boost::shared_ptr<M const>&), 
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -589,8 +589,8 @@ if (sub)  // Enter if subscriber is valid
     return subscribe(ops);
   }
   template<class M, class T>
-  Subscriber subscribe(const std::string& topic, uint32_t queue_size,
-                       void(T::*fp)(const boost::shared_ptr<M const>&) const,
+  Subscriber subscribe(const std::string& topic, uint32_t queue_size, 
+                       void(T::*fp)(const boost::shared_ptr<M const>&) const, 
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
@@ -1129,7 +1129,7 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the service name begins with a tilde, or is an otherwise invalid graph resource name
    */
   template<class MReq, class MRes>
-  ServiceServer advertiseService(const std::string& service, const boost::function<bool(MReq&, MRes&)>& callback,
+  ServiceServer advertiseService(const std::string& service, const boost::function<bool(MReq&, MRes&)>& callback, 
                                  const VoidConstPtr& tracked_object = VoidConstPtr())
   {
     AdvertiseServiceOptions ops;
@@ -1174,7 +1174,7 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the service name begins with a tilde, or is an otherwise invalid graph resource name
    */
   template<class S>
-  ServiceServer advertiseService(const std::string& service, const boost::function<bool(S&)>& callback,
+  ServiceServer advertiseService(const std::string& service, const boost::function<bool(S&)>& callback, 
                                  const VoidConstPtr& tracked_object = VoidConstPtr())
   {
     AdvertiseServiceOptions ops;
@@ -1224,7 +1224,7 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the service name begins with a tilde, or is an otherwise invalid graph resource name
    */
   template<class MReq, class MRes>
-  ServiceClient serviceClient(const std::string& service_name, bool persistent = false,
+  ServiceClient serviceClient(const std::string& service_name, bool persistent = false, 
                               const M_string& header_values = M_string())
   {
     ServiceClientOptions ops;
@@ -1244,7 +1244,7 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the service name begins with a tilde, or is an otherwise invalid graph resource name
    */
   template<class Service>
-  ServiceClient serviceClient(const std::string& service_name, bool persistent = false,
+  ServiceClient serviceClient(const std::string& service_name, bool persistent = false, 
                               const M_string& header_values = M_string())
   {
     ServiceClientOptions ops;
@@ -1297,7 +1297,7 @@ if (service)  // Enter if advertised service is valid
    * \param autostart If true (default), return timer that is already started
    */
   template<class T>
-  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&) const, T* obj,
+  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&) const, T* obj, 
                     bool oneshot = false, bool autostart = true) const
   {
     return createTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
@@ -1317,7 +1317,7 @@ if (service)  // Enter if advertised service is valid
    * \param autostart If true (default), return timer that is already started
    */
   template<class T>
-  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), T* obj,
+  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), T* obj, 
                     bool oneshot = false, bool autostart = true) const
   {
     return createTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
@@ -1339,7 +1339,7 @@ if (service)  // Enter if advertised service is valid
    * \param autostart If true (default), return timer that is already started
    */
   template<class T>
-  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), const boost::shared_ptr<T>& obj,
+  Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), const boost::shared_ptr<T>& obj, 
                     bool oneshot = false, bool autostart = true) const
   {
     TimerOptions ops(period, boost::bind(callback, obj.get(), _1), 0);
@@ -1394,7 +1394,7 @@ if (service)  // Enter if advertised service is valid
    * \param autostart If true (default), return timer that is already started
    */
   template<class T>
-  WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&), T* obj,
+  WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&), T* obj, 
                             bool oneshot = false, bool autostart = true) const
   {
     return createWallTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
@@ -1416,8 +1416,8 @@ if (service)  // Enter if advertised service is valid
    * \param oneshot If true, this timer will only fire once
    */
   template<class T>
-  WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&),
-                            const boost::shared_ptr<T>& obj,
+  WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&), 
+                            const boost::shared_ptr<T>& obj, 
                             bool oneshot = false, bool autostart = true) const
   {
     WallTimerOptions ops(period, boost::bind(callback, obj.get(), _1), 0);
@@ -1439,7 +1439,7 @@ if (service)  // Enter if advertised service is valid
    * \param callback The function to call
    * \param oneshot If true, this timer will only fire once
    */
-  WallTimer createWallTimer(WallDuration period, const WallTimerCallback& callback,
+  WallTimer createWallTimer(WallDuration period, const WallTimerCallback& callback, 
                             bool oneshot = false, bool autostart = true) const;
 
   /**

--- a/clients/roscpp/include/ros/param.h
+++ b/clients/roscpp/include/ros/param.h
@@ -610,6 +610,31 @@ void param(const std::string& param_name, T& param_val, const T& default_val)
   param_val = default_val;
 }
 
+/**
+ * \brief Return value from parameter server, or default if unavailable.
+ *
+ * This method tries to retrieve the indicated parameter value from the
+ * parameter server. If the parameter cannot be retrieved, \c default_val
+ * is returned instead.
+ *
+ * \param param_name The key to be searched on the parameter server.
+ *
+ * \param default_val Value to return if the server doesn't contain this
+ * parameter.
+ *
+ * \return The parameter value retrieved from the parameter server, or
+ * \c default_val if unavailable.
+ *
+ * \throws InvalidNameException If the key is not a valid graph resource name.
+ */
+template<typename T>
+T param(const std::string& param_name, const T& default_val)
+{
+  T param_val;
+  param(param_name, param_val, default_val);
+  return param_val;
+}
+
 } // namespace param
 
 } // namespace ros

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -533,14 +533,14 @@ TEST(Params, paramTemplateFunction)
   EXPECT_EQ( param::param<std::string>( "string", "" ), "test" );
   EXPECT_EQ( param::param<std::string>( "gnirts", "test" ), "test" );
 
-  EXPECT_TRUE( param::param<int>( "int", 0 ) == 10 );
-  EXPECT_TRUE( param::param<int>( "tni", 10 ) == 10 );
+  EXPECT_EQ( param::param<int>( "int", 0 ), 10 );
+  EXPECT_EQ( param::param<int>( "tni", 10 ), 10 );
 
   EXPECT_DOUBLE_EQ( param::param<double>( "double", 0.0 ), 10.5 );
   EXPECT_DOUBLE_EQ( param::param<double>( "elbuod", 10.5 ), 10.5 );
 
-  EXPECT_FALSE( param::param<bool>( "bool", true ) );
-  EXPECT_TRUE( param::param<bool>( "loob", true ) );
+  EXPECT_EQ( param::param<bool>( "bool", true ), false );
+  EXPECT_EQ( param::param<bool>( "loob", true ), true );
 }
 
 TEST(Params, paramNodeHandleTemplateFunction)
@@ -550,14 +550,14 @@ TEST(Params, paramNodeHandleTemplateFunction)
   EXPECT_EQ( nh.param<std::string>( "string", "" ), "test" );
   EXPECT_EQ( nh.param<std::string>( "gnirts", "test" ), "test" );
 
-  EXPECT_TRUE( nh.param<int>( "int", 0 ) == 10 );
-  EXPECT_TRUE( nh.param<int>( "tni", 10 ) == 10 );
+  EXPECT_EQ( nh.param<int>( "int", 0 ), 10 );
+  EXPECT_EQ( nh.param<int>( "tni", 10 ), 10 );
 
   EXPECT_DOUBLE_EQ( nh.param<double>( "double", 0.0 ), 10.5 );
   EXPECT_DOUBLE_EQ( nh.param<double>( "elbuod", 10.5 ), 10.5 );
 
-  EXPECT_FALSE( nh.param<bool>( "bool", true ) );
-  EXPECT_TRUE( nh.param<bool>( "loob", true ) );
+  EXPECT_EQ( nh.param<bool>( "bool", true ), false );
+  EXPECT_EQ( nh.param<bool>( "loob", true ), true );
 }
 
 int

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -530,8 +530,8 @@ TEST(Params, mapBoolParam)
 
 TEST(Params, paramTemplateFunction)
 {
-  EXPECT_TRUE( param::param<std::string>( "string", "" ) == "test" );
-  EXPECT_TRUE( param::param<std::string>( "gnirts", "test" ) == "test" );
+  EXPECT_EQ( param::param<std::string>( "string", "" ), "test" );
+  EXPECT_EQ( param::param<std::string>( "gnirts", "test" ), "test" );
 
   EXPECT_TRUE( param::param<int>( "int", 0 ) == 10 );
   EXPECT_TRUE( param::param<int>( "tni", 10 ) == 10 );

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -72,7 +72,7 @@ TEST(Params, setThenGetString)
   std::string param;
   ASSERT_TRUE( param::get( "test_set_param", param ) );
   ASSERT_STREQ( "asdf", param.c_str() );
-
+  
   XmlRpc::XmlRpcValue v;
   param::get("test_set_param", v);
   ASSERT_EQ(v.getType(), XmlRpc::XmlRpcValue::TypeString);

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -72,7 +72,7 @@ TEST(Params, setThenGetString)
   std::string param;
   ASSERT_TRUE( param::get( "test_set_param", param ) );
   ASSERT_STREQ( "asdf", param.c_str() );
-  
+
   XmlRpc::XmlRpcValue v;
   param::get("test_set_param", v);
   ASSERT_EQ(v.getType(), XmlRpc::XmlRpcValue::TypeString);
@@ -526,6 +526,38 @@ TEST(Params, mapBoolParam)
 
   ASSERT_EQ(map_b.size(), map_b2.size());
   ASSERT_TRUE(std::equal(map_b.begin(), map_b.end(), map_b2.begin()));
+}
+
+TEST(Params, paramTemplateFunction)
+{
+  EXPECT_TRUE( param::param<std::string>( "string", "" ) == "test" );
+  EXPECT_TRUE( param::param<std::string>( "gnirts", "test" ) == "test" );
+
+  EXPECT_TRUE( param::param<int>( "int", 0 ) == 10 );
+  EXPECT_TRUE( param::param<int>( "tni", 10 ) == 10 );
+
+  EXPECT_DOUBLE_EQ( param::param<double>( "double", 0.0 ), 10.5 );
+  EXPECT_DOUBLE_EQ( param::param<double>( "elbuod", 10.5 ), 10.5 );
+
+  EXPECT_FALSE( param::param<bool>( "bool", true ) );
+  EXPECT_TRUE( param::param<bool>( "loob", true ) );
+}
+
+TEST(Params, paramNodeHandleTemplateFunction)
+{
+  NodeHandle nh;
+
+  EXPECT_TRUE( nh.param<std::string>( "string", "" ) == "test" );
+  EXPECT_TRUE( nh.param<std::string>( "gnirts", "test" ) == "test" );
+
+  EXPECT_TRUE( nh.param<int>( "int", 0 ) == 10 );
+  EXPECT_TRUE( nh.param<int>( "tni", 10 ) == 10 );
+
+  EXPECT_DOUBLE_EQ( nh.param<double>( "double", 0.0 ), 10.5 );
+  EXPECT_DOUBLE_EQ( nh.param<double>( "elbuod", 10.5 ), 10.5 );
+
+  EXPECT_FALSE( nh.param<bool>( "bool", true ) );
+  EXPECT_TRUE( nh.param<bool>( "loob", true ) );
 }
 
 int

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -547,8 +547,8 @@ TEST(Params, paramNodeHandleTemplateFunction)
 {
   NodeHandle nh;
 
-  EXPECT_TRUE( nh.param<std::string>( "string", "" ) == "test" );
-  EXPECT_TRUE( nh.param<std::string>( "gnirts", "test" ) == "test" );
+  EXPECT_EQ( nh.param<std::string>( "string", "" ), "test" );
+  EXPECT_EQ( nh.param<std::string>( "gnirts", "test" ), "test" );
 
   EXPECT_TRUE( nh.param<int>( "int", 0 ) == 10 );
   EXPECT_TRUE( nh.param<int>( "tni", 10 ) == 10 );


### PR DESCRIPTION
(Note: my editor automatically removed a number of line-ending whistespaces in "node_handle.h". If this is a problem, feel free to reject this pull request, and I'll resubmit it with these changes rolled back.)

Template methods ros::param::param() and ros::NodeHandle::param() set a
variable either to the value of a parameter or, if not available, a predefined
default value. Often the variable is passed straight to a constructor or
function call and then disregarded.

The alternative versions of the param() methods introduced here enable
retrieving the result value from a function return, rather than through an
output variable. This makes possible to write more streamlined code.

For example, the code below:

```
std::string path;
std::string format;
double fps;

param("~path", path, "video.mpg");
param("~format", format, "MPEG");
param("~fps", fps, 30.0);

VideoRecorder recorder(path, format, fps);
```

Could be more succinctly written as:

```
VideoRecorder recorder(
    param<std::string>("~path", "video.mpg"),
    param<std::string>("~format", "MPEG"),
    param<double>("~fps", 30.0)
);
```

Or:

```
NodeHandle nh("~");

VideoRecorder recorder(
    nh.param<std::string>("path", "video.mpg"),
    nh.param<std::string>("format", "MPEG"),
    nh.param<double>("fps", 30.0)
);
```

Signed-off-by: Helio Perroni Filho xperroni@gmail.com
