### PR TITLE
Fixed a typo in unknown host error message

### DIFF
--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -120,8 +120,8 @@ Please manually:
 then try roslaunching again.
 
 If you wish to configure roslaunch to automatically recognize unknown
-hosts, please set the environment variable ROSLAUNCH_SSH_UNKNOWN=1"""%(resolved_address, user_str, port_str, resolved_address)
-        
+hosts, please set the environment variable ROSLAUNCH_SSH_UNKNOWN=1"""%(resolved_address, port_str, user_str, resolved_address)
+
 class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
     """
     Process wrapper for launching and monitoring a child roslaunch process over SSH
@@ -142,9 +142,9 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         self.started = False
         self.uri = None
         # self.is_dead is a flag set by is_alive that affects whether or not we
-        # log errors during a stop(). 
+        # log errors during a stop().
         self.is_dead = False
-        
+
     def _ssh_exec(self, command, address, port, username=None, password=None):
         """
         :returns: (ssh pipes, message).  If error occurs, returns (None, error message).
@@ -182,7 +182,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         #load ssh client and connect
         ssh = paramiko.SSHClient()
         err_msg = ssh_check_known_hosts(ssh, address, port, username=username, logger=_logger)
-        
+
         if not err_msg:
             username_str = '%s@'%username if username else ''
             try:
@@ -220,7 +220,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         to the remote host.
         """
         self.started = False #won't set to True until we are finished
-        self.ssh = self.sshin = self.sshout = self.ssherr = None        
+        self.ssh = self.sshin = self.sshout = self.ssherr = None
         with self.lock:
             name = self.name
             m = self.machine
@@ -235,7 +235,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
                 return False
             self.ssh, self.sshin, self.sshout, self.ssherr = sshvals
             printlog("remote[%s]: ssh connection created"%name)
-            self.started = True            
+            self.started = True
             return True
 
     def getapi(self):
@@ -246,7 +246,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
             return ServerProxy(self.uri)
         else:
             return None
-    
+
     def is_alive(self):
         """
         :returns: ``True`` if the process is alive. is_alive needs to be
@@ -317,18 +317,18 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
                 else:
                     printlog("remote[%s]: unable to contact [%s] to shutdown cleanly. The remote roslaunch may have exited already."%(self.name, address))
             except:
-                # temporary: don't really want to log here as this 
+                # temporary: don't really want to log here as this
                 # may occur during shutdown
                 traceback.print_exc()
 
             _logger.info("remote[%s]: closing ssh connection", self.name)
             self.sshin.close()
             self.sshout.close()
-            self.ssherr.close()                        
+            self.ssherr.close()
             self.ssh.close()
 
             self.sshin  = None
             self.sshout = None
-            self.ssherr = None            
+            self.ssherr = None
             self.ssh = None
-            _logger.info("remote[%s]: ssh connection closed", self.name)            
+            _logger.info("remote[%s]: ssh connection closed", self.name)

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -121,7 +121,7 @@ then try roslaunching again.
 
 If you wish to configure roslaunch to automatically recognize unknown
 hosts, please set the environment variable ROSLAUNCH_SSH_UNKNOWN=1"""%(resolved_address, port_str, user_str, resolved_address)
-
+        
 class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
     """
     Process wrapper for launching and monitoring a child roslaunch process over SSH
@@ -142,9 +142,9 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         self.started = False
         self.uri = None
         # self.is_dead is a flag set by is_alive that affects whether or not we
-        # log errors during a stop().
+        # log errors during a stop(). 
         self.is_dead = False
-
+        
     def _ssh_exec(self, command, address, port, username=None, password=None):
         """
         :returns: (ssh pipes, message).  If error occurs, returns (None, error message).
@@ -182,7 +182,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         #load ssh client and connect
         ssh = paramiko.SSHClient()
         err_msg = ssh_check_known_hosts(ssh, address, port, username=username, logger=_logger)
-
+        
         if not err_msg:
             username_str = '%s@'%username if username else ''
             try:
@@ -220,7 +220,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         to the remote host.
         """
         self.started = False #won't set to True until we are finished
-        self.ssh = self.sshin = self.sshout = self.ssherr = None
+        self.ssh = self.sshin = self.sshout = self.ssherr = None        
         with self.lock:
             name = self.name
             m = self.machine
@@ -235,7 +235,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
                 return False
             self.ssh, self.sshin, self.sshout, self.ssherr = sshvals
             printlog("remote[%s]: ssh connection created"%name)
-            self.started = True
+            self.started = True            
             return True
 
     def getapi(self):
@@ -246,7 +246,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
             return ServerProxy(self.uri)
         else:
             return None
-
+    
     def is_alive(self):
         """
         :returns: ``True`` if the process is alive. is_alive needs to be
@@ -317,18 +317,18 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
                 else:
                     printlog("remote[%s]: unable to contact [%s] to shutdown cleanly. The remote roslaunch may have exited already."%(self.name, address))
             except:
-                # temporary: don't really want to log here as this
+                # temporary: don't really want to log here as this 
                 # may occur during shutdown
                 traceback.print_exc()
 
             _logger.info("remote[%s]: closing ssh connection", self.name)
             self.sshin.close()
             self.sshout.close()
-            self.ssherr.close()
+            self.ssherr.close()                        
             self.ssh.close()
 
             self.sshin  = None
             self.sshout = None
-            self.ssherr = None
+            self.ssherr = None            
             self.ssh = None
-            _logger.info("remote[%s]: ssh connection closed", self.name)
+            _logger.info("remote[%s]: ssh connection closed", self.name)            


### PR DESCRIPTION
This fixes a typo when generating the error message when a machine's address was not found in the known_hosts file. The port string and the user string were reversed so if a username and port were provided it would generate an error like this:

```
Please manually:
   ssh username@-p 26 127.0.0.1
```

Rather than the correct version:

```
Please manually:
   ssh -p 26 username@127.0.0.1
```

The first is not a valid ssh command, while the second is.
