### PR TITLE
Fix for #616 (Transport tcp deadlock)

### DIFF
--- a/clients/roscpp/include/ros/transport/transport_tcp.h
+++ b/clients/roscpp/include/ros/transport/transport_tcp.h
@@ -141,6 +141,16 @@ private:
 
   socket_fd_t sock_;
   bool closed_;
+
+  /**
+   * This mutex protects the closed_ property and is also held while
+   * close() is running. Please refer to close() to find out when you need
+   * to hold it.
+   *
+   * @note It is *not* allowed to hold this mutex while calling callbacks, since
+   *   those are typically higher-level functions. Calling those with held
+   *   mutexes might lead to deadlocks.
+   **/
   boost::recursive_mutex close_mutex_;
 
   bool expecting_read_;


### PR DESCRIPTION
This is a quick fix for #616. I wrote this on-the-fly, so please check that I interpreted the function of the `close_mutex_` correctly.

It also makes a lot of the `TransportTCP` methods thread-safe. I don't know if that is necessary, since I don't understand all call chains in roscpp...

This has been running here for three days without the deadlocks occuring (which usually happen a few times per day).
