### PR TITLE
waiting for param server to be available before trying to get Param

### DIFF
--- a/tools/roslaunch/src/roslaunch/scriptapi.py
+++ b/tools/roslaunch/src/roslaunch/scriptapi.py
@@ -58,7 +58,7 @@ class ROSLaunch(object):
         """
         import rosgraph.masterapi
         master = rosgraph.masterapi.Master('/roslaunch_script')
-        uuid = master.getParam('/run_id')
+        uuid = roslaunch.rlutil.get_or_generate_uuid(None, True)
         self.parent = roslaunch.parent.ROSLaunchParent(uuid, [], is_core=False)
         self.started = False
 


### PR DESCRIPTION
This fixes a problem when launching roscore and using scriptapi very quickly ( scripts for tests for exemple ). Now scriptapi wait for the param server to be available ( the same way than the main roslaunch method does )
