### PR TITLE
Add `-w` and `-t` options to roscore.

### DIFF
--- a/tools/roslaunch/scripts/roscore
+++ b/tools/roslaunch/scripts/roscore
@@ -33,6 +33,7 @@
 
 import sys
 from optparse import OptionParser
+from rosmaster.master_api import NUM_WORKERS
 
 NAME = 'roscore'
 
@@ -49,6 +50,12 @@ def _get_optparse():
     parser.add_option("-v", action="store_true",
                       dest="verbose", default=False,
                       help="verbose printing")
+    parser.add_option("-w", "--numworkers",
+                      dest="num_workers", default=NUM_WORKERS, type=int,
+                      help="override number of worker threads", metavar="NUM_WORKERS")
+    parser.add_option("-t", "--timeout",
+                      dest="timeout",
+                      help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
     return parser
 
 

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -65,7 +65,9 @@ try:
     from rosmaster import DEFAULT_MASTER_PORT
 except:
     DEFAULT_MASTER_PORT = 11311
-    
+
+from rosmaster.master_api import NUM_WORKERS
+
 NAME = 'roslaunch'
 
 def configure_logging(uuid):
@@ -172,6 +174,12 @@ def _get_optparse():
     parser.add_option("--disable-title", default=False, action="store_true",
                       dest="disable_title",
                       help="Disable setting of terminal title")
+    parser.add_option("-w", "--numworkers",
+                      dest="num_workers", default=NUM_WORKERS, type=int,
+                      help="override number of worker threads. Only valid for core services.", metavar="NUM_WORKERS")
+    parser.add_option("-t", "--timeout",
+                      dest="timeout",
+                      help="override the socket connection timeout (in seconds). Only valid for core services.", metavar="TIMEOUT")
 
     return parser
     
@@ -294,7 +302,8 @@ def main(argv=sys.argv):
                     options.port = options.port or DEFAULT_MASTER_PORT
                 p = roslaunch_parent.ROSLaunchParent(uuid, args, roslaunch_strs=roslaunch_strs,
                         is_core=options.core, port=options.port, local_only=options.local_only,
-                        verbose=options.verbose, force_screen=options.force_screen)
+                        verbose=options.verbose, force_screen=options.force_screen,
+                        num_workers=options.num_workers, timeout=options.timeout)
                 p.start()
                 p.spin()
             finally:

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -57,6 +57,8 @@ from roslaunch.pmon import start_process_monitor, ProcessListener
 
 from roslaunch.rlutil import update_terminal_name
 
+from rosmaster.master_api import NUM_WORKERS
+
 _TIMEOUT_MASTER_START = 10.0 #seconds
 _TIMEOUT_MASTER_STOP  = 10.0 #seconds
 
@@ -233,7 +235,7 @@ class ROSLaunchRunner(object):
     monitored.
     """
     
-    def __init__(self, run_id, config, server_uri=None, pmon=None, is_core=False, remote_runner=None, is_child=False, is_rostest=False):
+    def __init__(self, run_id, config, server_uri=None, pmon=None, is_core=False, remote_runner=None, is_child=False, is_rostest=False, num_workers=NUM_WORKERS, timeout=None):
         """
         @param run_id: /run_id for this launch. If the core is not
             running, this value will be used to initialize /run_id. If
@@ -258,7 +260,11 @@ class ROSLaunchRunner(object):
         @param is_rostest: if True, this runner is a rostest
             instance. This affects certain validation checks.
         @type  is_rostest: bool
-        """            
+        @param num_workers: If this is the core, the number of worker-threads to use.
+        @type num_workers: int
+        @param timeout: If this is the core, the socket-timeout to use.
+        @type timeout: Float or None
+        """
         if run_id is None:
             raise RLException("run_id is None")
         self.run_id = run_id
@@ -273,6 +279,8 @@ class ROSLaunchRunner(object):
         self.is_child = is_child
         self.is_core = is_core
         self.is_rostest = is_rostest
+        self.num_workers = num_workers
+        self.timeout = timeout
         self.logger = logging.getLogger('roslaunch')
         self.pm = pmon or start_process_monitor()
 
@@ -386,7 +394,7 @@ class ROSLaunchRunner(object):
             validate_master_launch(m, self.is_core, self.is_rostest)
 
             printlog("auto-starting new master")
-            p = create_master_process(self.run_id, m.type, get_ros_root(), m.get_port())
+            p = create_master_process(self.run_id, m.type, get_ros_root(), m.get_port(), self.num_workers, self.timeout)
             self.pm.register_core_proc(p)
             success = p.start()
             if not success:

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -49,6 +49,8 @@ from roslaunch.core import *
 from roslaunch.node_args import create_local_process_args
 from roslaunch.pmon import Process, FatalProcessLaunch
 
+from rosmaster.master_api import NUM_WORKERS
+
 import logging
 _logger = logging.getLogger("roslaunch")
 
@@ -61,7 +63,7 @@ def _next_counter():
     _counter += 1
     return _counter
 
-def create_master_process(run_id, type_, ros_root, port):
+def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None):
     """
     Launch a master
     @param type_: name of master executable (currently just Master.ZENMASTER)
@@ -70,18 +72,24 @@ def create_master_process(run_id, type_, ros_root, port):
     @type  ros_root: str
     @param port: port to launch master on
     @type  port: int
+    @param num_workers: number of worker threads.
+    @type  num_workers: int
+    @param timeout: socket timeout for connections.
+    @type  timeout: float
     @raise RLException: if type_ or port is invalid
     """    
     if port < 1 or port > 65535:
         raise RLException("invalid port assignment: %s"%port)
 
-    _logger.info("create_master_process: %s, %s, %s", type_, ros_root, port)
+    _logger.info("create_master_process: %s, %s, %s, %s, %s", type_, ros_root, port, num_workers, timeout)
     # catkin/fuerte: no longer use ROS_ROOT-relative executables, search path instead
     master = type_
     # zenmaster is deprecated and aliased to rosmaster
     if type_ in [Master.ROSMASTER, Master.ZENMASTER]:        
         package = 'rosmaster'        
-        args = [master, '--core', '-p', str(port)]
+        args = [master, '--core', '-p', str(port), '-w', str(num_workers)]
+        if timeout is not None:
+            args += ['-t', str(timeout)]
     else:
         raise RLException("unknown master typ_: %s"%type_)
 

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -54,6 +54,8 @@ import roslaunch.pmon
 import roslaunch.server
 import roslaunch.xmlloader 
 
+from rosmaster.master_api import NUM_WORKERS
+
 #TODO: probably move process listener infrastructure into here
 
 # TODO: remove after wg_hardware_roslaunch has been updated
@@ -71,7 +73,7 @@ class ROSLaunchParent(object):
     """
 
     def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,
-            verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None):
+            verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None):
         """
         @param run_id: UUID of roslaunch session
         @type  run_id: str
@@ -94,6 +96,10 @@ class ROSLaunchParent(object):
         @param is_rostest bool: if True, this launch is a rostest
             instance. This affects validation checks.
         @type  is_rostest: bool
+        @param num_workers: If this is the core, the number of worker-threads to use.
+        @type num_workers: int
+        @param timeout: If this is the core, the socket-timeout to use.
+        @type timeout: Float or None
         @throws RLException
         """
         
@@ -108,6 +114,8 @@ class ROSLaunchParent(object):
         self.port = port
         self.local_only = local_only
         self.verbose = verbose
+        self.num_workers = num_workers
+        self.timeout = timeout
 
         # I don't think we should have to pass in so many options from
         # the outside into the roslaunch parent. One possibility is to
@@ -144,7 +152,7 @@ class ROSLaunchParent(object):
             raise RLException("pm is not initialized")
         if self.server is None:
             raise RLException("server is not initialized")
-        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest)
+        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout)
 
         # print runner info to user, put errors last to make the more visible
         if self.is_core:

--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -41,6 +41,7 @@ import time
 import optparse
 
 import rosmaster.master
+from rosmaster.master_api import NUM_WORKERS
 
 def configure_logging():
     """
@@ -64,6 +65,12 @@ def rosmaster_main(argv=sys.argv, stdout=sys.stdout, env=os.environ):
     parser.add_option("-p", "--port", 
                       dest="port", default=0,
                       help="override port", metavar="PORT")
+    parser.add_option("-w", "--numworkers",
+                      dest="num_workers", default=NUM_WORKERS, type=int,
+                      help="override number of worker threads", metavar="NUM_WORKERS")
+    parser.add_option("-t", "--timeout",
+                      dest="timeout",
+                      help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
     options, args = parser.parse_args(argv[1:])
 
     # only arg that zenmaster supports is __log remapping of logfilename
@@ -95,9 +102,15 @@ WARNING ACHTUNG WARNING ACHTUNG WARNING
 
     logger = logging.getLogger("rosmaster.main")
     logger.info("initialization complete, waiting for shutdown")
+
+    if options.timeout is not None and float(options.timeout) >= 0.0:
+        logger.info("Setting socket timeout to %s" % options.timeout)
+        import socket
+        socket.setdefaulttimeout(float(options.timeout))
+
     try:
         logger.info("Starting ROS Master Node")
-        master = rosmaster.master.Master(port)
+        master = rosmaster.master.Master(port, options.num_workers)
         master.start()
 
         import time

--- a/tools/rosmaster/src/rosmaster/master.py
+++ b/tools/rosmaster/src/rosmaster/master.py
@@ -50,8 +50,9 @@ DEFAULT_MASTER_PORT=11311 #default port for master's to bind to
 
 class Master(object):
     
-    def __init__(self, port=DEFAULT_MASTER_PORT):
+    def __init__(self, port=DEFAULT_MASTER_PORT, num_workers=rosmaster.master_api.NUM_WORKERS):
         self.port = port
+        self.num_workers = num_workers
         
     def start(self):
         """
@@ -61,7 +62,7 @@ class Master(object):
         self.master_node = None
         self.uri = None
 
-        handler = rosmaster.master_api.ROSMasterHandler()
+        handler = rosmaster.master_api.ROSMasterHandler(self.num_workers)
         master_node = rosgraph.xmlrpc.XmlRpcNode(self.port, handler)
         master_node.start()
 

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -236,13 +236,13 @@ class ROSMasterHandler(object):
     this parameter (see ros::client::getMaster()).
     """
     
-    def __init__(self):
+    def __init__(self, num_workers=NUM_WORKERS):
         """ctor."""
 
         self.uri = None
         self.done = False
 
-        self.thread_pool = rosmaster.threadpool.MarkedThreadPool(NUM_WORKERS)
+        self.thread_pool = rosmaster.threadpool.MarkedThreadPool(num_workers)
         # pub/sub/providers: dict { topicName : [publishers/subscribers names] }
         self.ps_lock = threading.Condition(threading.Lock())
 


### PR DESCRIPTION
These define the number of worker-threads of the master and the socket timeout to use.

For large projects, the default of 3 workers with the OS' default timeout (of roughly 2-3mins) will cause the topic notification queue to stall as soon as a computer doesn't answer. So large projects want to set the timeout much lower and increase the thread-pool size a bit.

I'd like to add that having to define the option in three places and pass it through multiple objects almost made me go insane.

Ping @tlind as he debugged this together with me.
