### PR TITLE
getParamNames

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -2016,6 +2016,11 @@ if (service)  // Enter if advertised service is valid
    * \throws InvalidNameException If the parameter key begins with a tilde, or is an otherwise invalid graph resource name
    */
   bool deleteParam(const std::string& key) const;
+  /** \brief Get the keys for all the parameters in the parameter server.
+   * \param keys The keys retrieved.
+   * \return true if the query succeeded, false otherwise.
+   */
+  bool getParamNames(std::vector<std::string> keys) const;
 
   /** \brief Assign value from parameter server, with default.
    *

--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -2020,7 +2020,7 @@ if (service)  // Enter if advertised service is valid
    * \param keys The keys retrieved.
    * \return true if the query succeeded, false otherwise.
    */
-  bool getParamNames(std::vector<std::string> keys) const;
+  bool getParamNames(std::vector<std::string>& keys) const;
 
   /** \brief Assign value from parameter server, with default.
    *

--- a/clients/roscpp/include/ros/param.h
+++ b/clients/roscpp/include/ros/param.h
@@ -543,6 +543,7 @@ ROSCPP_DECL bool getCached(const std::string& key, std::map<std::string, bool>& 
  * \throws InvalidNameException if the key is not a valid graph resource name
  */
 ROSCPP_DECL bool has(const std::string& key);
+
 /** \brief Delete a parameter from the parameter server.
  *
  * \param key The key to delete.
@@ -583,6 +584,13 @@ ROSCPP_DECL bool search(const std::string& ns, const std::string& key, std::stri
  * \throws InvalidNameException if the key is not a valid graph resource name
  */
 ROSCPP_DECL bool search(const std::string& key, std::string& result);
+
+/**
+ * \brief Get the list of all the parameters in the server
+ * \param keys The vector of all the keys
+ * \return false if the process fails
+ */
+ROSCPP_DECL bool getParamNames(std::vector<std::string>& keys);
 
 /** \brief Assign value from parameter server, with default.
  *

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -592,7 +592,7 @@ bool NodeHandle::deleteParam(const std::string& key) const
   return param::del(resolveName(key));
 }
 
-bool NodeHandle::getParamNames(std::vector<std::string> keys) const
+bool NodeHandle::getParamNames(std::vector<std::string>& keys) const
 {
   return param::getParamNames(keys);
 }

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -592,6 +592,11 @@ bool NodeHandle::deleteParam(const std::string& key) const
   return param::del(resolveName(key));
 }
 
+bool NodeHandle::getParamNames(std::vector<std::string> keys) const
+{
+  return param::getParamNames(keys);
+}
+
 bool NodeHandle::getParam(const std::string& key, XmlRpc::XmlRpcValue& v) const
 {
   return param::get(resolveName(key), v);

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -720,6 +720,31 @@ bool getCached(const std::string& key, std::map<std::string, bool>& map)
   return getImpl(key, map, true);
 }
 
+bool getParamNames(std::vector<std::string>& keys)
+{
+  XmlRpc::XmlRpcValue params, result, payload;
+  params[0] = this_node::getName();
+  if (!master::execute("getParamNames", params, result, payload, false))
+    return false;
+  // Make sure it's an array type
+  if (result.getType() != XmlRpc::XmlRpcValue::TypeArray)
+    return false;
+  // Make sure it returned 3 elements
+  if (result.size() != 3)
+    return false;
+  // Get the actual parameter keys
+  XmlRpc::XmlRpcValue parameters = result[2];
+  // Resize the output
+  keys.resize(parameters.size());
+
+  // Fill the output vector with the answer
+  for (int i = 0; i < parameters.size(); i++) {
+    if (parameters[i].getType() != XmlRpc::XmlRpcValue::TypeString)
+      return false;
+    keys[i] = std::string(parameters[i]);
+  }
+  return true;
+}
 
 bool search(const std::string& key, std::string& result_out)
 {

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -560,6 +560,12 @@ TEST(Params, paramNodeHandleTemplateFunction)
   EXPECT_EQ( nh.param<bool>( "loob", true ), true );
 }
 
+TEST(Params, getParamNames) {
+  std::vector<std::string> test_params;
+  EXPECT_TRUE(ros::param::getParamNames(test_params));
+  EXPECT_LT(10, test_params.size());
+}
+
 int
 main(int argc, char** argv)
 {


### PR DESCRIPTION
Added method for getting all the parameters from the parameter server as implemented in the rospy client. Implemented in NodeHandle and added simple unit test.
