### PR TITLE
Prevent QueuedConnection memory/thread leak

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -394,7 +394,8 @@ class QueuedConnection(object):
         self._thread.start()
 
     def _closed_connection_callback(self, connection):
-        self._cond_data_available.notify()
+        with self._lock:
+            self._cond_data_available.notify()
 
     def __getattr__(self, name):
         if name.startswith('__'):

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -426,7 +426,16 @@ class _TopicImpl(object):
             self.connections = new_connections
 
             # connections make a callback when closed
-            c.set_cleanup_callback(self.remove_connection)
+            # don't clobber an existing callback
+            if not c.cleanup_cb:
+                c.set_cleanup_callback(self.remove_connection)
+            else:
+                previous_callback = c.cleanup_cb
+                new_callback = self.remove_connection
+                def cleanup_cb_wrapper(s):
+                    new_callback(s)
+                    previous_callback(s)
+                c.set_cleanup_callback(cleanup_cb_wrapper)
             
             return True
 


### PR DESCRIPTION
Added a timeout to `QueuedConnection`'s conditional wait() to prevent indefinite hanging threads.  These threads would eventually fill the process table when started by applications like rosbridge_server, which is expected to create and destroy many pub/sub connections.

There was a cleanup callback set on `TCPROSTransport` that was supposed to `notify()` the `Condition`, but it was being overwritten by the cleanup callback of `_PublisherImpl` and `_SubscriberImpl`.

Switching from the (broken) `notify()` callback to a timeout was less efficient than turning the transport cleanup callbacks into a list, so I did that too.

Fixes RobotWebTools/rosbridge_suite#165
