### PR TITLE
Use slots for IndexEntry types

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -1475,6 +1475,8 @@ class _ChunkHeader(object):
             return 'compression: %s, size: %d, uncompressed: %d' % (self.compression, self.compressed_size, self.uncompressed_size)
 
 class ComparableMixin(object):
+    __slots__ = []
+
     def _compare(self, other, method):
         try:
             return method(self._cmpkey(), other._cmpkey())
@@ -1502,6 +1504,8 @@ class ComparableMixin(object):
         return self._compare(other, lambda s, o: s != o)
 
 class _IndexEntry(ComparableMixin):
+    __slots__ = ['time']
+
     def __init__(self, time):
         self.time = time
 
@@ -1509,6 +1513,8 @@ class _IndexEntry(ComparableMixin):
         return self.time
 
 class _IndexEntry102(_IndexEntry):
+    __slots__ = ['offset']
+
     def __init__(self, time, offset):
         self.time   = time
         self.offset = offset
@@ -1521,6 +1527,8 @@ class _IndexEntry102(_IndexEntry):
         return '%d.%d: %d' % (self.time.secs, self.time.nsecs, self.offset)
 
 class _IndexEntry200(_IndexEntry):
+    __slots__ = ['chunk_pos', 'offset']
+
     def __init__(self, time, chunk_pos, offset):
         self.time      = time
         self.chunk_pos = chunk_pos


### PR DESCRIPTION
This PR adds `__slots__` to frequently used Python classes.

Rosbag was using a lot of memory when I was trying to transform a bag.  I did a quick heap profile with heapy to figure out why, and here's what I found:

```
Partition of a set of 1369283 objects. Total size = 116324360 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0 227676  17 63749280  55  63749280  55 dict of rosbag.bag._IndexEntry200
     1 227676  17 18214080  16  81963360  70 rospy.rostime.Time
     2 684156  50 16419744  14  98383104  85 int
     3 227676  17 14571264  13 112954368  97 rosbag.bag._IndexEntry200
     4     11   0  2650880   2 115605248  99 str
     5    409   0   420952   0 116026200 100 dict (no owner)
     6    396   0   110880   0 116137080 100 dict of rosbag.bag._ChunkHeader
     7    396   0   110880   0 116247960 100 dict of rosbag.bag._ChunkInfo
     8    396   0    25344   0 116273304 100 rosbag.bag._ChunkHeader
     9    396   0    25344   0 116298648 100 rosbag.bag._ChunkInfo
```

The `dict of rosbag.bag._IndexEntry200` is the dict that holds the instance variables for `_IndexEntry200`.  If we add `__slots__` declarations to the class, then these no longer get created.

In my case, memory usage dropped by around 66%.
