### PR TITLE
Fix roscpp crash in topic statistics

### DIFF
--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -158,3 +158,5 @@ add_rostest(launch/local_remappings.xml)
 add_rostest(launch/global_remappings.xml)
 add_rostest(launch/ns_node_remapping.xml)
 add_rostest(launch/search_param.xml)
+
+add_rostest(launch/stamped_topic_statistics_with_empty_timestamp.xml)

--- a/test/test_roscpp/test/launch/stamped_topic_statistics_with_empty_timestamp.xml
+++ b/test/test_roscpp/test/launch/stamped_topic_statistics_with_empty_timestamp.xml
@@ -1,0 +1,5 @@
+<launch>
+  <param name="enable_statistics" value="true" />
+  <test test-name="stamped_topic_statistics_with_empty_timestamp" pkg="test_roscpp" type="test_roscpp-stamped_topic_statistics_empty_timestamp"/>
+</launch>
+

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -198,6 +198,9 @@ add_executable(${PROJECT_NAME}-string_msg_expect EXCLUDE_FROM_ALL string_msg_exp
 target_link_libraries(${PROJECT_NAME}-string_msg_expect ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME}-string_msg_expect std_msgs_gencpp)
 
+add_executable(${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp EXCLUDE_FROM_ALL stamped_topic_statistics_empty_timestamp.cpp)
+target_link_libraries(${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+
 # The publisher and subscriber are compiled but not registered as a unit test
 # since the test execution requires a network connection which drops packages.
 # Call scripts/test_udp_with_dropped_packets.sh to run the test.
@@ -272,6 +275,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-string_msg_expect
     ${PROJECT_NAME}-publisher
     ${PROJECT_NAME}-subscriber
+    ${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp
   )
 endif()
 
@@ -334,3 +338,5 @@ add_dependencies(${PROJECT_NAME}-test_ns_node_remapping ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-test_search_param ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-left_right ${PROJECT_NAME}_gencpp)
 add_dependencies(${PROJECT_NAME}-string_msg_expect ${PROJECT_NAME}_gencpp)
+add_dependencies(${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp
+ ${PROJECT_NAME}_gencpp)

--- a/test/test_roscpp/test/src/stamped_topic_statistics_empty_timestamp.cpp
+++ b/test/test_roscpp/test/src/stamped_topic_statistics_empty_timestamp.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015, Eric Perko
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <ros/ros.h>
+
+#include <test_roscpp/TestWithHeader.h>
+
+void callback(const test_roscpp::TestWithHeaderConstPtr& msg)
+{
+  // No operation needed here
+}
+
+TEST(TopicStatistics, empty_timestamp_crash_check)
+{
+  ros::NodeHandle nh;
+
+  ros::Publisher pub = nh.advertise<test_roscpp::TestWithHeader>("test_with_empty_timestamp", 0);
+  ros::Subscriber sub = nh.subscribe("test_with_empty_timestamp", 0, callback);
+
+  ros::Time start = ros::Time::now();
+  ros::Duration time_to_publish(10.0);
+  while ( (ros::Time::now() - start) < time_to_publish )
+  {
+    test_roscpp::TestWithHeader msg;
+    msg.header.frame_id = "foo";
+    // Don't fill in timestamp so that it defaults to 0.0
+
+    pub.publish(msg);
+    ros::spinOnce();
+    ros::WallDuration(0.01).sleep();
+  }
+
+  SUCCEED();
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  ros::init(argc, argv, "stamped_topic_statistics_empty_timestamp");
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This includes @ericperko 's test from #556 with an alternative fix. While looking at the code for computing standard deviation with @dirk-thomas , we didn't like using `ros::Duration` as an intermediate type for this calculation. Instead, I use a `double` to compute variance then another `double` to compute the standard deviation. I then wrap the final conversion to `ros::Duration` in a `try`/`catch` block similar to the one in #556.

@ericperko how does this look?
