### PR TITLE
Fix bug with missing current logger levels

### DIFF
--- a/clients/rospy/src/rospy/rosconsole.py
+++ b/clients/rospy/src/rospy/rosconsole.py
@@ -97,6 +97,7 @@ def _rosconsole_cmd_set(argv):
         parser.error("you must specify a node, a logger and a level")
 
     logger_level = LoggerLevelServiceCaller()
+    logger_level.get_loggers(args[0])
 
     if args[1] not in logger_level._current_levels:
         error(2, "node " + args[0] + " does not contain logger " + args[1])
@@ -126,6 +127,7 @@ def _rosconsole_cmd_get(argv):
         parser.error("you must specify a node and a logger")
 
     logger_level = LoggerLevelServiceCaller()
+    logger_level.get_loggers(args[0])
 
     if args[1] not in logger_level._current_levels:
         error(2, "node " + args[0] + " does not contain logger " + args[1])


### PR DESCRIPTION
Since get_loggers is not called, the names and statuses of the loggers is not known to the object. So, it fails in the following if statement because it cannot access current_levels. The effect is that both set and get do not work in the latest jade package.

This was apparently overlooked by @dirk-thomas and @gerkey when we cleaned up from #576 to #594. You can see the offending commit here 8d6b842. @dirk-thomas most likely didn't realize there were side effects of that function and the return value was not used. I should have caught it in review. 
