### PR TITLE
rostest: Slashes in ARGS cause invalid target names

### DIFF
--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -36,8 +36,6 @@ function(add_rostest file)
   rostest__strip_prefix(_testname "${PROJECT_SOURCE_DIR}/")
   rostest__strip_prefix(_testname "${PROJECT_BINARY_DIR}/")
 
-  string(REPLACE "/" "_" _testname ${_testname})
-
   # to support registering the same test with different ARGS
   # append the args to the test name
   if(_rostest_ARGS)
@@ -49,6 +47,8 @@ function(add_rostest file)
     endforeach()
     set(_testname "${_testname}${_ext}")
   endif()
+  
+  string(REPLACE "/" "_" _testname ${_testname})
 
   get_filename_component(_output_name ${_testname} NAME_WE)
   set(_output_name "${_output_name}.xml")


### PR DESCRIPTION
Slashes in rostest ARGS are not replaced, leading to invalid target names.

In CMakeLists.txt:

``` cmake
  add_rostest(
    test/pickit.test
    ARGS cam_rosbag_file:=${PROJECT_BINARY_DIR}/bagfiles/bag.bag
  )
```

Error output:

```
CMake Error at /opt/ros/indigo/share/catkin/cmake/test/tests.cmake:133 (add_custom_target):
  add_custom_target called with invalid target name
  "run_tests_im_pickit_test_rostest_test_pickit__cam_rosbag_file_/home/jenkins/workspace/pickit-pull-requests-im-pkg/258/build/im_pickit_test/bagfiles/bag.bag.test".
  Target names may not contain a slash.  Use ADD_CUSTOM_COMMAND to generate
  files.  Set CMAKE_BACKWARDS_COMPATIBILITY to 2.2 or lower to skip this
  check.
```
