### PR TITLE
rostopic: handling multiple array index specifications

### DIFF
--- a/test/test_rostopic/CMakeLists.txt
+++ b/test/test_rostopic/CMakeLists.txt
@@ -8,10 +8,12 @@ if(CATKIN_ENABLE_TESTING)
   add_message_files(DIRECTORY msg
     FILES
     Arrays.msg
+    ArrayVal.msg
     Embed.msg
     Floats.msg
     Simple.msg
     TVals.msg
+    Val.msg
   )
   generate_messages(DEPENDENCIES std_msgs)
 endif()

--- a/test/test_rostopic/msg/ArrayVal.msg
+++ b/test/test_rostopic/msg/ArrayVal.msg
@@ -1,0 +1,1 @@
+Val[] vals

--- a/test/test_rostopic/msg/Val.msg
+++ b/test/test_rostopic/msg/Val.msg
@@ -1,0 +1,1 @@
+string val

--- a/test/test_rostopic/test/test_rostopic_unit.py
+++ b/test/test_rostopic/test/test_rostopic_unit.py
@@ -390,7 +390,7 @@ class TestRostopicUnit(unittest.TestCase):
         self.assertEquals(['seq', 'stamp'], list(f(m)))
 
     def test_slicing(self):
-        from test_rospy.msg import ArrayVal, Val
+        from test_rostopic.msg import ArrayVal, Val
         from rostopic import msgevalgen as f
 
         # prepare a sliceable msg
@@ -400,7 +400,7 @@ class TestRostopicUnit(unittest.TestCase):
 
         self.assertEqual(f(''), None)
         self.assertEqual(f('/'), None)
-        self.assertListEqual(f('/vals')(msg),    msg.vals)
+        self.assertListEqual(f('/vals')(msg), msg.vals)
         # first-level slicing
         self.assertListEqual(f('/vals[:]')(msg), msg.vals)
         self.assertListEqual(f('/vals[0:2]')(msg), msg.vals[0:2])

--- a/test/test_rostopic/test/test_rostopic_unit.py
+++ b/test/test_rostopic/test/test_rostopic_unit.py
@@ -388,3 +388,45 @@ class TestRostopicUnit(unittest.TestCase):
         self.assertEquals(['t', 'd'], list(f(m)))
         m = Header()
         self.assertEquals(['seq', 'stamp'], list(f(m)))
+
+    def test_slicing(self):
+        from test_rospy.msg import ArrayVal, Val
+        from rostopic import msgevalgen as f
+
+        # prepare a sliceable msg
+        msg = ArrayVal()
+        for v in ['ABCDEFG', 'abcdefg', '1234567', 'short']:
+            msg.vals.append(Val(val=v))
+
+        self.assertEqual(f(''), None)
+        self.assertEqual(f('/'), None)
+        self.assertListEqual(f('/vals')(msg),    msg.vals)
+        # first-level slicing
+        self.assertListEqual(f('/vals[:]')(msg), msg.vals)
+        self.assertListEqual(f('/vals[0:2]')(msg), msg.vals[0:2])
+        # element access
+        self.assertEqual(f('/vals[0]')(msg), msg.vals[0])
+        self.assertEqual(f('/vals[1]')(msg), msg.vals[1])
+        # element access continued
+        self.assertEqual(f('/vals[0]/val')(msg), msg.vals[0].val)
+        self.assertEqual(f('/vals[1]/val')(msg), msg.vals[1].val)
+        # second-level slicing
+        self.assertEqual(f('/vals[0]/val[:]')(msg), msg.vals[0].val)
+        self.assertEqual(f('/vals[0]/val[0:2]')(msg), msg.vals[0].val[0:2])
+        self.assertEqual(f('/vals[0]/val[:-3]')(msg), msg.vals[0].val[:-3])
+        self.assertEqual(f('/vals[0]/val[2]')(msg), msg.vals[0].val[2])
+        # first-level slicing + second-level access
+        self.assertListEqual(f('/vals[:3]/val[0]')(msg), ['A', 'a', '1'])
+        self.assertListEqual(f('/vals[:3]/val[0]')(msg), ['A', 'a', '1'])
+        self.assertListEqual(f('/vals[1:3]/val[0]')(msg), ['a', '1'])
+        self.assertListEqual(f('/vals[:]/val[-1]')(msg), ['G', 'g', '7', 't'])
+        # multiple slicing
+        self.assertListEqual(f('/vals[:3]/val[1:3]')(msg), ['BC', 'bc', '23'])
+        # out-of-range errors
+        self.assertEqual(f('/vals[5]/val')(msg), None)
+        self.assertListEqual(f('/vals[:]/val[6]')(msg), ['G', 'g', '7', None])
+        # invalid descriptions
+        self.assertEqual(f('/vals[:]/val[]'), None)
+        self.assertEqual(f('/unknown[:]/val[0]')(msg), None)
+        self.assertListEqual(f('/vals[:]/unknown[0]')(msg), [None, None, None, None])
+        self.assertEqual(f('/vals/unknown[0]')(msg), None)

--- a/test/test_rostopic/test/test_rostopic_unit.py
+++ b/test/test_rostopic/test/test_rostopic_unit.py
@@ -408,6 +408,7 @@ class TestRostopicUnit(unittest.TestCase):
         # element access
         self.assertEqual(f('/vals[0]')(msg), msg.vals[0])
         self.assertEqual(f('/vals[1]')(msg), msg.vals[1])
+        self.assertEqual(f('/vals[0'), None)
         # element access continued
         self.assertEqual(f('/vals[0]/val')(msg), msg.vals[0].val)
         self.assertEqual(f('/vals[1]/val')(msg), msg.vals[1].val)

--- a/test/test_rostopic/test/test_rostopic_unit.py
+++ b/test/test_rostopic/test/test_rostopic_unit.py
@@ -401,6 +401,7 @@ class TestRostopicUnit(unittest.TestCase):
         self.assertEqual(f(''), None)
         self.assertEqual(f('/'), None)
         self.assertListEqual(f('/vals')(msg), msg.vals)
+        self.assertListEqual(f('/vals/')(msg), msg.vals)
         # first-level slicing
         self.assertListEqual(f('/vals[:]')(msg), msg.vals)
         self.assertListEqual(f('/vals[0:2]')(msg), msg.vals[0:2])

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -311,7 +311,7 @@ def msgevalgen(pattern):
         else:
             evals.append((f, None))
 
-    def _msgeval(msg, evals):
+    def msgeval(msg, evals):
         for i, (field_name, slice_object) in enumerate(evals):
             try: # access field first
                 msg = getattr(msg, field_name)
@@ -331,13 +331,10 @@ def msgevalgen(pattern):
                 # in order to handle nested slices
                 if isinstance(msg, list):
                     rest = evals[i + 1:]
-                    return [_msgeval(m, rest) for m in msg]
+                    return [msgeval(m, rest) for m in msg]
         return msg
 
-    def msgeval(msg):
-        return _msgeval(msg, evals)
-
-    return msgeval if evals else None
+    return (lambda msg: msgeval(msg, evals)) if evals else None
 
 
 def _get_array_index_or_slice_object(index_string):

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -60,7 +60,7 @@ import genpy
 
 import roslib.message
 import rosgraph
-#TODO: lazy-import rospy or move rospy-dependent routines to separate location
+# TODO: lazy-import rospy or move rospy-dependent routines to separate location
 import rospy
 
 class ROSTopicException(Exception):
@@ -280,7 +280,7 @@ def _rostopic_bw(topic, window_size=-1):
     # we use a large buffer size as we don't know what sort of messages we're dealing with.
     # may parameterize this in the future
     sub = rospy.Subscriber(real_topic, rospy.AnyMsg, rt.callback)
-    print("subscribed to [%s]"%real_topic)
+    print("subscribed to [%s]" % real_topic)
     while not rospy.is_shutdown():
         _sleep(1.0)
         rt.print_bw()
@@ -292,7 +292,7 @@ def msgevalgen(pattern):
     :param pattern: subtopic, e.g. /x[2:]/y[:-1]/z, ``str``
     :returns: function that converts a message into the desired value, ``fn(Message) -> value``
     """
-    evals = [] # list of (field_name, slice_object) pairs
+    evals = []  # list of (field_name, slice_object) pairs
     fields = [f for f in pattern.split('/') if f]
     for f in fields:
         if '[' in f:
@@ -329,7 +329,7 @@ def msgevalgen(pattern):
                 # we need to recursively call msg_eval() with the rest of evals
                 # in order to handle nested slices
                 if isinstance(msg, list):
-                    rest = evals[i+1:]
+                    rest = evals[i + 1:]
                     return [_msgeval(m, rest) for m in msg]
         return msg
 
@@ -461,7 +461,7 @@ def get_topic_class(topic, blocking=False):
         return None, None, None
     msg_class = roslib.message.get_message_class(topic_type)
     if not msg_class:
-        raise ROSTopicException("Cannot load message class for [%s]. Are your messages built?"%topic_type)
+        raise ROSTopicException("Cannot load message class for [%s]. Are your messages built?" % topic_type)
     return msg_class, real_topic, msg_eval
 
 def _str_plot_fields(val, f, field_filter):
@@ -804,7 +804,7 @@ def _rostopic_echo(topic, callback_echo, bag_file=None, echo_all_topics=False):
                     if fields:
                         submsg_class = roslib.message.get_message_class(type_information.split('[')[0])
                         if not submsg_class:
-                            raise ROSTopicException("Cannot load message class for [%s]. Are your messages built?"%type_information)
+                            raise ROSTopicException("Cannot load message class for [%s]. Are your messages built?" % type_information)
 
         use_sim_time = rospy.get_param('/use_sim_time', False)
         sub = rospy.Subscriber(real_topic, msg_class, callback_echo.callback, {'topic': topic, 'type_information': type_information})

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -301,8 +301,8 @@ def msgevalgen(pattern):
             try:
                 array_index_or_slice_object = _get_array_index_or_slice_object(rest)
             except AssertionError as e:
-                sys.stderr.write("field '%s' has invalid slice argument '%s': %s\n"
-                                 % (field_name, rest, str(e)))
+                print("field '%s' has invalid slice argument '%s': %s"
+                      % (field_name, rest, str(e)), file=sys.stderr)
                 return None
             evals.append((field_name, array_index_or_slice_object))
         else:
@@ -315,14 +315,14 @@ def msgevalgen(pattern):
             try: # access field first
                 msg = getattr(msg, field_name)
             except AttributeError:
-                sys.stderr.write("no field named [%s]\n" % field_name)
+                print("no field named %s in %s" % (field_name, pattern), file=sys.stderr)
                 return None
 
             if slice_object is not None: # access slice
                 try:
                     msg = msg.__getitem__(slice_object)
                 except IndexError as e:
-                    sys.stderr.write("%s: %s\n" % (str(e), pattern))
+                    print("%s: %s" % (str(e), pattern), file=sys.stderr)
                     return None
 
                 # if a list is returned here (i.e. not only a single element accessed),

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -296,8 +296,8 @@ def msgevalgen(pattern):
     fields = [f for f in pattern.split('/') if f]
     for f in fields:
         if '[' in f:
-            field_name, rest = f.split('[')
-            rest = rest[:rest.find(']')]
+            field_name, rest = f.split('[', 1)
+            rest = rest[:-1]  # slice content, removing closing bracket
             try:
                 array_index_or_slice_object = _get_array_index_or_slice_object(rest)
             except AssertionError as e:
@@ -309,8 +309,6 @@ def msgevalgen(pattern):
             evals.append((f, None))
 
     def _msgeval(msg, evals):
-        if not evals:
-            return msg
         for i, (field_name, slice_object) in enumerate(evals):
             try: # access field first
                 msg = getattr(msg, field_name)

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -297,6 +297,9 @@ def msgevalgen(pattern):
     for f in fields:
         if '[' in f:
             field_name, rest = f.split('[', 1)
+            if rest[-1] != ']':
+                print("missing closing ']' in slice spec '%s'" % f, file=sys.stderr)
+                return None
             rest = rest[:-1]  # slice content, removing closing bracket
             try:
                 array_index_or_slice_object = _get_array_index_or_slice_object(rest)
@@ -800,7 +803,7 @@ def _rostopic_echo(topic, callback_echo, bag_file=None, echo_all_topics=False):
                     index = submsg_class.__slots__.index(field)
                     type_information = submsg_class._slot_types[index]
                     if fields:
-                        submsg_class = roslib.message.get_message_class(type_information.split('[')[0])
+                        submsg_class = roslib.message.get_message_class(type_information.split('[',1)[0])
                         if not submsg_class:
                             raise ROSTopicException("Cannot load message class for [%s]. Are your messages built?" % type_information)
 

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -322,7 +322,7 @@ def msgevalgen(pattern):
                 try:
                     msg = msg.__getitem__(slice_object)
                 except IndexError as e:
-                    sys.stdout.write("%s: %s\n" % (str(e), pattern))
+                    sys.stderr.write("%s: %s\n" % (str(e), pattern))
                     return None
 
                 # if a list is returned here (i.e. not only a single element accessed),

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -334,9 +334,13 @@ def msgevalgen(pattern):
                 sys.stdout.write("no field named [%s]\n"%pattern)
             return None
         if array_index_or_slice_object is not None:
-            value = value[array_index_or_slice_object]
-            if rec_msgeval is not None:
-                value = rec_msgeval(value)
+            try:
+                value = value[array_index_or_slice_object]
+                if rec_msgeval is not None:
+                    value = rec_msgeval(value)
+            except IndexError as e:
+                sys.stdout.write("%s: %s\n" % (str(e), pattern))
+                return None
         return value
     return msgeval
 


### PR DESCRIPTION
Please consider this patch that fixes an issue with multiple array index specifications for subfields in rostopic echo. E.g.
- `rostopic echo /tactile_mid_prox/sensors[1]/proximal[1]` failed with

> Topic name 'sensors[1]/proximal' contains '[' but does not end with ']'
- `rostopic echo /tactile_mid_prox/sensors[1]/proximal[1]` failed with

> Topic name 'sensors[1]/proximal[1]' contains invalid slice argument '1]/proximal[1': non-integer array index step '1]/proximal[1'

The reason were two issues:
- First, in function `msgevalgen`, it was assumed that there will be only a single index specification. I fixed, that by a) looking for the matching closing bracket (instead of using the whole rest of the string) and b) calling `msgevalgen` recursively on trailing sub fields.
- Second, in function `_rostopic_echo` when extracting the `type_information` for the to-be-displayed values, a second index specification was not expected too, resulting in an attempt to extract the type for `subtype[]` instead of `subtype`. This was easily fixed, dropping the brackets.
