### PR TITLE
rosbag: better exception on empty bag

### DIFF
--- a/test/test_rosbag/test/test_bag.py
+++ b/test/test_rosbag/test/test_bag.py
@@ -317,8 +317,12 @@ class TestRosbag(unittest.TestCase):
         fn = '/tmp/test_get_time_emtpy_bag.bag'
 
         with rosbag.Bag(fn, mode='w') as bag:
-            self.assertRaises(rosbag.ROSBagException, bag.get_start_time)
-            self.assertRaises(rosbag.ROSBagException, bag.get_end_time)
+            self.assertRaisesRegexp(rosbag.ROSBagException,
+                                    'Bag contains no message',
+                                    bag.get_start_time)
+            self.assertRaisesRegexp(rosbag.ROSBagException,
+                                    'Bag contains no message',
+                                    bag.get_end_time)
 
     def test_get_type_and_topic_info(self):
         fn = '/tmp/test_get_type_and_topic_info.bag'

--- a/test/test_rosbag/test/test_bag.py
+++ b/test/test_rosbag/test/test_bag.py
@@ -312,6 +312,14 @@ class TestRosbag(unittest.TestCase):
             self.assertEquals(start_stamp, 0.0)
             self.assertEquals(end_stamp, 99.0)
 
+    def test_get_time_empty_bag(self):
+        """Test for issue #657"""
+        fn = '/tmp/test_get_time_emtpy_bag.bag'
+
+        with rosbag.Bag(fn, mode='w') as bag:
+            self.assertRaises(rosbag.ROSBagException, bag.get_start_time)
+            self.assertRaises(rosbag.ROSBagException, bag.get_end_time)
+
     def test_get_type_and_topic_info(self):
         fn = '/tmp/test_get_type_and_topic_info.bag'
         topic_1 = "/test_bag"

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -492,6 +492,8 @@ class Bag(object):
         if self._chunks:
             start_stamp = self._chunks[0].start_time.to_sec()
         else:
+            if not self._connection_indexes:
+                raise ROSBagException('Bag contains no message')
             start_stamp = min([index[0].time.to_sec() for index in self._connection_indexes.values()])
         
         return start_stamp
@@ -506,6 +508,8 @@ class Bag(object):
         if self._chunks:
             end_stamp = self._chunks[-1].end_time.to_sec()
         else:
+            if not self._connection_indexes:
+                raise ROSBagException('Bag contains no message')
             end_stamp = max([index[-1].time.to_sec() for index in self._connection_indexes.values()])
         
         return end_stamp


### PR DESCRIPTION
Bag.get_start_time and Bag.get_end_time thorw a better exception
if the bag contains no message.

Main modifications are on line approx. 496 and 512.
The rest is whitespace deletion.
