### PR TITLE
Add pass_all_args attr to include tag

### DIFF
--- a/tools/roslaunch/test/xml/test-arg-all.xml
+++ b/tools/roslaunch/test/xml/test-arg-all.xml
@@ -1,0 +1,48 @@
+<launch>
+
+  <arg name="required" />
+  <arg name="optional" default="not_set" />
+  <arg name="grounded" value="parent" />
+  <arg name="include_arg" value="dontcare" />
+  <arg name="if_test" value="dontcare" />
+
+  <arg name="param1_name" value="p1" />
+  <arg name="param2_name" value="p2" />
+  <arg name="param3_name" value="p3" />
+
+  <arg name="param1_value" value="$(arg required)" />
+  <arg name="param2_value" value="$(arg optional)" />
+  <arg name="param3_value" value="$(arg grounded)" />
+
+  <param name="$(arg param1_name)_test" value="$(arg param1_value)" />
+  <param name="$(arg param2_name)_test" value="$(arg param2_value)" />
+  <param name="$(arg param3_name)_test" value="$(arg param3_value)" />
+
+  <!-- Normal include: explicitly set args -->
+  <include ns="notall" file="$(find roslaunch)/test/xml/test-arg-include.xml">
+    <arg name="required" value="$(arg required)" />
+    <arg name="include_arg" value="$(arg include_arg)" />
+    <arg name="if_test" value="$(arg if_test)" />
+  </include>
+
+  <!-- Normal include: explicitly set args, including an optional one -->
+  <include ns="notall_optional" file="$(find roslaunch)/test/xml/test-arg-include.xml">
+    <arg name="required" value="$(arg required)" />
+    <arg name="optional" value="$(arg optional)" />
+    <arg name="include_arg" value="$(arg include_arg)" />
+    <arg name="if_test" value="$(arg if_test)" />
+  </include>
+
+  <!-- Include with passing in all args in my namespace -->
+  <include ns="all" file="$(find roslaunch)/test/xml/test-arg-include.xml"
+           pass_all_args="true">
+  </include>
+
+  <!-- Include with passing in all args in my namespace, and then override one
+       of them explicitly -->
+  <include ns="all_override" file="$(find roslaunch)/test/xml/test-arg-include.xml"
+           pass_all_args="true">
+    <arg name="required" value="override" />
+  </include>
+
+</launch>

--- a/tools/roslaunch/test/xml/test-arg-invalid-include.xml
+++ b/tools/roslaunch/test/xml/test-arg-invalid-include.xml
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(find roslaunch)/test/xml/test-arg-invalid-included.xml">
+    <arg name="grounded" value="not_set"/>
+  </include>
+</launch>

--- a/tools/roslaunch/test/xml/test-arg-invalid-include2.xml
+++ b/tools/roslaunch/test/xml/test-arg-invalid-include2.xml
@@ -1,0 +1,6 @@
+<launch>
+  <include file="$(find roslaunch)/test/xml/test-arg-invalid-included.xml" pass_all_args="true">
+    <arg name="grounded" value="not_set"/>
+  </include>
+</launch>
+

--- a/tools/roslaunch/test/xml/test-arg-invalid-included.xml
+++ b/tools/roslaunch/test/xml/test-arg-invalid-included.xml
@@ -1,0 +1,3 @@
+<launch>
+  <arg name="grounded" value="set"/>
+</launch>

--- a/tools/roslaunch/test/xml/test-arg-valid-include.xml
+++ b/tools/roslaunch/test/xml/test-arg-valid-include.xml
@@ -1,0 +1,5 @@
+<launch>
+  <arg name="grounded" value="not_set"/>
+  <include file="$(find roslaunch)/test/xml/test-arg-invalid-included.xml" pass_all_args="true"/>
+</launch>
+


### PR DESCRIPTION
Add a new attribute, `pass_all_args`, to the `include` tag.  It's a bool, with default of false.  E.g.:

``` xml
<arg name="foo" value="bar"/>
<arg name="bat" value="bang"/>

<!-- Pass down foo=bar and bat=bang -->
<include file="foo.launch" pass_all_args="true"/>

<!-- Pass down foo=override and bat=bang -->
<include file="foo.launch" pass_all_args="true">
  <arg name="foo" value="override"/>
</include>

<!-- The existing syntax can still be used to explicitly pass down foo=bar and bat=bang -->
<include file="foo.launch" pass_all_args="false">
  <arg name="foo" value="bar"/>
  <arg name="bat" value="bang"/>
</include>
```

If false, then nothing changes from existing behavior.

If true, then all args set in the current context are added to the child context that is created for processing the included file.  You can do this instead of explicitly listing each argument that you want to pass down.

Notes on behavior when `pass_all_args="true"`:
- In the case that the parent passes down a value for an arg that is defined as constant in the child, then the child's value is used.
- If an `<arg>` tag explicitly passes down an argument that is also set in the parent, then that explicit value overrides.
