### PR TITLE
Make roswtf to support IPv6 % symbols (issue #585)

### DIFF
--- a/utilities/roswtf/src/roswtf/network.py
+++ b/utilities/roswtf/src/roswtf/network.py
@@ -53,7 +53,11 @@ def ip_check(ctx):
 
     remote_ips = list(set(global_ips) - set(local_addrs))
     if remote_ips:
-        return "Local hostname [%s] resolves to [%s], which does not appear to be a local IP address %s."%(socket.gethostname(), ','.join(remote_ips), str(local_addrs))
+        retval = "Local hostname [%s] resolves to [%s], which does not appear to be a local IP address %s." % (socket.gethostname(), ','.join(remote_ips), str(local_addrs))
+        # IPv6 support % to denote zone/scope ids. The value is expanded
+        # in other functions, this is why we are using replace command in
+        # the return. For more info https://github.com/ros/ros_comm/pull/598
+        return retval.replace('%', '%%')
 
 # suggestion by mquigley based on laptop dhcp issues    
 def ros_hostname_check(ctx):


### PR DESCRIPTION
Patch provided by neurovertex in issue #585 

I was able to test it with my IPv4 setup and all seems to keep working. I was unable to recreate the issue though. I tried tricking my /etc/hosts with the IPv6 address but it did not work, probably some more configurations are needed.

In IPv6, % they can be used to determine the zone id in the form of:
`<address>%<zone_id>`

Please read http://tools.ietf.org/html/rfc4007 section 11 for more information.
