### PR TITLE
Adds stdio Support to rosparam

### DIFF
--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -160,11 +160,16 @@ def load_file(filename, default_namespace=None, verbose=False):
       corresponding namespaces for each YAML document in the file
     :raises: :exc:`RosParamException`: if unable to load contents of filename
     """
-    if not os.path.isfile(filename):
-        raise RosParamException("file [%s] does not exist"%filename)
-    if verbose:
-        print("reading parameters from [%s]"%filename)
-    f = open(filename, 'r')
+    if not filename or filename == '-':
+        f = sys.stdin
+        if verbose:
+            print("reading parameters from stdin")
+    else:
+        if not os.path.isfile(filename):
+            raise RosParamException("file [%s] does not exist"%filename)
+        if verbose:
+            print("reading parameters from [%s]"%filename)
+        f = open(filename, 'r')
     try:
         return load_str(f.read(), filename, default_namespace=default_namespace, verbose=verbose)
     finally:
@@ -499,7 +504,7 @@ def _rosparam_cmd_set_load(cmd, argv):
     arg2 = None
     if len(args) == 0:
         if cmd == 'load':
-            parser.error("invalid arguments. Please specify a file name")
+            arg = '-'
         elif cmd == 'set':
             parser.error("invalid arguments. Please specify a parameter name")
     elif len(args) == 1:

--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -298,7 +298,10 @@ def dump_params(filename, param, verbose=False):
     tree = get_param(param)
     if verbose:
         print_params(tree, param)
-    f = open(filename, 'w')
+    if not filename or filename == '-':
+        f = sys.stdout
+    else:
+        f = open(filename, 'w')
     try:
         yaml.dump(tree, f)
     finally:
@@ -429,7 +432,7 @@ def _rosparam_cmd_get_dump(cmd, argv):
     
     if len(args) == 0:
         if cmd == 'dump':
-            parser.error("invalid arguments. Please specify a file name")
+            arg = '-'
         elif cmd == 'get':
             parser.error("invalid arguments. Please specify a parameter name")
     elif len(args) == 1:


### PR DESCRIPTION
`rosparam dump` to stdout is useful for piping the rosparam yaml output to other programs. `rosparam load` from stdin is useful for piping yaml into rosparam.

This PR implements both, such that if the user does not specify a filename to the command (or specifies "-" as the filename), `rosparam` uses stdio instead of creating a file handle.

My particular usecase for `rosparam load` from stdin is being able to only load parameters from a launch file:

```
roslaunch robot.launch --dump-params | rosparam load -
```
