### PR TITLE
Timeout can be specified for roscpp service calls

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -18,7 +18,7 @@ list(GET roscpp_VERSION_LIST 2 roscpp_VERSION_PATCH)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/ros/common.h.in ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros/common.h)
 
-find_package(Boost REQUIRED COMPONENTS signals filesystem system)
+find_package(Boost REQUIRED COMPONENTS signals filesystem system chrono)
 
 include_directories(include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 

--- a/clients/roscpp/include/ros/service_client.h
+++ b/clients/roscpp/include/ros/service_client.h
@@ -160,6 +160,13 @@ public:
    */
   std::string getService();
 
+  /**
+   * \brief Set timeout for service calls
+   * \param timeout The amount of time to wait for call response. If timeout is -1 (default),
+   * waits until call is complete
+   */
+  void setTimeout(double timeout);
+
   operator void*() const { return isValid() ? (void*)1 : (void*)0; }
   bool operator<(const ServiceClient& rhs) const
   {
@@ -199,6 +206,7 @@ private:
     M_string header_values_;
     std::string service_md5sum_;
     bool is_shutdown_;
+    double timeout;		///< Timeout for calling service
   };
   typedef boost::shared_ptr<Impl> ImplPtr;
   typedef boost::weak_ptr<Impl> ImplWPtr;

--- a/clients/roscpp/include/ros/service_server_link.h
+++ b/clients/roscpp/include/ros/service_server_link.h
@@ -105,7 +105,8 @@ public:
    * If there is already a call happening in another thread, this will queue up the call and still block until
    * it has finished.
    */
-  bool call(const SerializedMessage& req, SerializedMessage& resp, double timeout = -1);
+  bool call(const SerializedMessage& req, SerializedMessage& resp);
+  bool call(const SerializedMessage& req, SerializedMessage& resp, double timeout);
 
 private:
   void onConnectionDropped(const ConnectionPtr& conn);

--- a/clients/roscpp/include/ros/service_server_link.h
+++ b/clients/roscpp/include/ros/service_server_link.h
@@ -105,7 +105,7 @@ public:
    * If there is already a call happening in another thread, this will queue up the call and still block until
    * it has finished.
    */
-  bool call(const SerializedMessage& req, SerializedMessage& resp);
+  bool call(const SerializedMessage& req, SerializedMessage& resp, double timeout = -1);
 
 private:
   void onConnectionDropped(const ConnectionPtr& conn);

--- a/clients/roscpp/src/libros/service_client.cpp
+++ b/clients/roscpp/src/libros/service_client.cpp
@@ -174,10 +174,10 @@ bool ServiceClient::isPersistent() const
 
 void ServiceClient::setTimeout(double timeout)
 {
-	if(impl_)
-	{
-		impl_->timeout = timeout;
-	}
+  if(impl_)
+  {
+    impl_->timeout = timeout;
+  }
 }
 
 void ServiceClient::shutdown()

--- a/clients/roscpp/src/libros/service_client.cpp
+++ b/clients/roscpp/src/libros/service_client.cpp
@@ -35,7 +35,7 @@ namespace ros
 {
 
 ServiceClient::Impl::Impl() 
-  : is_shutdown_(false)
+  : is_shutdown_(false), timeout (-1.0)
 { }
 
 ServiceClient::Impl::~Impl()
@@ -140,7 +140,7 @@ bool ServiceClient::call(const SerializedMessage& req, SerializedMessage& resp, 
     }
   }
 
-  bool ret = link->call(req, resp);
+  bool ret = link->call(req, resp, impl_->timeout);
   link.reset();
 
   // If we're shutting down but the node haven't finished yet, wait until we do
@@ -170,6 +170,14 @@ bool ServiceClient::isPersistent() const
   }
 
   return false;
+}
+
+void ServiceClient::setTimeout(double timeout)
+{
+	if(impl_)
+	{
+		impl_->timeout = timeout;
+	}
 }
 
 void ServiceClient::shutdown()

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -322,11 +322,6 @@ void ServiceServerLink::processNextCall()
   }
 }
 
-bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& resp)
-{
-  return call(req, resp, -1);
-}
-
 bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& resp, double timeout)
 {
   CallInfoPtr info(new CallInfo);
@@ -400,6 +395,11 @@ bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& re
   }
 
   return info->success_;
+}
+
+bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& resp)
+{
+  return call(req, resp, -1);
 }
 
 bool ServiceServerLink::isValid() const

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -364,23 +364,24 @@ bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& re
 
     while (!info->finished_)
     {
-    	if(timeout > 0)
-    	{
-    		boost::chrono::milliseconds duration(static_cast<int>(timeout * 1000));
-    		if(info->finished_condition_.wait_for(lock, duration))
-    		{
-    			ROS_ERROR("Service [%s] call failed: no response for %fsec", service_name_.c_str(), timeout);
-    			interrupted = true;
-    			break;
-    		}
-    	}
-    	else
-    		info->finished_condition_.wait(lock);
+      if(timeout > 0)
+      {
+        boost::chrono::milliseconds duration(static_cast<int>(timeout * 1000));
+        if(info->finished_condition_.wait_for(lock, duration))
+        {
+          ROS_ERROR("Service [%s] call failed: no response for %fsec", service_name_.c_str(), timeout);
+          interrupted = true;
+          break;
+        }
+      }
+      else
+        info->finished_condition_.wait(lock);
     }
+
+    if(interrupted)
+        this->clearCalls();
   }
 
-  if(interrupted)
-	  this->clearCalls();
 
   info->call_finished_ = true;
 

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -41,6 +41,7 @@
 #include "ros/file_log.h"
 
 #include <boost/bind.hpp>
+#include <boost/chrono.hpp>
 
 #include <sstream>
 
@@ -321,7 +322,7 @@ void ServiceServerLink::processNextCall()
   }
 }
 
-bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& resp)
+bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& resp, double timeout)
 {
   CallInfoPtr info(new CallInfo);
   info->req_ = req;
@@ -357,14 +358,29 @@ bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& re
     processNextCall();
   }
 
+  bool interrupted = false;
   {
     boost::mutex::scoped_lock lock(info->finished_mutex_);
 
     while (!info->finished_)
     {
-      info->finished_condition_.wait(lock);
+    	if(timeout > 0)
+    	{
+    		boost::chrono::milliseconds duration(static_cast<int>(timeout * 1000));
+    		if(info->finished_condition_.wait_for(lock, duration))
+    		{
+    			ROS_ERROR("Service [%s] call failed: no response for %fsec", service_name_.c_str(), timeout);
+    			interrupted = true;
+    			break;
+    		}
+    	}
+    	else
+    		info->finished_condition_.wait(lock);
     }
   }
+
+  if(interrupted)
+	  this->clearCalls();
 
   info->call_finished_ = true;
 

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -381,10 +381,10 @@ bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& re
       else
         info->finished_condition_.wait(lock);
     }
-
-    if(interrupted)
-        this->clearCalls();
   }
+  // Clear calls is properly protected
+  if(interrupted)
+    this->clearCalls();
 
 
   info->call_finished_ = true;

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -362,12 +362,16 @@ bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& re
   {
     boost::mutex::scoped_lock lock(info->finished_mutex_);
 
+    using namespace boost::chrono;
+    system_clock::time_point now = system_clock::now();
+
     while (!info->finished_)
     {
       if(timeout > 0)
       {
-        boost::chrono::milliseconds duration(static_cast<int>(timeout * 1000));
-        if(info->finished_condition_.wait_for(lock, duration))
+        system_clock::time_point wall_time = now + milliseconds(static_cast<int>(timeout * 1000));
+
+        if(info->finished_condition_.wait_until(lock, wall_time) == boost::cv_status::timeout)
         {
           ROS_ERROR("Service [%s] call failed: no response for %fsec", service_name_.c_str(), timeout);
           interrupted = true;

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -322,6 +322,11 @@ void ServiceServerLink::processNextCall()
   }
 }
 
+bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& resp)
+{
+  return call(req, resp, -1);
+}
+
 bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& resp, double timeout)
 {
   CallInfoPtr info(new CallInfo);


### PR DESCRIPTION
Added function ros::ServiceClient::setTimeout to limit the time roscpp service client waits for response. By defaut it is set to -1.0 seconds,  and the service call blocks until it gets a response or connection is dropped.

Straightforward solution for #152 
