### PR TITLE
fix location of rosunit result files generated by rostests

### DIFF
--- a/tools/rostest/src/rostest/rostest_main.py
+++ b/tools/rostest/src/rostest/rostest_main.py
@@ -156,7 +156,7 @@ def rostestmain():
         parser.error("test file is invalid. Generated failure case result file in %s"%results_file)
         
     try:
-        testCase = rostest.runner.createUnitTest(pkg, test_file, options.reuse_master, options.clear)
+        testCase = rostest.runner.createUnitTest(pkg, test_file, options.reuse_master, options.clear, options.results_base_dir)
         suite = unittest.TestLoader().loadTestsFromTestCase(testCase)
 
         if options.text_mode:


### PR DESCRIPTION
Based on the discussion from https://github.com/ros/ros_comm/pull/666#issuecomment-141535738
