### PR TITLE
do not fail if other package.xml provides package required

### DIFF
--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -193,6 +193,7 @@ def check_roslaunch(f):
     except roslaunch.core.RLException as e:
         return str(e)
     
+    rospack = rospkg.RosPack()
     errors = []
     # check for missing deps
     try:
@@ -206,8 +207,21 @@ def check_roslaunch(f):
         missing = {}
         file_deps = {}
     for pkg, miss in missing.items():
-        if miss:
+        # even if the pkgs is not found in packges.xml, if other package.xml provdes that pkgs, then it will be ok
+        all_pkgs = []
+        try:
+            for file_dep in file_deps.keys():
+                file_pkg = rospkg.get_package_name(file_dep)
+                all_pkgs.extend(rospack.get_depends(file_pkg,implicit=False))
+                miss_all = list(set(miss) - set(all_pkgs))
+        except Exception as e:
+            print(e, file=sys.stderr)
+            miss_all = True
+        if miss_all:
+            print("Missing package dependencies: %s/package.xml: %s"%(pkg, ', '.join(miss)), file=sys.stderr)
             errors.append("Missing package dependencies: %s/package.xml: %s"%(pkg, ', '.join(miss)))
+        elif miss:
+            print("Missing package dependencies: %s/package.xml: %s (notify upstream maintainer)"%(pkg, ', '.join(miss)), file=sys.stderr)
     
     # load all node defs
     nodes = []
@@ -215,7 +229,6 @@ def check_roslaunch(f):
         nodes.extend(rldeps.nodes)
 
     # check for missing packages
-    rospack = rospkg.RosPack()
     for pkg, node_type in nodes:
         try:
             rospack.get_path(pkg)


### PR DESCRIPTION
roslaunch-check fails for heqtor_quadrotor_gazebo

```
$ rosrun roslaunch roslaunch-check  /opt/ros/indigo/share/hector_quadrotor_gazebo/launch/quadrotor_empty_world.launch 
checking /opt/ros/indigo/share/hector_quadrotor_gazebo/launch/quadrotor_empty_world.launch
...writing test results to /home/k-okada/.ros/test_results/hector_quadrotor_gazebo/rosunit-roslaunch_check_quadrotor_empty_world_launch.xml
FAILURE:
[/opt/ros/indigo/share/hector_quadrotor_gazebo/launch/quadrotor_empty_world.launch]:
    Missing package dependencies: hector_quadrotor_gazebo/package.xml: gazebo_ros, hector_quadrotor_controller
Missing package dependencies: hector_quadrotor_controller/package.xml: controller_manager
```

but it has dependency like

```
$ rospack depends-why --target gazebo_ros hector_quadrotor_gazebo 
Dependency chains from hector_quadrotor_gazebo to gazebo_ros:
* hector_quadrotor_gazebo -> gazebo_plugins -> gazebo_ros 
* hector_quadrotor_gazebo -> hector_gazebo_plugins -> gazebo_ros 
* hector_quadrotor_gazebo -> hector_sensors_gazebo -> gazebo_plugins -> gazebo_ros 
* hector_quadrotor_gazebo -> hector_sensors_gazebo -> hector_gazebo_plugins -> gazebo_ros 
* hector_quadrotor_gazebo -> hector_quadrotor_gazebo_plugins -> gazebo_ros 
* hector_quadrotor_gazebo -> hector_quadrotor_gazebo_plugins -> hector_gazebo_plugins -> gazebo_ros 
* hector_quadrotor_gazebo -> hector_quadrotor_controller_gazebo -> gazebo_ros_control -> gazebo_ros
```
