### PR TITLE
ros_comm:691 rosmsg info prints better message if message was not found

### DIFF
--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -419,7 +419,6 @@ def get_msg_text(type_, raw=False, rospack=None):
     :returns: text of .msg file, ``str``
     :raises :exc:`ROSMsgException` If type_ is unknown
     """
-
     if rospack is None:
         rospack = rospkg.RosPack()
     search_path = {}

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -419,6 +419,7 @@ def get_msg_text(type_, raw=False, rospack=None):
     :returns: text of .msg file, ``str``
     :raises :exc:`ROSMsgException` If type_ is unknown
     """
+
     if rospack is None:
         rospack = rospkg.RosPack()
     search_path = {}
@@ -610,7 +611,11 @@ def rosmsg_cmd_show(mode, full):
         if '/' in arg: #package specified
             rosmsg_debug(rospack, mode, arg, options.raw)
         else:
-            for found in rosmsg_search(rospack, mode, arg):
+            found_msgs = list(rosmsg_search(rospack, mode, arg))
+            if not found_msgs:
+                print("Could not find msg '%s' " % arg)
+                exit(1)
+            for found in found_msgs:
                 print("[%s]:"%found)
                 rosmsg_debug(rospack, mode, found, options.raw)
 

--- a/tools/rosmsg/test/test_rosmsg_command_line.py
+++ b/tools/rosmsg/test/test_rosmsg_command_line.py
@@ -168,3 +168,6 @@ class TestRosmsg(unittest.TestCase):
             self.assertEquals(text, output[0], "Failed: %s"%(str(output)))
             output = Popen(['rosmsg', 'show', '--raw', type_], stdout=PIPE).communicate()[0]
             self.assertEquals(text, output)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Pull request for https://github.com/ros/ros_comm/issues/691

rosmsg did not show a warning if a msg was not found in the local package (looking for std_msgs/NonExistingMsg already created a message). 

So far no tests, but will be added. Where is the test_ros package that is used in the test cases?

http://answers.ros.org/question/220696/where-can-i-find-the-test_ros-package/
