### PR TITLE
using rl_config.nodes() to get all node information

### DIFF
--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -211,8 +211,8 @@ def check_roslaunch(f):
     
     # load all node defs
     nodes = []
-    for filename, rldeps in file_deps.items():
-        nodes.extend(rldeps.nodes)
+    for node in rl_config.nodes: # using rl_config instead of 'for filename, rldeps in file_deps.items():' for evaluating if/unless
+        nodes.extend([(node.package, node.type)])
 
     # check for missing packages
     rospack = rospkg.RosPack()


### PR DESCRIPTION
current roslaunch-check checks if all nodes exists, even if that tag is disabled by if statement, for example

```
<launch>
 <group if="true"> <node pkg="foo" name="bar_exists" type="valid" /> </group>
 <group if="false"> <node pkg="foo" name="bar_dummy" type="invalid" /> </group>
</launch>
```

and `valid` node exists and `invalid` node does not, current roslaunch-check implementation is try to check both nodes and returns failure because of missing `invalid` node. (real example is [1]  ,which naoqi_joint_states_cpp is not distributed ad deb due to some reason (may be copyright issue)

[1] https://github.com/ros-naoqi/naoqi_bridge/blob/0.4.8/naoqi_driver/launch/naoqi_driver.launch
