### PR TITLE
fix encoding of header fields (fix #704)

### DIFF
--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -400,11 +400,13 @@ def encode_ros_handshake_header(header):
     # in the usual configuration, the error 'TypeError: can't concat bytes to str' appears:
     if python3 == 0:
         #python 2
+        fields = [str(f) for f in fields]
         s = ''.join(["%s%s"%(struct.pack('<I', len(f)), f) for f in fields])
         return struct.pack('<I', len(s)) + s
     else:
         #python 3 
-        s = b''.join([(struct.pack('<I', len(f)) + f.encode("utf-8")) for f in fields])
+        fields = [f.encode('utf-8') for f in fields]
+        s = b''.join([(struct.pack('<I', f) + f) for f in fields])
         return struct.pack('<I', len(s)) + s
                                         
 def write_ros_handshake_header(sock, header):


### PR DESCRIPTION
Fixes #704.

For Python 2 the field is explicitly converted to a string which usually means ASCII.

For Python 3 it actually fixes another bug: `len(f)` does not need to be equal to `len(f.encode('utf-8'))`. And in that case the length of the encoded data must be serialized.
