### PR TITLE
Fix remaining rosmsg tests

### DIFF
--- a/tools/rosmsg/test/RosmsgC_raw.txt
+++ b/tools/rosmsg/test/RosmsgC_raw.txt
@@ -1,2 +1,4 @@
 test_rosmaster/String s1
+  string data
 test_rosmaster/String s2
+  string data

--- a/tools/rosmsg/test/msg/RosmsgC.msg
+++ b/tools/rosmsg/test/msg/RosmsgC.msg
@@ -1,2 +1,2 @@
-std_msgs/String s1
-std_msgs/String s2
+test_rosmaster/String s1
+test_rosmaster/String s2

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -133,16 +133,19 @@ test_rosmaster/String s2
     def test_get_srv_text(self):
         d = get_test_path()
         srv_d = os.path.join(d, 'srv')
-        with open(os.path.join(srv_d, 'RossrvA.srv'), 'r') as f:
-            text = f.read()
-        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvA', raw=False))
-        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvA', raw=True))
-
-        # std_msgs/empty / std_msgs/empty
-        with open(os.path.join(srv_d, 'RossrvB.srv'), 'r') as f:
-            text = f.read()
-        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvB', raw=False))
-        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvB', raw=True))
+        
+        test_srv_package = 'test_rosmaster'
+        rospack = rospkg.RosPack()
+        srv_raw_d = os.path.join(rospack.get_path(test_srv_package), 'srv')
+        for t in ['RossrvA', 'RossrvB']:
+            with open(os.path.join(srv_d, '%s.srv'%t), 'r') as f:
+                text = f.read()
+            with open(os.path.join(srv_raw_d, '%s.srv'%t), 'r') as f:
+                text_raw = f.read()
+                
+            type_ = test_srv_package+'/'+t
+            self.assertEquals(text, rosmsg.get_srv_text(type_, raw=False))
+            self.assertEquals(text_raw, rosmsg.get_srv_text(type_, raw=True))
 
     def test_rosmsg_cmd_packages(self):
         from rosmsg import rosmsg_cmd_packages, MODE_MSG, MODE_SRV

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -39,6 +39,8 @@ try:
 except ImportError:
     from io import StringIO
 import time
+
+import rospkg
         
 import rosmsg
 
@@ -66,19 +68,26 @@ class TestRosmsg(unittest.TestCase):
     def test_get_msg_text(self):
         d = get_test_path()
         msg_d = os.path.join(d, 'msg')
+        
+        test_message_package = 'test_rosmaster'
+        rospack = rospkg.RosPack()
+        msg_raw_d = os.path.join(rospack.get_path(test_message_package), 'msg')
         for t in ['RosmsgA', 'RosmsgB']:
             with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
                 text = f.read()
-            type_ = 'test_rosmaster/'+t
+            with open(os.path.join(msg_raw_d, '%s.msg'%t), 'r') as f:
+                text_raw = f.read()
+                
+            type_ = test_message_package+'/'+t
             self.assertEquals(text, rosmsg.get_msg_text(type_, raw=False))
-            self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
+            self.assertEquals(text_raw, rosmsg.get_msg_text(type_, raw=True))
             
         # test recursive types
         t = 'RosmsgC'
-        with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
-            text = f.read()
+        with open(os.path.join(msg_raw_d, '%s.msg'%t), 'r') as f:
+            text_raw = f.read()
         type_ = 'test_rosmaster/'+t
-        self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
+        self.assertEquals(text_raw, rosmsg.get_msg_text(type_, raw=True))
         self.assertEquals("""test_rosmaster/String s1
   string data
 test_rosmaster/String s2

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -84,14 +84,14 @@ class TestRosmsg(unittest.TestCase):
             
         # test recursive types
         t = 'RosmsgC'
+        with open(os.path.join(d, '%s_raw.txt'%t), 'r') as f:
+            text = f.read()
         with open(os.path.join(msg_raw_d, '%s.msg'%t), 'r') as f:
             text_raw = f.read()
-        type_ = 'test_rosmaster/'+t
+        type_ = test_message_package+'/'+t
+        
+        self.assertEquals(text, rosmsg.get_msg_text(type_, raw=False))
         self.assertEquals(text_raw, rosmsg.get_msg_text(type_, raw=True))
-        self.assertEquals("""test_rosmaster/String s1
-  string data
-test_rosmaster/String s2
-  string data""", rosmsg.get_msg_text(type_, raw=False).strip())
 
     def test_iterate_packages(self):
         from rosmsg import iterate_packages, MODE_MSG, MODE_SRV

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -79,9 +79,9 @@ class TestRosmsg(unittest.TestCase):
             text = f.read()
         type_ = 'test_rosmaster/'+t
         self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
-        self.assertEquals("""std_msgs/String s1
+        self.assertEquals("""test_rosmaster/String s1
   string data
-std_msgs/String s2
+test_rosmaster/String s2
   string data""", rosmsg.get_msg_text(type_, raw=False).strip())
 
     def test_iterate_packages(self):

--- a/tools/rosmsg/test/test_rosmsg_command_line.py
+++ b/tools/rosmsg/test/test_rosmsg_command_line.py
@@ -143,28 +143,36 @@ class TestRosmsg(unittest.TestCase):
         self.assertEquals('int64 a\nint64 b\n---\nint64 sum', output.strip())
 
         # test against test_rosmsg package
-        rospack = rospkg.RosPack()
-        d = rospack.get_path('test_rosmaster')
+        d = os.path.abspath(os.path.dirname(__file__))
         msg_d = os.path.join(d, 'msg')
-        # - test with non-recursive types, which should have identical raw/non-raw
+        
+        test_message_package = 'test_rosmaster'
+        rospack = rospkg.RosPack()
+        msg_raw_d = os.path.join(rospack.get_path(test_message_package), 'msg')
+        
+        # - test with non-recursive types
         for t in ['RosmsgA', 'RosmsgB']:
             with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
                 text = f.read()
+            with open(os.path.join(msg_raw_d, '%s.msg'%t), 'r') as f:
+                text_raw = f.read()
             text = text+'\n' # running command adds one new line
-            type_ ='test_rosmaster/'+t
+            text_raw = text_raw+'\n'
+            type_ =test_message_package+'/'+t
             output = Popen(['rosmsg', 'show', type_], stdout=PIPE).communicate()[0]
             self.assertEquals(text, output)
-            output = Popen(['rosmsg', 'show', '-r',type_], stdout=PIPE, stderr=PIPE).communicate()
-            self.assertEquals(text, output[0], "Failed: %s"%(str(output)))
+            output = Popen(['rosmsg', 'show', '-r',type_], stdout=PIPE).communicate()[0]
+            self.assertEquals(text_raw, output)
             output = Popen(['rosmsg', 'show', '--raw', type_], stdout=PIPE).communicate()[0]
-            self.assertEquals(text, output)
+            self.assertEquals(text_raw, output)
 
             # test as search
             type_ = t
             text = "[test_rosmaster/%s]:\n%s"%(t, text)
+            text_raw = "[test_rosmaster/%s]:\n%s"%(t, text_raw)
             output = Popen(['rosmsg', 'show', type_], stdout=PIPE).communicate()[0]
             self.assertEquals(text, output)
             output = Popen(['rosmsg', 'show', '-r',type_], stdout=PIPE, stderr=PIPE).communicate()
-            self.assertEquals(text, output[0], "Failed: %s"%(str(output)))
+            self.assertEquals(text_raw, output[0], "Failed: %s"%(str(output)))
             output = Popen(['rosmsg', 'show', '--raw', type_], stdout=PIPE).communicate()[0]
-            self.assertEquals(text, output)
+            self.assertEquals(text_raw, output)


### PR DESCRIPTION
Building on work related to issue https://github.com/ros/ros_comm/issues/709

```
======================================================================
FAIL: test_get_msg_text (test_rosmsg.TestRosmsg)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/gerkey/code/rosmsg-tests/src/ros_comm/tools/rosmsg/test/test_rosmsg.py", line 74, in test_get_msg_text
    self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
AssertionError: 'test_rosmaster/Empty empty\n' != 'Empty empty\n'
```

From what I can see, rosmsg.get_msg_text() used to have a 'fulltext' option which would refer to the msg types with their package name included ('test_rosmaster/Empty empty\n' vs 'Empty empty\n', as in the error output). This was removed in https://github.com/ros/ros_comm/commit/ef2beb715ed502d65e8a0c4e2149d9437e4d2483, but now having the parameter raw=False returns msgs in fulltext, [while raw=True doesn't](https://github.com/ros/ros_comm/commit/ef2beb715ed502d65e8a0c4e2149d9437e4d2483#diff-88c107efa9221d2911e1ca87e7246869R252). 

The tests are failing because they don't expect this discrepancy.

The current behaviour is:
With raw=False, messages are: recursive, whitespace removed, fulltext.
with raw=True, messages are not recursive, with whitespace not removed, and not fulltext.

I updated the tests to match the current behaviour of get_msg_text/get_srv_text, but it's possible that the appropriate fix is actually the other way around, as, judging from [this comment](https://github.com/ros/ros_comm/blob/indigo-devel/tools/rosmsg/test/test_rosmsg_command_line.py#L149) in the previously failing test, the behaviour when raw=False vs True used to be different (with respect to fulltext).
