### PR TITLE
topic_tools/scripts/transform: add --wait-for-start

### DIFF
--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -55,6 +55,10 @@ class TopicOp:
             '-i', '--import', dest='modules', nargs='+', default=['numpy'],
             help='List of Python modules to import.'
         )
+        parser.add_argument(
+            '--wait-for-start', dest='wait_for_start', action='store_true',
+            help='Wait for input messages.'
+        )
 
         args = parser.parse_args()
 
@@ -69,7 +73,7 @@ class TopicOp:
 
         self.expression = args.expression
 
-        input_class, input_topic, self.input_fn = rostopic.get_topic_class(args.input)
+        input_class, input_topic, self.input_fn = rostopic.get_topic_class(args.input,blocking=args.wait_for_start)
         if input_topic is None:
             print('ERROR: Wrong input topic (or topic field): %s' % args.input, file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
add wait-for-start option to avoid exitting this script in the first time

current implemnetation exit the scirpt if the input topic is not found, but if you start `transform` with other node in the launch file, usually it takes a few seconds to start publishing topics, so `transform` node exits in the first time, this option avoid such situation
