### PR TITLE
Pause playback for topics

### DIFF
--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -90,6 +90,7 @@ struct ROSBAG_DECL PlayerOptions
 
     std::vector<std::string> bags;
     std::vector<std::string> topics;
+    std::vector<std::string> pause_topics;
 };
 
 
@@ -182,6 +183,8 @@ private:
     ros::NodeHandle node_handle_;
 
     bool paused_;
+
+    bool pause_for_topics_;
 
     ros::WallTime paused_time_;
 

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -59,7 +59,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       ("keep-alive,k", "keep alive past end of bag (useful for publishing latched topics)")
       ("try-future-version", "still try to open a bag file, even if the version is not known to the player")
       ("topics", po::value< std::vector<std::string> >()->multitoken(), "topics to play back")
-      ("pause_topics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
+      ("pause-topics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
       ("bags", po::value< std::vector<std::string> >(), "bag files to play back from");
     
     po::positional_options_description p;
@@ -125,9 +125,9 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
         opts.topics.push_back(*i);
     }
 
-    if (vm.count("pause_topics"))
+    if (vm.count("pause-topics"))
     {
-      std::vector<std::string> pause_topics = vm["pause_topics"].as< std::vector<std::string> >();
+      std::vector<std::string> pause_topics = vm["pause-topics"].as< std::vector<std::string> >();
       for (std::vector<std::string>::iterator i = pause_topics.begin();
            i != pause_topics.end();
            i++)
@@ -142,8 +142,9 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
            i++)
           opts.bags.push_back(*i);
     } else {
-      if (vm.count("topics"))
-        throw ros::Exception("When using --topics, --bags should be specified to list bags.");
+      if (vm.count("topics") || vm.count("pause-topics"))
+        throw ros::Exception("When using --topics or --pause-topics, --bags "
+          "should be specified to list bags.");
       throw ros::Exception("You must specify at least one bag to play back.");
     }
             

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -59,6 +59,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       ("keep-alive,k", "keep alive past end of bag (useful for publishing latched topics)")
       ("try-future-version", "still try to open a bag file, even if the version is not known to the player")
       ("topics", po::value< std::vector<std::string> >()->multitoken(), "topics to play back")
+      ("pause_topics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
       ("bags", po::value< std::vector<std::string> >(), "bag files to play back from");
     
     po::positional_options_description p;
@@ -122,6 +123,15 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
            i != topics.end();
            i++)
         opts.topics.push_back(*i);
+    }
+
+    if (vm.count("pause_topics"))
+    {
+      std::vector<std::string> pause_topics = vm["pause_topics"].as< std::vector<std::string> >();
+      for (std::vector<std::string>::iterator i = pause_topics.begin();
+           i != pause_topics.end();
+           i++)
+        opts.pause_topics.push_back(*i);
     }
 
     if (vm.count("bags"))

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -121,7 +121,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       std::vector<std::string> topics = vm["topics"].as< std::vector<std::string> >();
       for (std::vector<std::string>::iterator i = topics.begin();
            i != topics.end();
-           i++)
+           ++i)
         opts.topics.push_back(*i);
     }
 
@@ -130,7 +130,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       std::vector<std::string> pause_topics = vm["pause-topics"].as< std::vector<std::string> >();
       for (std::vector<std::string>::iterator i = pause_topics.begin();
            i != pause_topics.end();
-           i++)
+           ++i)
         opts.pause_topics.push_back(*i);
     }
 
@@ -139,7 +139,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       std::vector<std::string> bags = vm["bags"].as< std::vector<std::string> >();
       for (std::vector<std::string>::iterator i = bags.begin();
            i != bags.end();
-           i++)
+           ++i)
           opts.bags.push_back(*i);
     } else {
       if (vm.count("topics") || vm.count("pause-topics"))

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -121,7 +121,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       std::vector<std::string> topics = vm["topics"].as< std::vector<std::string> >();
       for (std::vector<std::string>::iterator i = topics.begin();
            i != topics.end();
-           ++i)
+           i++)
         opts.topics.push_back(*i);
     }
 
@@ -130,7 +130,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       std::vector<std::string> pause_topics = vm["pause-topics"].as< std::vector<std::string> >();
       for (std::vector<std::string>::iterator i = pause_topics.begin();
            i != pause_topics.end();
-           ++i)
+           i++)
         opts.pause_topics.push_back(*i);
     }
 
@@ -139,7 +139,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       std::vector<std::string> bags = vm["bags"].as< std::vector<std::string> >();
       for (std::vector<std::string>::iterator i = bags.begin();
            i != bags.end();
-           ++i)
+           i++)
           opts.bags.push_back(*i);
     } else {
       if (vm.count("topics") || vm.count("pause-topics"))

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -102,14 +102,11 @@ void PlayerOptions::check() {
 Player::Player(PlayerOptions const& options) :
     options_(options),
     paused_(false),
-    terminal_modified_(false)
-{
+    terminal_modified_(false),
     // If we were given a list of topics to pause on, then go into that mode
     // by default (it can be toggled later via 't' from the keyboard).
-    if (options_.pause_topics.size() > 0)
-        pause_for_topics_ = true;
-    else
-        pause_for_topics_ = false;
+    pause_for_topics_(options_.pause_topics.size() > 0)
+{
 }
 
 Player::~Player() {

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -317,7 +317,7 @@ void Player::doPublish(MessageInstance const& m) {
     {
         for (std::vector<std::string>::iterator i = options_.pause_topics.begin();
              i != options_.pause_topics.end();
-             i++)
+             ++i)
         {
             if (topic == *i)
             {
@@ -515,7 +515,7 @@ int Player::readCharFromStdin() {
         b = ReadConsoleInput(input_handle, input_record, input_size, &events);
         if (b)
         {
-            for (unsigned int i = 0; i < events; i++)
+            for (unsigned int i = 0; i < events; ++i)
             {
                 if (input_record[i].EventType & KEY_EVENT & input_record[i].Event.KeyEvent.bKeyDown)
                 {

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -102,9 +102,14 @@ void PlayerOptions::check() {
 Player::Player(PlayerOptions const& options) :
     options_(options),
     paused_(false),
-    pause_for_topics_(false),
     terminal_modified_(false)
 {
+    // If we were given a list of topics to pause on, then go into that mode
+    // by default (it can be toggled later via 't' from the keyboard).
+    if (options_.pause_topics.size() > 0)
+        pause_for_topics_ = true;
+    else
+        pause_for_topics_ = false;
 }
 
 Player::~Player() {

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -102,6 +102,7 @@ void PlayerOptions::check() {
 Player::Player(PlayerOptions const& options) :
     options_(options),
     paused_(false),
+    pause_for_topics_(false),
     terminal_modified_(false)
 {
 }
@@ -307,6 +308,20 @@ void Player::doPublish(MessageInstance const& m) {
       return;
     }
 
+    if (pause_for_topics_)
+    {
+        for (std::vector<std::string>::iterator i = options_.pause_topics.begin();
+             i != options_.pause_topics.end();
+             i++)
+        {
+            if (topic == *i)
+            {
+                paused_ = true;
+                paused_time_ = ros::WallTime::now();
+            }
+        }
+    }
+
     while ((paused_ || !time_publisher_.horizonReached()) && node_handle_.ok())
     {
         bool charsleftorpaused = true;
@@ -346,6 +361,9 @@ void Player::doPublish(MessageInstance const& m) {
                     printTime();
                     return;
                 }
+                break;
+            case 't':
+                pause_for_topics_ = !pause_for_topics_;
                 break;
             case EOF:
                 if (paused_)

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -172,6 +172,18 @@ def handle_topics(option, opt_str, value, parser):
     del parser.rargs[:len(topics)]
 
 
+def handle_pause_topics(option, opt_str, value, parser):
+    pause_topics = []
+    for arg in parser.rargs:
+        if arg[:2] == "--" and len(arg) > 2:
+            break
+        if arg[:1] == "-" and len(arg) > 1:
+            break
+        pause_topics.append(arg)
+    parser.values.pause_topics.extend(pause_topics)
+    del parser.rargs[:len(pause_topics)]
+
+
 def play_cmd(argv):
     parser = optparse.OptionParser(usage="rosbag play BAGFILE1 [BAGFILE2 BAGFILE3 ...]",
                                    description="Play back the contents of one or more bag files in a time-synchronized fashion.")
@@ -190,6 +202,7 @@ def play_cmd(argv):
     parser.add_option("-k", "--keep-alive",   dest="keep_alive", default=False, action="store_true", help="keep alive past end of bag (useful for publishing latched topics)")
     parser.add_option("--try-future-version", dest="try_future", default=False, action="store_true", help="still try to open a bag file, even if the version number is not known to the player")
     parser.add_option("--topics", dest="topics", default=[],  callback=handle_topics, action="callback", help="topics to play back")
+    parser.add_option("--pause_topics", dest="pause_topics", default=[],  callback=handle_pause_topics, action="callback", help="topics to pause on during playback")
     parser.add_option("--bags",  help="bags files to play back from")
 
     (options, args) = parser.parse_args(argv)
@@ -222,7 +235,13 @@ def play_cmd(argv):
         cmd.extend(['--skip-empty', str(options.skip_empty)])
 
     if options.topics:
-        cmd.extend(['--topics'] + options.topics + ['--bags'])
+        cmd.extend(['--topics'] + options.topics)
+
+    if options.pause_topics:
+        cmd.extend(['--pause_topics'] + options.pause_topics)
+
+    if options.bags:
+        cmd.extend(["--bags", str(options.bags)])
 
     cmd.extend(args)
     # Better way of handling it than os.execv

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -202,7 +202,7 @@ def play_cmd(argv):
     parser.add_option("-k", "--keep-alive",   dest="keep_alive", default=False, action="store_true", help="keep alive past end of bag (useful for publishing latched topics)")
     parser.add_option("--try-future-version", dest="try_future", default=False, action="store_true", help="still try to open a bag file, even if the version number is not known to the player")
     parser.add_option("--topics", dest="topics", default=[],  callback=handle_topics, action="callback", help="topics to play back")
-    parser.add_option("--pause_topics", dest="pause_topics", default=[],  callback=handle_pause_topics, action="callback", help="topics to pause on during playback")
+    parser.add_option("--pause-topics", dest="pause_topics", default=[],  callback=handle_pause_topics, action="callback", help="topics to pause on during playback")
     parser.add_option("--bags",  help="bags files to play back from")
 
     (options, args) = parser.parse_args(argv)
@@ -238,7 +238,7 @@ def play_cmd(argv):
         cmd.extend(['--topics'] + options.topics)
 
     if options.pause_topics:
-        cmd.extend(['--pause_topics'] + options.pause_topics)
+        cmd.extend(['--pause-topics'] + options.pause_topics)
 
     if options.bags:
         cmd.extend(["--bags", str(options.bags)])


### PR DESCRIPTION
This PR is a replacement for #569, targeting Indigo instead of Hydro.

It's @tdenewiler's patch, with a couple of my tweaks.  The only substantial change I made was to start in topic-pausing mode if `--pause-topics` is given at the command line, because I found that to be more intuitive (as opposed to requiring the user to hit `t` to go into that mode).

I tested with a few different cases, found it to work as advertised, and not to have any obvious side-effects.

To @dirk-thomas to approve and merge.
