### PR TITLE
Proposed solution for issue 621

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -1589,6 +1589,17 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
    */
   bool getParam(const std::string& key, double& d) const;
+  /** \brief Get a float value from the parameter server.
+   *
+   * If you want to provide a default value in case the key does not exist use param().
+   *
+   * \param key The key to be used in the parameter server's dictionary
+   * \param[out] f Storage for the retrieved value.
+   *
+   * \return true if the parameter value was retrieved, false otherwise
+   * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
+   */
+  bool getParam(const std::string& key, float& f) const;
   /** \brief Get an integer value from the parameter server.
    *
    * If you want to provide a default value in case the key does not exist use param().

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -607,6 +607,14 @@ bool NodeHandle::getParam(const std::string& key, double& d) const
   return param::get(resolveName(key), d);
 }
 
+bool NodeHandle::getParam(const std::string& key, float& f) const
+{
+  double d = 0.0;
+  const bool ret = getParam(key,d);
+  if (ret) f = static_cast<float>(d);
+  return ret;
+}
+
 bool NodeHandle::getParam(const std::string& key, int& i) const
 {
   return param::get(resolveName(key), i);


### PR DESCRIPTION
This small changeset extends the syntactic sugar provided for retrieving collections to the retrieval of single float values, allowing them to be retrieved from NodeHandle objects via a dedicated getParam overload.
