### PR TITLE
rostest can load tests from a dotted name

### DIFF
--- a/tools/rostest/test/dotname_cases.py
+++ b/tools/rostest/test/dotname_cases.py
@@ -1,0 +1,31 @@
+import unittest
+
+class CaseA(unittest.TestCase):
+
+    def runTest(self):
+        self.assertTrue(True)
+
+class CaseB(unittest.TestCase):
+    
+    def runTest(self):
+        self.assertTrue(True)
+
+class DotnameLoadingSuite(unittest.TestSuite):
+
+    def __init__(self):
+        super(DotnameLoadingSuite, self).__init__()
+        self.addTest(CaseA())
+        self.addTest(CaseB())
+    
+class DotnameLoadingTest(unittest.TestCase):
+
+    def test_a(self):
+        self.assertTrue(True)
+    
+    def test_b(self):
+        self.assertTrue(True)
+
+class NotTestCase():
+
+    def not_test(self):
+        pass

--- a/tools/rostest/test/test_dotname.py
+++ b/tools/rostest/test/test_dotname.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+# This file should be run using a non-ros unit test framework such as nose using
+# nosetests test_dotname.py.
+
+import unittest
+import rostest
+from dotname_cases import DotnameLoadingTest, NotTestCase, DotnameLoadingSuite
+import exceptions
+
+class TestDotnameLoading(unittest.TestCase):
+
+    def test_class_basic(self):
+        rostest.rosrun('test_rostest', 'test_class_basic', DotnameLoadingTest)
+
+    def test_class_dotname(self):
+        rostest.rosrun('test_rostest', 'test_class_dotname', 'dotname_cases.DotnameLoadingTest')
+
+    def test_method_dotname(self):
+        rostest.rosrun('test_rostest', 'test_method_dotname', 'dotname_cases.DotnameLoadingTest.test_a')
+
+    def test_suite_dotname(self):
+        rostest.rosrun('test_rostest', 'test_suite_dotname', 'dotname_cases.DotnameLoadingSuite')
+
+    def test_class_basic_nottest(self):
+        # class which exists but is not a TestCase
+        with self.assertRaises(SystemExit):
+            rostest.rosrun('test_rostest', 'test_class_basic_nottest', NotTestCase)
+
+    def test_suite_basic(self):
+        # can't load suites with the basic loader
+        with self.assertRaises(SystemExit):
+            rostest.rosrun('test_rosunit', 'test_suite_basic', DotnameLoadingSuite)
+
+    def test_class_dotname_nottest(self):
+        # class which exists but is not a valid test
+        with self.assertRaises(TypeError):
+            rostest.rosrun('test_rostest', 'test_class_dotname_nottest', 'dotname_cases.NotTestCase')
+
+    def test_class_dotname_noexist(self):
+        # class which does not exist in the module
+        with self.assertRaises(AttributeError):
+            rostest.rosrun('test_rostest', 'test_class_dotname_noexist', 'dotname_cases.DotnameLoading')
+
+    def test_method_dotname_noexist(self):
+        # method which does not exist in the class
+        with self.assertRaises(AttributeError):
+            rostest.rosrun('test_rostest', 'test_method_dotname_noexist', 'dotname_cases.DotnameLoadingTest.not_method')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is a simple solution to the issue, using [`unittest.TestLoader().loadTestsFromName`](https://docs.python.org/2/library/unittest.html#unittest.TestLoader.loadTestsFromName). The dual-use (`str` or `unittest.TestCase`) of the `test` parameter could be changed to use a kwarg instead. That would necessitate `test` being an optional parameter which specifies the `unittest.TestCase` class, and some other parameter (`test_from_name` or something?) specifying a string from which tests should be loaded. That would probably require additional checks to ensure that at least one of the optional parameters existed.

You can check that the name-based loading works by changing [line 56](https://github.com/ros/ros_comm/blob/a0a45fddeb5ad94f2a657710d1db532d148bfe30/test/test_rosbag/test/latched_pub.py#L56) in `test_rosbag` to

```
rostest.rosrun('test_rosbag', 'latched_pub', 'latched_pub.LatchedPub', sys.argv)
```

Here's a test you can run to check that suite loading works correctly. You can run it with `rosrun test_rosbag tmp.py`. Don't forget to `chmod +x`.

`ros_comm/test/test_rosbag/test/tmp.py`:

``` python
#!/usr/bin/env python

import unittest
import rostest
import rospy
import sys

class CaseA(unittest.TestCase):

    def runTest(self):
        self.assertTrue(True)

class CaseB(unittest.TestCase):

    def runTest(self):
        self.assertTrue(True)

class SuiteTest(unittest.TestSuite):

    def __init__(self):
        super(SuiteTest, self).__init__()
        self.addTest(CaseA())
        self.addTest(CaseB())

if __name__ == '__main__':
      rostest.rosrun('test_rosbag', 'temp_tests', 'tmp.SuiteTest', sys.argv)

```

Fixes #423.
