### PR TITLE
Extend timer.Timer to include startup method

### DIFF
--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -207,7 +207,7 @@ class Timer(threading.Thread):
         """
         self._shutdown = True
 
-    def start(self):
+    def startup(self):
         """
         Start run method by setting self._shutdown to False.
         """

--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -194,7 +194,8 @@ class Timer(threading.Thread):
         @type  start: bool
         """
         threading.Thread.__init__(self)
-        self._period   = period
+        self.__period = period
+        self._period   = self.__period
         self._callback = callback
         self._oneshot  = oneshot
         self._shutdown = not start_running
@@ -206,6 +207,7 @@ class Timer(threading.Thread):
         Stop firing callbacks.
         """
         self._shutdown = True
+        self._period = self.__period
 
     def startup(self):
         """

--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -190,8 +190,8 @@ class Timer(threading.Thread):
         @type  callback: function taking rospy.TimerEvent
         @param oneshot: if True, fire only once, otherwise fire continuously until shutdown is called [default: False]
         @type  oneshot: bool
-        @param start: if True, begin running the `run` method immediately, otherwise wait until self.start() is called [default: False]
-        @type  start: bool
+        @param start_running: if True, begin running the `run` method immediately, otherwise wait until self.start() is called [default: False]
+        @type  start_running: bool
         """
         threading.Thread.__init__(self)
         self.__period = period

--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -48,7 +48,7 @@ class Rate(object):
     """
     Convenience class for sleeping in a loop at a specified rate
     """
-    
+
     def __init__(self, hz):
         """
         Constructor.
@@ -181,7 +181,7 @@ class Timer(threading.Thread):
     Convenience class for calling a callback at a specified rate
     """
 
-    def __init__(self, period, callback, oneshot=False):
+    def __init__(self, period, callback, oneshot=False, start_running=False):
         """
         Constructor.
         @param period: desired period between callbacks
@@ -190,12 +190,14 @@ class Timer(threading.Thread):
         @type  callback: function taking rospy.TimerEvent
         @param oneshot: if True, fire only once, otherwise fire continuously until shutdown is called [default: False]
         @type  oneshot: bool
+        @param start: if True, begin running the `run` method immediately, otherwise wait until self.start() is called [default: False]
+        @type  start: bool
         """
         threading.Thread.__init__(self)
         self._period   = period
         self._callback = callback
         self._oneshot  = oneshot
-        self._shutdown = False
+        self._shutdown = not start_running
         self.setDaemon(True)
         self.start()
 
@@ -204,7 +206,13 @@ class Timer(threading.Thread):
         Stop firing callbacks.
         """
         self._shutdown = True
-        
+
+    def start(self):
+        """
+        Start run method by setting self._shutdown to False.
+        """
+        self._shutdown = False
+
     def run(self):
         r = Rate(1.0 / self._period.to_sec())
         current_expected = rospy.rostime.get_rostime() + self._period

--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -181,7 +181,7 @@ class Timer(threading.Thread):
     Convenience class for calling a callback at a specified rate
     """
 
-    def __init__(self, period, callback, oneshot=False, start_running=False):
+    def __init__(self, period, callback, oneshot=False, start_running=True):
         """
         Constructor.
         @param period: desired period between callbacks

--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -48,7 +48,7 @@ class Rate(object):
     """
     Convenience class for sleeping in a loop at a specified rate
     """
-
+    
     def __init__(self, hz):
         """
         Constructor.


### PR DESCRIPTION
In working with the `rospy.timer.Timer` class, it feels to me like it could be improved with two subtle changes:
- A kwarg in its constructor that allows its invoker to either instantiate it in a running or shutdown state
- A companion method to `shutdown` that starts running the timer instead of turning it off.

This PR adds a kwarg to the `timer.Timer` constructor, `start_running` that defaults to False. In the `__init__` method, `self._shutdown` is set to `not start_running` so that if you wish to start the Timer in a running state, `start_running=True` and `self._shutdown = False`.

This PR also adds a `startup` method as a companion to `shutdown`, adding the ability to retain one instance of a `timer.Timer` object with the ability to toggle its running state. 

I have found this great for establishing a timer that controls a certain behavior with our robot, that may start and stop depending on repeating conditions.

Thanks for checking this out!
-- Keith
