### PR TITLE
fix location of rostest result files

### DIFF
--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -52,7 +52,7 @@ function(add_rostest file)
 
   get_filename_component(_output_name ${_testname} NAME_WE)
   set(_output_name "${_output_name}.xml")
-  set(cmd "${ROSTEST_EXE} --pkgdir=${PROJECT_SOURCE_DIR} --package=${PROJECT_NAME} --results-filename ${_output_name} ${_file_name} ${_rostest_ARGS}")
+  set(cmd "${ROSTEST_EXE} --pkgdir=${PROJECT_SOURCE_DIR} --package=${PROJECT_NAME} --results-filename ${_output_name} --results-dir \"${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}\" ${_file_name} ${_rostest_ARGS}")
   catkin_run_tests_target("rostest" ${_testname} "rostest-${_output_name}" COMMAND ${cmd} WORKING_DIRECTORY ${_rostest_WORKING_DIRECTORY} DEPENDENCIES ${_rostest_DEPENDENCIES})
 endfunction()
 


### PR DESCRIPTION
This is necessary for `rostest`s to be placed in the "right" location after ros/catkin#728.

@esteve @tfoote @wjwwood Please review.
