### PR TITLE
Allow transform to be used with ros arguments and in a launch file #644

### DIFF
--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -56,7 +56,9 @@ class TopicOp:
             help='List of Python modules to import.'
         )
 
-        args = parser.parse_args()
+        # get and strip out ros args first
+        args0 = rospy.myargv()
+        args = parser.parse_args(args0[1:])
 
         self.modules = {}
         for module in args.modules:


### PR DESCRIPTION
Get ros args with rospy.argv before passing to argparse.
