### PR TITLE
[roslaunch-check] support check on rostest

### DIFF
--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -35,6 +35,7 @@ from __future__ import print_function
 
 import os
 import sys
+import re
 
 import rospkg
 
@@ -66,17 +67,32 @@ if __name__ == '__main__':
     parser.add_option("-o", "--output-file",
                       dest="output_file", default=None,
                       help="file to store test results in", metavar="FILE")
+    parser.add_option("--gtest_output",
+                      dest="gtest_output", default=None,
+                      help="file to store test results in for when launching by rostest")
 
     options, args = parser.parse_args()
+
+    # if --gtsest_output option is given, overwrite output_file option
+    if options.gtest_output:
+        delimiter_index = options.gtest_output.find(":")
+        if delimiter_index == -1: # not found
+            options.output_file = options.gtest_output
+        else:
+            options.output_file = options.gtest_output[delimiter_index+1:]
+
     if not args:
         parser.error('please specify a file or directory for roslaunch files to test')
     roslaunch_path = args[0]
 
     # #2590: implementing this quick and dirty as this script should only be used by higher level tools
+    # check if valid for environment value
+    pattern = re.compile(r"^[a-zA-Z_]+[a-zA-Z0-9_]*$")
     env_vars = args[1:]
     for e in env_vars:
         var, val = e.split('=')
-        os.environ[var] = val
+        if pattern.match(var):
+            os.environ[var] = val
 
     pkg = rospkg.get_package_name(roslaunch_path)
     r = rospkg.RosPack()


### PR DESCRIPTION
Currently we cannot use `roslaunch-check` script as test program on `rostest`, because implicit argument `--gtest_output` given from `rostest` is ignored and other ROS args are evaluated as os environment variables.

**BEFORE**

when test file is like below:

``` xml
<launch>
  <test test-name="check_planner_launch" pkg="roslaunch" type="roslaunch-check"
        args="$(find jsk_2013_04_pr2_610)/launch/planner.launch" />
</launch>
```

rostest always fails:

``` bash
$ rostest test-launch.test                                                                     ⮂  
... logging to /home/leus/.ros/log/rostest-Z800-4621.log
[ROSUNIT] Outputting test results to /home/leus/.ros/test_results/jsk_2013_04_pr2_610/rostest-test_test-launch.xml
Usage:  roslaunch-check [options] <file|directory> [env=value...]

roslaunch-check: error: no such option: --gtest_output   # here roslaunch-check does not work with rostest
testcheck_planner_launch ... FAILURE!
FAILURE: test [check_planner_launch] did not generate test results
  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rostest/runner.py", line 164, in fn
    self.assert_(os.path.isfile(test_file), "test [%s] did not generate test results"%test_name)
  File "/usr/lib/python2.7/unittest/case.py", line 424, in assertTrue
    raise self.failureException(msg)
--------------------------------------------------------------------------------

[ROSTEST]-----------------------------------------------------------------------

[testcheck_planner_launch][failed]

SUMMARY
 * RESULT: FAIL
 * TESTS: 0
 * ERRORS: 0
 * FAILURES: 1

ERROR: The following tests failed to run:
 * testcheck_planner_launch

rostest log file is in /home/leus/.ros/log/rostest-Z800-4621.log
```

**AFTER**

if launch file to be tested is valid:

``` bash
rostest test-launch.test                                                                     ⮂  
... logging to /home/leus/.ros/log/rostest-Z800-1957.log
[ROSUNIT] Outputting test results to /home/leus/.ros/test_results/jsk_2013_04_pr2_610/rostest-test_test-launch.xml
testcheck_planner_launch ... ok

[ROSTEST]-----------------------------------------------------------------------

[jsk_2013_04_pr2_610.rosunit-check_planner_launch/test_ran][passed]

SUMMARY
 * RESULT: SUCCESS
 * TESTS: 1
 * ERRORS: 0
 * FAILURES: 0

rostest log file is in /home/leus/.ros/log/rostest-Z800-1957.log
```

if launch file is invalid:

``` xml
<launch>
  <arg name="debug" default="false" />
  <arg name="use_ffha" default="false" />
  <arg name="launch_sound_play" default="true" />
  <arf name="test" default="true" /> <!-- this tag is invalid -->
...
</launch>
```

``` bash
rostest test-launch.test                                                                     ⮂  
... logging to /home/leus/.ros/log/rostest-Z800-2206.log
[ROSUNIT] Outputting test results to /home/leus/.ros/test_results/jsk_2013_04_pr2_610/rostest-test_test-launch.xml
FAILURE:
[/home/leus/ros/indigo/src/jsk-ros-pkg/jsk_demos/jsk_2013_04_pr2_610/launch/planner.launch]:
    ROSLaunch config error: unrecognized tag arf # here indicates where is the error in launch file
testcheck_planner_launch ... ok

[ROSTEST]-----------------------------------------------------------------------

[jsk_2013_04_pr2_610.rosunit-check_planner_launch/test_ran][FAILURE]------------
roslaunch check [/home/leus/ros/indigo/src/jsk-ros-pkg/jsk_demos/jsk_2013_04_pr2_610/launch/planner.launch] failed
--------------------------------------------------------------------------------


SUMMARY
 * RESULT: FAIL
 * TESTS: 1
 * ERRORS: 0
 * FAILURES: 1

rostest log file is in /home/leus/.ros/log/rostest-Z800-2206.log
```
