### PR TITLE
Test publisher deregister leak with patch

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -394,7 +394,8 @@ class QueuedConnection(object):
         self._thread.start()
 
     def _closed_connection_callback(self, connection):
-        self._cond_data_available.notify()
+        with self._lock:
+            self._cond_data_available.notify()
 
     def __getattr__(self, name):
         if name.startswith('__'):

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -426,7 +426,16 @@ class _TopicImpl(object):
             self.connections = new_connections
 
             # connections make a callback when closed
-            c.set_cleanup_callback(self.remove_connection)
+            # don't clobber an existing callback
+            if not c.cleanup_cb:
+                c.set_cleanup_callback(self.remove_connection)
+            else:
+                previous_callback = c.cleanup_cb
+                new_callback = self.remove_connection
+                def cleanup_cb_wrapper(s):
+                    new_callback(s)
+                    previous_callback(s)
+                c.set_cleanup_callback(cleanup_cb_wrapper)
             
             return True
 


### PR DESCRIPTION
#666 but with the patch applied to check that unit test passes now. @mvollrath FYI

This should not be merged!
