### PR TITLE
add --local option to rostest, replaces #637

### DIFF
--- a/tools/rostest/package.xml
+++ b/tools/rostest/package.xml
@@ -17,6 +17,7 @@
 
   <run_depend>boost</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>rosgraph</run_depend>
   <run_depend>roslaunch</run_depend>
   <run_depend>rosmaster</run_depend>
   <run_depend>rosunit</run_depend>

--- a/tools/rostest/src/rostest/rostest_main.py
+++ b/tools/rostest/src/rostest/rostest_main.py
@@ -98,6 +98,8 @@ def rostestmain():
     parser.add_option("--results-base-dir", metavar="RESULTS_BASE_DIR",
                       help="The base directory of the test results. The test result file is " +
                            "created in a subfolder name PKG_DIR.")
+    parser.add_option("--reuse-master", action="store_true",
+                      help="Connect to an existing ROS master instead of spawning a new ROS master on a custom port")
     (options, args) = parser.parse_args()
     try:
         args = roslaunch.rlutil.resolve_launch_arguments(args)
@@ -147,7 +149,7 @@ def rostestmain():
         parser.error("test file is invalid. Generated failure case result file in %s"%results_file)
         
     try:
-        testCase = rostest.runner.createUnitTest(pkg, test_file)
+        testCase = rostest.runner.createUnitTest(pkg, test_file, options.reuse_master)
         suite = unittest.TestLoader().loadTestsFromTestCase(testCase)
 
         if options.text_mode:

--- a/tools/rostest/src/rostest/rostest_main.py
+++ b/tools/rostest/src/rostest/rostest_main.py
@@ -100,6 +100,8 @@ def rostestmain():
                            "created in a subfolder name PKG_DIR.")
     parser.add_option("--reuse-master", action="store_true",
                       help="Connect to an existing ROS master instead of spawning a new ROS master on a custom port")
+    parser.add_option("-c", "--clear", action="store_true",
+                      help="Clear all parameters when connecting to an existing ROS master (only works with --reuse-master)")
     (options, args) = parser.parse_args()
     try:
         args = roslaunch.rlutil.resolve_launch_arguments(args)
@@ -149,7 +151,7 @@ def rostestmain():
         parser.error("test file is invalid. Generated failure case result file in %s"%results_file)
         
     try:
-        testCase = rostest.runner.createUnitTest(pkg, test_file, options.reuse_master)
+        testCase = rostest.runner.createUnitTest(pkg, test_file, options.reuse_master, options.clear)
         suite = unittest.TestLoader().loadTestsFromTestCase(testCase)
 
         if options.text_mode:

--- a/tools/rostest/src/rostest/rostest_parent.py
+++ b/tools/rostest/src/rostest/rostest_parent.py
@@ -35,28 +35,57 @@
 import logging
 import sys
 
+import rosgraph
 import roslaunch.config
 from roslaunch.core import printlog_bold, RLException
 import roslaunch.launch
 import roslaunch.pmon
 import roslaunch.server
 import roslaunch.xmlloader 
-import roslaunch.rlutil
 
 import roslaunch.parent
 
 from rosmaster.master import Master
+from rospy import logwarn
+
 
 class ROSTestLaunchParent(roslaunch.parent.ROSLaunchParent):
 
-    def __init__(self, config, roslaunch_files, port=0, reuse_master=False):
+    def __init__(self, config, roslaunch_files, port=0, reuse_master=False, clear=False):
         if config is None:
             raise Exception("config not initialized")
         # we generate a run_id for each test
         if not reuse_master:
             run_id = roslaunch.core.generate_run_id()
         else:
-            run_id = roslaunch.rlutil.get_or_generate_uuid(None, False)
+            param_server = rosgraph.Master('/roslaunch')
+            have_master = False
+            try:
+                run_id = param_server.getParam('/run_id')
+                have_master = True
+            except Exception as e:
+                logwarn("Could not connect to existing ROS master; will create a new master: " +
+                        str(e))
+            except:
+                # oh boy; we got something that wasn't an exception...
+                # ignore it, the same way that roslaunch does in this situation
+                logwarn("Could not connect to existing ROS master; will create a new master")
+            if not have_master:
+                run_id = roslaunch.core.generate_run_id()
+
+            if clear and have_master:
+                params = param_server.getParamNames()
+                # whitelist of parameters to keep
+                whitelist = ['/run_id', '/rosversion', '/rosdistro']
+                for i in reversed(range(len(params))):
+                    param = params[i]
+                    if param in whitelist:
+                        del params[i]
+                    elif param.startswith('/roslaunch/'):
+                        del params[i]
+                for param in params:
+                    param_server.deleteParam(param)
+
         super(ROSTestLaunchParent, self).__init__(run_id, roslaunch_files, is_core=False, is_rostest=True)
         self.config = config
         self.port = port

--- a/tools/rostest/src/rostest/runner.py
+++ b/tools/rostest/src/rostest/runner.py
@@ -190,7 +190,7 @@ def setUp(self):
     # new test_parent for each run. we are a bit inefficient as it would be possible to
     # reuse the roslaunch base infrastructure for each test, but the roslaunch code
     # is not abstracted well enough yet
-    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file])
+    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file], reuse_master=self.reuse_master)
     
     printlog("setup[%s] run_id[%s] starting", self.test_file, self.test_parent.run_id)
 
@@ -212,7 +212,7 @@ def tearDown(self):
         
     printlog("rostest teardown %s complete", self.test_file)
     
-def createUnitTest(pkg, test_file):
+def createUnitTest(pkg, test_file, reuse_master=False):
     """
     Unit test factory. Constructs a unittest class based on the roslaunch
 
@@ -226,7 +226,8 @@ def createUnitTest(pkg, test_file):
 
     # pass in config to class as a property so that test_parent can be initialized
     classdict = { 'setUp': setUp, 'tearDown': tearDown, 'config': config,
-                  'test_parent': None, 'test_file': test_file }
+                  'test_parent': None, 'test_file': test_file,
+                  'reuse_master': reuse_master }
     
     # add in the tests
     testNames = []

--- a/tools/rostest/src/rostest/runner.py
+++ b/tools/rostest/src/rostest/runner.py
@@ -190,7 +190,7 @@ def setUp(self):
     # new test_parent for each run. we are a bit inefficient as it would be possible to
     # reuse the roslaunch base infrastructure for each test, but the roslaunch code
     # is not abstracted well enough yet
-    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file], reuse_master=self.reuse_master)
+    self.test_parent = ROSTestLaunchParent(self.config, [self.test_file], reuse_master=self.reuse_master, clear=self.clear)
     
     printlog("setup[%s] run_id[%s] starting", self.test_file, self.test_parent.run_id)
 
@@ -212,7 +212,7 @@ def tearDown(self):
         
     printlog("rostest teardown %s complete", self.test_file)
     
-def createUnitTest(pkg, test_file, reuse_master=False):
+def createUnitTest(pkg, test_file, reuse_master=False, clear=False):
     """
     Unit test factory. Constructs a unittest class based on the roslaunch
 
@@ -227,7 +227,7 @@ def createUnitTest(pkg, test_file, reuse_master=False):
     # pass in config to class as a property so that test_parent can be initialized
     classdict = { 'setUp': setUp, 'tearDown': tearDown, 'config': config,
                   'test_parent': None, 'test_file': test_file,
-                  'reuse_master': reuse_master }
+                  'reuse_master': reuse_master, 'clear': clear }
     
     # add in the tests
     testNames = []


### PR DESCRIPTION
This has been derived from PR #637 with the following changes:
- since the reused master might not be local the option has been renamed from `-local` to `--reuse-master`
- the `metavar` argument is not relevant for boolean flags in argparse and has been removed
- it has been clarified that `--clear` only works together with `--reuse-master`
- missing imports for `rospy.logwarn` added
