### PR TITLE
rostopic: catch some more error conditions in array index specifications

### DIFF
--- a/test/test_rostopic/test/test_rostopic_unit.py
+++ b/test/test_rostopic/test/test_rostopic_unit.py
@@ -408,6 +408,8 @@ class TestRostopicUnit(unittest.TestCase):
         # element access
         self.assertEqual(f('/vals[0]')(msg), msg.vals[0])
         self.assertEqual(f('/vals[1]')(msg), msg.vals[1])
+        self.assertEqual(f('/vals['), None)
+        self.assertEqual(f('/vals[]'), None)
         self.assertEqual(f('/vals[0'), None)
         # element access continued
         self.assertEqual(f('/vals[0]/val')(msg), msg.vals[0].val)

--- a/test/test_rostopic/test/test_rostopic_unit.py
+++ b/test/test_rostopic/test/test_rostopic_unit.py
@@ -414,6 +414,9 @@ class TestRostopicUnit(unittest.TestCase):
         # element access continued
         self.assertEqual(f('/vals[0]/val')(msg), msg.vals[0].val)
         self.assertEqual(f('/vals[1]/val')(msg), msg.vals[1].val)
+        self.assertEqual(f('/vals[/val'), None)
+        self.assertEqual(f('/vals[]/val'), None)
+        self.assertEqual(f('/vals[0/val'), None)
         # second-level slicing
         self.assertEqual(f('/vals[0]/val[:]')(msg), msg.vals[0].val)
         self.assertEqual(f('/vals[0]/val[0:2]')(msg), msg.vals[0].val[0:2])

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -297,7 +297,7 @@ def msgevalgen(pattern):
     for f in fields:
         if '[' in f:
             field_name, rest = f.split('[', 1)
-            if not rest or rest[-1] != ']':
+            if not rest.endswith(']'):
                 print("missing closing ']' in slice spec '%s'" % f, file=sys.stderr)
                 return None
             rest = rest[:-1]  # slice content, removing closing bracket

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -297,7 +297,7 @@ def msgevalgen(pattern):
     for f in fields:
         if '[' in f:
             field_name, rest = f.split('[', 1)
-            if rest[-1] != ']':
+            if not rest or rest[-1] != ']':
                 print("missing closing ']' in slice spec '%s'" % f, file=sys.stderr)
                 return None
             rest = rest[:-1]  # slice content, removing closing bracket


### PR DESCRIPTION
This is a follow up on #606. We have overlooked an error condition (namely array index spec with opening bracket but nothing more), which is now caught and covered in the unittest.
