### PR TITLE
Add --local option to rostest. Implements #137

### DIFF
--- a/tools/rostest/package.xml
+++ b/tools/rostest/package.xml
@@ -16,9 +16,10 @@
   <build_depend>rosunit</build_depend>
 
   <run_depend>boost</run_depend>
-  <run_depend>rospy</run_depend>
+  <run_depend>rosgraph</run_depend>
   <run_depend>roslaunch</run_depend>
   <run_depend>rosmaster</run_depend>
+  <run_depend>rospy</run_depend>
   <run_depend>rosunit</run_depend>
 
   <export>

--- a/tools/rostest/src/rostest/rostest_main.py
+++ b/tools/rostest/src/rostest/rostest_main.py
@@ -98,7 +98,16 @@ def rostestmain():
     parser.add_option("--results-base-dir", metavar="RESULTS_BASE_DIR",
                       help="The base directory of the test results. The test result file is " +
                            "created in a subfolder name PKG_DIR.")
+    parser.add_option("-r", "--reuse-master", action="store_true",
+                      help="Connect to an existing ROS master instead of spawning a new ROS master on a custom port")
+    parser.add_option("-c", "--clear", action="store_true",
+                      help="Clear all parameters when connecting to an existing ROS master (only works with --reuse-master)")
     (options, args) = parser.parse_args()
+
+    if options.clear and not options.reuse_master:
+        print("The --clear option is only valid with --reuse-master", file=sys.stderr)
+        sys.exit(1)
+
     try:
         args = roslaunch.rlutil.resolve_launch_arguments(args)
     except roslaunch.core.RLException as e:
@@ -147,7 +156,7 @@ def rostestmain():
         parser.error("test file is invalid. Generated failure case result file in %s"%results_file)
         
     try:
-        testCase = rostest.runner.createUnitTest(pkg, test_file)
+        testCase = rostest.runner.createUnitTest(pkg, test_file, options.reuse_master, options.clear)
         suite = unittest.TestLoader().loadTestsFromTestCase(testCase)
 
         if options.text_mode:

--- a/tools/rostest/src/rostest/runner.py
+++ b/tools/rostest/src/rostest/runner.py
@@ -190,7 +190,7 @@ def setUp(self):
     # new test_parent for each run. we are a bit inefficient as it would be possible to
     # reuse the roslaunch base infrastructure for each test, but the roslaunch code
     # is not abstracted well enough yet
-    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file])
+    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file], reuse_master=self.reuse_master, clear=self.clear)
     
     printlog("setup[%s] run_id[%s] starting", self.test_file, self.test_parent.run_id)
 
@@ -212,7 +212,7 @@ def tearDown(self):
         
     printlog("rostest teardown %s complete", self.test_file)
     
-def createUnitTest(pkg, test_file):
+def createUnitTest(pkg, test_file, reuse_master=False, clear=False):
     """
     Unit test factory. Constructs a unittest class based on the roslaunch
 
@@ -226,7 +226,8 @@ def createUnitTest(pkg, test_file):
 
     # pass in config to class as a property so that test_parent can be initialized
     classdict = { 'setUp': setUp, 'tearDown': tearDown, 'config': config,
-                  'test_parent': None, 'test_file': test_file }
+                  'test_parent': None, 'test_file': test_file,
+                  'reuse_master': reuse_master, 'clear': clear }
     
     # add in the tests
     testNames = []


### PR DESCRIPTION
Add an option to rostest which suppresses the behavior of spawning a ROS
master, and instead uses the default roslaunch behavior of connecting to
the ROS master specified in ROS_MASTER_URI, or creating a new ROS
master.

There is one final question here: with the --local option, the rostest environment is polluted by any parameters that already exist on the running ROS master.

I think it is reasonable to have an option for rostest to delete all of the existing parameters, so that the test can run with a clean parameter space. Should this option default to being on or off?
