### PR TITLE
avoid redefining ROS_ASSERT_ENABLED

### DIFF
--- a/tools/rosconsole/include/ros/assert.h
+++ b/tools/rosconsole/include/ros/assert.h
@@ -107,7 +107,9 @@
 #endif
 
 #ifndef NDEBUG
+#ifndef ROS_ASSERT_ENABLED
 #define ROS_ASSERT_ENABLED
+#endif
 #endif
 
 #ifdef ROS_ASSERT_ENABLED


### PR DESCRIPTION
In order to compile in release mode with ROS_ASSERT enabled, one can force catkin to define ROS_ASSERT_ENABLED on the command line. That works but you end up with a lot of warning about ROS_ASSERT_ENABLED being redefined
