### PR TITLE
filterROSArgs function in init.cpp

### DIFF
--- a/clients/roscpp/include/ros/init.h
+++ b/clients/roscpp/include/ros/init.h
@@ -196,6 +196,16 @@ ROSCPP_DECL bool isStarted();
 ROSCPP_DECL CallbackQueue* getGlobalCallbackQueue();
 
 /**
+ * \brief searches the command line arguments for the given arg parameter. In case this argument is not found
+ * an empty string is returned.
+ *
+ * \param argc the number of command-line arguments
+ * \param argv the command-line arguments
+ * \param arg argument to search for
+ */
+ROSCPP_DECL std::string getROSArg(int argc, const char* const* argv, const std::string& arg);
+
+/**
  * \brief returns a vector of program arguments that do not include any ROS remapping arguments.  Useful if you need
  * to parse your arguments to determine your node name
  *

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -509,6 +509,20 @@ void init(const VP_string& remappings, const std::string& name, uint32_t options
   init(remappings_map, name, options);
 }
 
+std::string getROSArg(int argc, const char* const* argv, const std::string& arg)
+{
+  for (int i = 0; i < argc; ++i)
+  {
+    std::string str_arg = argv[i];
+    size_t pos = str_arg.find(":=");
+    if (str_arg.substr(0,pos) == arg)
+    {
+      return str_arg.substr(pos+2);
+    }
+  }
+  return "";
+}
+
 void removeROSArgs(int argc, const char* const* argv, V_string& args_out)
 {
   for (int i = 0; i < argc; ++i)


### PR DESCRIPTION
Allows a pre-filtering of ROS keywords before calling `ros::init()`.

This is an alternative to `ros::this_node::getName()` [[0]](http://docs.ros.org/api/roscpp/html/namespaceros_1_1this__node.html#a2a991f67172b59ccd7e5b4aeca9b76b7), since this requires to call `ros::init(argc, argv, "node_name")` beforehand and forcing to specify a node name. 
ros::filterROSArgs can be called wo/ init for filter various keywords such as `__name` or `__ns`. 

```
$ rosrun hello_world hello_world __name:=foo
```

```
// hello_world.cpp
int main( int argc, char** argv )
{ 
  std::string node_name = ros::filterROSArgs(argc, argv, "__name");
  if (!node_name.empty())
    ros::init(argc, argv, node_name);
  else
    ros::init(argc, argv, "bar");

  return 0;
}
```

In case the desired argument is not found, an empty string is returned.
