### PR TITLE
Arg port number for rostest

### DIFF
--- a/tools/rostest/src/rostest/rostest_main.py
+++ b/tools/rostest/src/rostest/rostest_main.py
@@ -98,6 +98,8 @@ def rostestmain():
     parser.add_option("--results-base-dir", metavar="RESULTS_BASE_DIR",
                       help="The base directory of the test results. The test result file is " +
                            "created in a subfolder name PKG_DIR.")
+    parser.add_option("--port", metavar="PORT",
+                      help="ROS Master port number (default: random unused port)")
     (options, args) = parser.parse_args()
     try:
         args = roslaunch.rlutil.resolve_launch_arguments(args)
@@ -147,7 +149,7 @@ def rostestmain():
         parser.error("test file is invalid. Generated failure case result file in %s"%results_file)
         
     try:
-        testCase = rostest.runner.createUnitTest(pkg, test_file)
+        testCase = rostest.runner.createUnitTest(pkg, test_file, port=options.port)
         suite = unittest.TestLoader().loadTestsFromTestCase(testCase)
 
         if options.text_mode:

--- a/tools/rostest/src/rostest/rostest_parent.py
+++ b/tools/rostest/src/rostest/rostest_parent.py
@@ -53,7 +53,7 @@ class ROSTestLaunchParent(roslaunch.parent.ROSLaunchParent):
             raise Exception("config not initialized")
         # we generate a run_id for each test
         run_id = roslaunch.core.generate_run_id()
-        super(ROSTestLaunchParent, self).__init__(run_id, roslaunch_files, is_core=False, is_rostest=True)
+        super(ROSTestLaunchParent, self).__init__(run_id, roslaunch_files, is_core=False, is_rostest=True, port=port)
         self.config = config
         self.port = port
         self.master = None

--- a/tools/rostest/src/rostest/runner.py
+++ b/tools/rostest/src/rostest/runner.py
@@ -190,7 +190,9 @@ def setUp(self):
     # new test_parent for each run. we are a bit inefficient as it would be possible to
     # reuse the roslaunch base infrastructure for each test, but the roslaunch code
     # is not abstracted well enough yet
-    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file])
+
+    # As long as passed here the port num can be specified.
+    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file], port=self.config.master.get_port())
     
     printlog("setup[%s] run_id[%s] starting", self.test_file, self.test_parent.run_id)
 
@@ -212,7 +214,7 @@ def tearDown(self):
         
     printlog("rostest teardown %s complete", self.test_file)
     
-def createUnitTest(pkg, test_file):
+def createUnitTest(pkg, test_file, port=None):
     """
     Unit test factory. Constructs a unittest class based on the roslaunch
 
@@ -220,9 +222,11 @@ def createUnitTest(pkg, test_file):
     @type  pkg: str
     @param test_file: rostest filename
     @type  test_file: str
+    @param port: ROS Master port to run a test at
+    @type  port: int
     """
     # parse the config to find the test files
-    config = roslaunch.parent.load_config_default([test_file], None)
+    config = roslaunch.parent.load_config_default([test_file], port)
 
     # pass in config to class as a property so that test_parent can be initialized
     classdict = { 'setUp': setUp, 'tearDown': tearDown, 'config': config,


### PR DESCRIPTION
Mentioned in http://answers.ros.org/question/208361/port-to-connect-to-rostest-rosmaster-after-indigo/?answer=208387#post-id-208387

With this PR, you can specify the port number of the `rostest`. E.g.,

```
term-1$ rostest leap_motion test_leap_motion.test --port 22423

term-2$ ROS_MASTER_URI=http://tork-kudu1:22423 rosparam get /sender_freq/freq
0.1
```

Drawback:
- Apparently this only works with a single test case. So I don't know if we want to merge this as it is. 
- I've tried to add test files for this too which I couldn't get working.
