### PR TITLE
Added explicit bool cast for c++11

### DIFF
--- a/clients/roscpp/src/libros/timer.cpp
+++ b/clients/roscpp/src/libros/timer.cpp
@@ -95,7 +95,7 @@ Timer::Timer(const TimerOptions& ops)
   impl_->callback_ = ops.callback;
   impl_->callback_queue_ = ops.callback_queue;
   impl_->tracked_object_ = ops.tracked_object;
-  impl_->has_tracked_object_ = ops.tracked_object;
+  impl_->has_tracked_object_ = (ops.tracked_object != NULL);
   impl_->oneshot_ = ops.oneshot;
 }
 

--- a/clients/roscpp/src/libros/wall_timer.cpp
+++ b/clients/roscpp/src/libros/wall_timer.cpp
@@ -95,7 +95,7 @@ WallTimer::WallTimer(const WallTimerOptions& ops)
   impl_->callback_ = ops.callback;
   impl_->callback_queue_ = ops.callback_queue;
   impl_->tracked_object_ = ops.tracked_object;
-  impl_->has_tracked_object_ = ops.tracked_object;
+  impl_->has_tracked_object_ = (ops.tracked_object != NULL);
   impl_->oneshot_ = ops.oneshot;
 }
 


### PR DESCRIPTION
I have a use case where I need to wrap a c++11 library with ROS.

While building ROS with the following command, libros fails to build.

./src/catkin/bin/catkin_make_isolated -DCMAKE_CXX_FLAGS="-std=c++11"

I don't believe this will cause a problem for backwards compatibility, so while c++11 isn't officially supported, this shouldn't stop anyone either.

gcc --version
gcc (Ubuntu 4.9.2-0ubuntu1~14.04) 4.9.2
