### PR TITLE
fix using callback info reference instead of copy

### DIFF
--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -359,7 +359,7 @@ CallbackQueue::CallOneResult CallbackQueue::callOneCB(TLS* tls)
   ROS_ASSERT(!tls->callbacks.empty());
   ROS_ASSERT(tls->cb_it != tls->callbacks.end());
 
-  CallbackInfo info = *tls->cb_it;
+  CallbackInfo& info = *tls->cb_it;
   CallbackInterfacePtr& cb = info.callback;
 
   IDInfoPtr id_info = getIDInfo(info.removal_id);


### PR DESCRIPTION
Addresses a problem mentioned in #577. It is not yet clear if that actually solves the problem completely though.
