### PR TITLE
add prefix option for prefixing output topics

### DIFF
--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -71,6 +71,7 @@ struct ROSBAG_DECL PlayerOptions
 
     void check();
 
+    std::string prefix;
     bool     quiet;
     bool     start_paused;
     bool     at_once;

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -44,7 +44,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
 
     desc.add_options()
       ("help,h", "produce help message")
-      ("prefix,q", po::value<std::string>()->default_value(""), "prefixes all output topics in replay")
+      ("prefix,p", po::value<std::string>()->default_value(""), "prefixes all output topics in replay")
       ("quiet,q", "suppress console output")
       ("immediate,i", "play back all messages without waiting")
       ("pause", "start in paused mode")
@@ -73,11 +73,9 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
     } catch (boost::program_options::invalid_command_line_syntax& e)
     {
-      std::cout << "error " << e.what() << std::endl;
       throw ros::Exception(e.what());
     }  catch (boost::program_options::unknown_option& e)
     {
-      std::cout << "error 2 " << e.what() << std::endl;
       throw ros::Exception(e.what());
     }
 
@@ -86,6 +84,8 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       exit(0);
     }
 
+    if (vm.count("prefix"))
+      opts.prefix = vm["prefix"].as<std::string>();
     if (vm.count("quiet"))
       opts.quiet = true;
     if (vm.count("immediate"))
@@ -118,11 +118,6 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       opts.loop = true;
     if (vm.count("keep-alive"))
       opts.keep_alive = true;
-
-    if (vm.count("prefix"))
-    {
-      opts.prefix = vm["prefix"].as<std::string>();
-    }
 
     if (vm.count("topics"))
     {

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -44,6 +44,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
 
     desc.add_options()
       ("help,h", "produce help message")
+      ("prefix,q", po::value<std::string>()->default_value(""), "prefixes all output topics in replay")
       ("quiet,q", "suppress console output")
       ("immediate,i", "play back all messages without waiting")
       ("pause", "start in paused mode")
@@ -61,20 +62,22 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       ("topics", po::value< std::vector<std::string> >()->multitoken(), "topics to play back")
       ("pause-topics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
       ("bags", po::value< std::vector<std::string> >(), "bag files to play back from");
-    
+
     po::positional_options_description p;
     p.add("bags", -1);
-    
+
     po::variables_map vm;
-    
-    try 
+
+    try
     {
       po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
     } catch (boost::program_options::invalid_command_line_syntax& e)
     {
+      std::cout << "error " << e.what() << std::endl;
       throw ros::Exception(e.what());
     }  catch (boost::program_options::unknown_option& e)
     {
+      std::cout << "error 2 " << e.what() << std::endl;
       throw ros::Exception(e.what());
     }
 
@@ -115,6 +118,12 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       opts.loop = true;
     if (vm.count("keep-alive"))
       opts.keep_alive = true;
+
+    if (vm.count("prefix"))
+    {
+      opts.prefix = vm["prefix"].as<std::string>();
+      std::cout << "PREFIX SET TO " << vm["prefix"].as<std::string>() << std::endl;
+    }
 
     if (vm.count("topics"))
     {

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -122,7 +122,6 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
     if (vm.count("prefix"))
     {
       opts.prefix = vm["prefix"].as<std::string>();
-      std::cout << "PREFIX SET TO " << vm["prefix"].as<std::string>() << std::endl;
     }
 
     if (vm.count("topics"))

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -57,7 +57,7 @@ using ros::Exception;
 namespace rosbag {
 
 ros::AdvertiseOptions createAdvertiseOptions(const ConnectionInfo* c, uint32_t queue_size, const std::string& prefix) {
-    ros::AdvertiseOptions opts(prefix+c->topic, queue_size, c->md5sum, c->datatype, c->msg_def);
+    ros::AdvertiseOptions opts(prefix + c->topic, queue_size, c->md5sum, c->datatype, c->msg_def);
     ros::M_string::const_iterator header_iter = c->header->find("latching");
     opts.latch = (header_iter != c->header->end() && header_iter->second == "1");
     return opts;
@@ -65,7 +65,7 @@ ros::AdvertiseOptions createAdvertiseOptions(const ConnectionInfo* c, uint32_t q
 
 
 ros::AdvertiseOptions createAdvertiseOptions(MessageInstance const& m, uint32_t queue_size, const std::string& prefix) {
-    return ros::AdvertiseOptions(prefix+m.getTopic(), queue_size, m.getMD5Sum(), m.getDataType(), m.getMessageDefinition());
+    return ros::AdvertiseOptions(prefix + m.getTopic(), queue_size, m.getMD5Sum(), m.getDataType(), m.getMessageDefinition());
 }
 
 // PlayerOptions
@@ -141,6 +141,11 @@ void Player::publish() {
     if (!node_handle_.ok())
       return;
 
+    if (!options_.prefix.empty())
+    {
+      ROS_INFO_STREAM("Using prefix " << options_.prefix << " for topics ");
+    }
+
     if (!options_.quiet)
       puts("");
 
@@ -176,11 +181,6 @@ void Player::publish() {
       std::cerr << "No messages to play on specified topics.  Exiting." << std::endl;
       ros::shutdown();
       return;
-    }
-
-    if (!options_.prefix.empty())
-    {
-      ROS_INFO_STREAM("Using prefix " << options_.prefix << " for topics ");
     }
 
     // Advertise all of our messages

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -178,6 +178,11 @@ void Player::publish() {
       return;
     }
 
+    if (!options_.prefix.empty())
+    {
+      ROS_INFO_STREAM("Using prefix " << options_.prefix << " for topics ");
+    }
+
     // Advertise all of our messages
     foreach(const ConnectionInfo* c, view.getConnections())
     {
@@ -189,12 +194,10 @@ void Player::publish() {
         map<string, ros::Publisher>::iterator pub_iter = publishers_.find(callerid_topic);
         if (pub_iter == publishers_.end()) {
 
-            std::cout << "using prefix " << options_.prefix << " for topic " << c->topic << std::endl;
             ros::AdvertiseOptions opts = createAdvertiseOptions(c, options_.queue_size, options_.prefix);
 
             ros::Publisher pub = node_handle_.advertise(opts);
             publishers_.insert(publishers_.begin(), pair<string, ros::Publisher>(callerid_topic, pub));
-            std::cout << "initialized publisher on topic " << pub.getTopic() << std::endl;
 
             pub_iter = publishers_.find(callerid_topic);
         }

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -187,8 +187,8 @@ def handle_pause_topics(option, opt_str, value, parser):
 def play_cmd(argv):
     parser = optparse.OptionParser(usage="rosbag play BAGFILE1 [BAGFILE2 BAGFILE3 ...]",
                                    description="Play back the contents of one or more bag files in a time-synchronized fashion.")
+    parser.add_option("-p", "--prefix",       dest="prefix",     default='',    type='str',          help="prefix all output topics")
     parser.add_option("-q", "--quiet",        dest="quiet",      default=False, action="store_true", help="suppress console output")
-    parser.add_option("-p", "--prefix",        dest="prefix",    default='',    type='str',          help="prefix all output topics")
     parser.add_option("-i", "--immediate",    dest="immediate",  default=False, action="store_true", help="play back all messages without waiting")
     parser.add_option("--pause",              dest="pause",      default=False, action="store_true", help="start in paused mode")
     parser.add_option("--queue",              dest="queue",      default=100,     type='int', action="store", help="use an outgoing queue of size SIZE (defaults to %default)", metavar="SIZE")
@@ -219,7 +219,8 @@ def play_cmd(argv):
         parser.error("Cannot find rosbag/play executable")
     cmd = [playpath[0]]
 
-    if options.prefix:     cmd.extend(["--prefix", str(options.prefix)])
+    if options.prefix:
+        cmd.extend(["--prefix", str(options.prefix)])
 
     if options.quiet:      cmd.extend(["--quiet"])
     if options.pause:      cmd.extend(["--pause"])
@@ -251,7 +252,6 @@ def play_cmd(argv):
         cmd.extend(['--bags'])
 
     cmd.extend(args)
-
     # Better way of handling it than os.execv
     # This makes sure stdin handles are passed to the process.
     subprocess.call(cmd)

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -252,10 +252,6 @@ def play_cmd(argv):
 
     cmd.extend(args)
 
-    print('hello world')
-    #print "command to forward"
-    for item in cmd:
-        print(item)
     # Better way of handling it than os.execv
     # This makes sure stdin handles are passed to the process.
     subprocess.call(cmd)

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -188,6 +188,7 @@ def play_cmd(argv):
     parser = optparse.OptionParser(usage="rosbag play BAGFILE1 [BAGFILE2 BAGFILE3 ...]",
                                    description="Play back the contents of one or more bag files in a time-synchronized fashion.")
     parser.add_option("-q", "--quiet",        dest="quiet",      default=False, action="store_true", help="suppress console output")
+    parser.add_option("-p", "--prefix",        dest="prefix",    default='',    type='str',          help="prefix all output topics")
     parser.add_option("-i", "--immediate",    dest="immediate",  default=False, action="store_true", help="play back all messages without waiting")
     parser.add_option("--pause",              dest="pause",      default=False, action="store_true", help="start in paused mode")
     parser.add_option("--queue",              dest="queue",      default=100,     type='int', action="store", help="use an outgoing queue of size SIZE (defaults to %default)", metavar="SIZE")
@@ -217,6 +218,8 @@ def play_cmd(argv):
     if not playpath:
         parser.error("Cannot find rosbag/play executable")
     cmd = [playpath[0]]
+
+    if options.prefix:     cmd.extend(["--prefix", str(options.prefix)])
 
     if options.quiet:      cmd.extend(["--quiet"])
     if options.pause:      cmd.extend(["--pause"])
@@ -248,6 +251,11 @@ def play_cmd(argv):
         cmd.extend(['--bags'])
 
     cmd.extend(args)
+
+    print('hello world')
+    #print "command to forward"
+    for item in cmd:
+        print(item)
     # Better way of handling it than os.execv
     # This makes sure stdin handles are passed to the process.
     subprocess.call(cmd)


### PR DESCRIPTION
The prefix option allows to publish all topics with the given string prefix. 

Use cases are e.g. playing a rosbag and the original source at the same time comparing the two outcomes simultaneously without topic conflicts. 
