### PR TITLE
Shutdown rospy timers cleanly

### DIFF
--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -210,7 +210,11 @@ class Timer(threading.Thread):
         current_expected = rospy.rostime.get_rostime() + self._period
         last_expected, last_real, last_duration = None, None, None
         while not rospy.core.is_shutdown() and not self._shutdown:
-            r.sleep()
+            try:
+                r.sleep()
+            except rospy.exceptions.ROSInterruptException as e:
+                if rospy.core.is_shutdown():
+                    break
             if self._shutdown:
                 break
             current_real = rospy.rostime.get_rostime()


### PR DESCRIPTION
Timers go off and start periodically running in the background, and will throw exceptions when ros shutdown occurs because of the sleep function.

These are impossible to catch as they're off in a background thread and can be cleanly handled as in the code change.

Others with the same problem:
- [baxter examples](https://github.com/RethinkRobotics/baxter_examples/issues/48)
