### PR TITLE
Use boost::make_shared instead of new for constructing shared_ptrs

### DIFF
--- a/clients/roscpp/include/ros/advertise_service_options.h
+++ b/clients/roscpp/include/ros/advertise_service_options.h
@@ -72,7 +72,7 @@ struct ROSCPP_DECL AdvertiseServiceOptions
     datatype = st::datatype<MReq>();
     req_datatype = mt::datatype<MReq>();
     res_datatype = mt::datatype<MRes>();
-    helper = ServiceCallbackHelperPtr(new ServiceCallbackHelperT<ServiceSpec<MReq, MRes> >(_callback));
+    helper = boost::make_shared<ServiceCallbackHelperT<ServiceSpec<MReq, MRes> > >(_callback);
   }
 
   /**
@@ -92,7 +92,7 @@ struct ROSCPP_DECL AdvertiseServiceOptions
     datatype = st::datatype<Service>();
     req_datatype = mt::datatype<Request>();
     res_datatype = mt::datatype<Response>();
-    helper = ServiceCallbackHelperPtr(new ServiceCallbackHelperT<ServiceSpec<Request, Response> >(_callback));
+    helper = boost::make_shared<ServiceCallbackHelperT<ServiceSpec<Request, Response> > >(_callback);
   }
 
   /**
@@ -112,7 +112,7 @@ struct ROSCPP_DECL AdvertiseServiceOptions
     datatype = st::datatype<Request>();
     req_datatype = mt::datatype<Request>();
     res_datatype = mt::datatype<Response>();
-    helper = ServiceCallbackHelperPtr(new ServiceCallbackHelperT<Spec>(_callback));
+    helper = boost::make_shared<ServiceCallbackHelperT<Spec> >(_callback);
   }
 
   std::string service;                                                ///< Service name

--- a/clients/roscpp/include/ros/forwards.h
+++ b/clients/roscpp/include/ros/forwards.h
@@ -35,6 +35,7 @@
 #include <list>
 
 #include <boost/shared_ptr.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/weak_ptr.hpp>
 #include <boost/function.hpp>
 

--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -387,7 +387,7 @@ ros::Subscriber sub = handle.subscribe("my_topic", 1, &Foo::callback, &foo_objec
 \verbatim
 ros::NodeHandle nodeHandle;
 void Foo::callback(const std_msgs::Empty::ConstPtr& message) {}
-boost::shared_ptr<Foo> foo_object(new Foo);
+boost::shared_ptr<Foo> foo_object(boost::make_shared<Foo>());
 ros::Subscriber sub = nodeHandle.subscribe("my_topic", 1, &Foo::callback, foo_object);
 if (sub)  // Enter if subscriber is valid
 {
@@ -450,7 +450,7 @@ ros::Subscriber sub = handle.subscribe("my_topic", 1, &Foo::callback, &foo_objec
 \verbatim
 ros::NodeHandle nodeHandle;
 void Foo::callback(const std_msgs::Empty::ConstPtr& message) {}
-boost::shared_ptr<Foo> foo_object(new Foo);
+boost::shared_ptr<Foo> foo_object(boost::make_shared<Foo>());
 ros::Subscriber sub = nodeHandle.subscribe("my_topic", 1, &Foo::callback, foo_object);
 if (sub)  // Enter if subscriber is valid
 {
@@ -496,7 +496,7 @@ void Foo::callback(const std_msgs::Empty::ConstPtr& message)
 {
 }
 
-boost::shared_ptr<Foo> foo_object(new Foo);
+boost::shared_ptr<Foo> foo_object(boost::make_shared<Foo>());
 ros::Subscriber sub = handle.subscribe("my_topic", 1, &Foo::callback, foo_object);
 \endverbatim
    *
@@ -514,7 +514,7 @@ ros::Subscriber sub = handle.subscribe("my_topic", 1, &Foo::callback, foo_object
 \verbatim
 ros::NodeHandle nodeHandle;
 void Foo::callback(const std_msgs::Empty::ConstPtr& message) {}
-boost::shared_ptr<Foo> foo_object(new Foo);
+boost::shared_ptr<Foo> foo_object(boost::make_shared<Foo>());
 ros::Subscriber sub = nodeHandle.subscribe("my_topic", 1, &Foo::callback, foo_object);
 if (sub)  // Enter if subscriber is valid
 {
@@ -561,7 +561,7 @@ void Foo::callback(const std_msgs::Empty::ConstPtr& message)
 {
 }
 
-boost::shared_ptr<Foo> foo_object(new Foo);
+boost::shared_ptr<Foo> foo_object(boost::make_shared<Foo>());
 ros::Subscriber sub = handle.subscribe("my_topic", 1, &Foo::callback, foo_object);
 \endverbatim
    *
@@ -579,7 +579,7 @@ ros::Subscriber sub = handle.subscribe("my_topic", 1, &Foo::callback, foo_object
 \verbatim
 ros::NodeHandle nodeHandle;
 void Foo::callback(const std_msgs::Empty::ConstPtr& message) {}
-boost::shared_ptr<Foo> foo_object(new Foo);
+boost::shared_ptr<Foo> foo_object(boost::make_shared<Foo>());
 ros::Subscriber sub = nodeHandle.subscribe("my_topic", 1, &Foo::callback, foo_object);
 if (sub)  // Enter if subscriber is valid
 {
@@ -940,7 +940,7 @@ bool Foo::callback(std_srvs::Empty& request, std_srvs::Empty& response)
   return true;
 }
 
-boost::shared_ptr<Foo> foo_object(new Foo);
+boost::shared_ptr<Foo> foo_object(boost::make_shared<Foo>());
 ros::ServiceServer service = handle.advertiseService("my_service", &Foo::callback, foo_object);
 \endverbatim
    *
@@ -987,7 +987,7 @@ bool Foo::callback(ros::ServiceEvent<std_srvs::Empty, std_srvs::Empty>& event)
   return true;
 }
 
-boost::shared_ptr<Foo> foo_object(new Foo);
+boost::shared_ptr<Foo> foo_object(boost::make_shared<Foo>());
 ros::ServiceServer service = handle.advertiseService("my_service", &Foo::callback, foo_object);
 \endverbatim
    *

--- a/clients/roscpp/include/ros/service_callback_helper.h
+++ b/clients/roscpp/include/ros/service_callback_helper.h
@@ -50,7 +50,7 @@ struct ROSCPP_DECL ServiceCallbackHelperCallParams
 template<typename M>
 inline boost::shared_ptr<M> defaultServiceCreateFunction()
 {
-  return boost::shared_ptr<M>(new M);
+  return boost::make_shared<M>();
 }
 
 template<typename MReq, typename MRes>

--- a/clients/roscpp/include/ros/subscribe_options.h
+++ b/clients/roscpp/include/ros/subscribe_options.h
@@ -88,7 +88,7 @@ struct ROSCPP_DECL SubscribeOptions
     queue_size = _queue_size;
     md5sum = message_traits::md5sum<MessageType>();
     datatype = message_traits::datatype<MessageType>();
-    helper = SubscriptionCallbackHelperPtr(new SubscriptionCallbackHelperT<P>(_callback, factory_fn));
+    helper = boost::make_shared<SubscriptionCallbackHelperT<P> >(_callback, factory_fn);
   }
 
   /**
@@ -109,7 +109,7 @@ struct ROSCPP_DECL SubscribeOptions
     queue_size = _queue_size;
     md5sum = message_traits::md5sum<MessageType>();
     datatype = message_traits::datatype<MessageType>();
-    helper = SubscriptionCallbackHelperPtr(new SubscriptionCallbackHelperT<const boost::shared_ptr<MessageType const>&>(_callback, factory_fn));
+    helper = boost::make_shared<SubscriptionCallbackHelperT<const boost::shared_ptr<MessageType const>&> >(_callback, factory_fn);
   }
 
   std::string topic;                                                ///< Topic to subscribe to

--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -282,7 +282,7 @@ template<class T, class D, class E>
 int32_t TimerManager<T, D, E>::add(const D& period, const boost::function<void(const E&)>& callback, CallbackQueueInterface* callback_queue,
                                    const VoidConstPtr& tracked_object, bool oneshot)
 {
-  TimerInfoPtr info(new TimerInfo);
+  TimerInfoPtr info(boost::make_shared<TimerInfo>());
   info->period = period;
   info->callback = callback;
   info->callback_queue = callback_queue;
@@ -515,7 +515,7 @@ void TimerManager<T, D, E>::threadFunc()
           current = T::now();
 
           //ROS_DEBUG("Scheduling timer callback for timer [%d] of period [%f], [%f] off expected", info->handle, info->period.toSec(), (current - info->next_expected).toSec());
-          CallbackInterfacePtr cb(new TimerQueueCallback(this, info, info->last_expected, info->last_real, info->next_expected));
+          CallbackInterfacePtr cb(boost::make_shared<TimerQueueCallback>(this, info, info->last_expected, info->last_real, info->next_expected));
           info->callback_queue->addCallback(cb, (uint64_t)info.get());
 
           waiting_.pop_front();

--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -117,7 +117,7 @@ void CallbackQueue::addCallback(const CallbackInterfacePtr& callback, uint64_t r
     M_IDInfo::iterator it = id_info_.find(removal_id);
     if (it == id_info_.end())
     {
-      IDInfoPtr id_info(new IDInfo);
+      IDInfoPtr id_info(boost::make_shared<IDInfo>());
       id_info->id = removal_id;
       id_info_.insert(std::make_pair(removal_id, id_info));
     }

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -295,8 +295,8 @@ Publisher NodeHandle::advertise(AdvertiseOptions& ops)
     }
   }
 
-  SubscriberCallbacksPtr callbacks(new SubscriberCallbacks(ops.connect_cb, ops.disconnect_cb, 
-							   ops.tracked_object, ops.callback_queue));
+  SubscriberCallbacksPtr callbacks(boost::make_shared<SubscriberCallbacks>(ops.connect_cb, ops.disconnect_cb, 
+                                                                           ops.tracked_object, ops.callback_queue));
 
   if (TopicManager::instance()->advertise(ops, callbacks))
   {

--- a/clients/roscpp/src/libros/publication.cpp
+++ b/clients/roscpp/src/libros/publication.cpp
@@ -113,7 +113,7 @@ void Publication::addCallbacks(const SubscriberCallbacksPtr& callbacks)
     for (; it != end; ++it)
     {
       const SubscriberLinkPtr& sub_link = *it;
-      CallbackInterfacePtr cb(new PeerConnDisconnCallback(callbacks->connect_, sub_link, callbacks->has_tracked_object_, callbacks->tracked_object_));
+      CallbackInterfacePtr cb(boost::make_shared<PeerConnDisconnCallback>(callbacks->connect_, sub_link, callbacks->has_tracked_object_, callbacks->tracked_object_));
       callbacks->callback_queue_->addCallback(cb, (uint64_t)callbacks.get());
     }
   }
@@ -331,7 +331,7 @@ void Publication::peerConnect(const SubscriberLinkPtr& sub_link)
     const SubscriberCallbacksPtr& cbs = *it;
     if (cbs->connect_ && cbs->callback_queue_)
     {
-      CallbackInterfacePtr cb(new PeerConnDisconnCallback(cbs->connect_, sub_link, cbs->has_tracked_object_, cbs->tracked_object_));
+      CallbackInterfacePtr cb(boost::make_shared<PeerConnDisconnCallback>(cbs->connect_, sub_link, cbs->has_tracked_object_, cbs->tracked_object_));
       cbs->callback_queue_->addCallback(cb, (uint64_t)cbs.get());
     }
   }
@@ -346,7 +346,7 @@ void Publication::peerDisconnect(const SubscriberLinkPtr& sub_link)
     const SubscriberCallbacksPtr& cbs = *it;
     if (cbs->disconnect_ && cbs->callback_queue_)
     {
-      CallbackInterfacePtr cb(new PeerConnDisconnCallback(cbs->disconnect_, sub_link, cbs->has_tracked_object_, cbs->tracked_object_));
+      CallbackInterfacePtr cb(boost::make_shared<PeerConnDisconnCallback>(cbs->disconnect_, sub_link, cbs->has_tracked_object_, cbs->tracked_object_));
       cbs->callback_queue_->addCallback(cb, (uint64_t)cbs.get());
     }
   }

--- a/clients/roscpp/src/libros/publisher.cpp
+++ b/clients/roscpp/src/libros/publisher.cpp
@@ -57,12 +57,12 @@ void Publisher::Impl::unadvertise()
 }
 
 Publisher::Publisher(const std::string& topic, const std::string& md5sum, const std::string& datatype, const NodeHandle& node_handle, const SubscriberCallbacksPtr& callbacks)
-: impl_(new Impl)
+: impl_(boost::make_shared<Impl>())
 {
   impl_->topic_ = topic;
   impl_->md5sum_ = md5sum;
   impl_->datatype_ = datatype;
-  impl_->node_handle_ = NodeHandlePtr(new NodeHandle(node_handle));
+  impl_->node_handle_ = boost::make_shared<NodeHandle>(node_handle);
   impl_->callbacks_ = callbacks;
 }
 

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -51,7 +51,7 @@ ROSOutAppender::ROSOutAppender()
   AdvertiseOptions ops;
   ops.init<rosgraph_msgs::Log>(names::resolve("/rosout"), 0);
   ops.latch = true;
-  SubscriberCallbacksPtr cbs(new SubscriberCallbacks);
+  SubscriberCallbacksPtr cbs(boost::make_shared<SubscriberCallbacks>());
   TopicManager::instance()->advertise(ops, cbs);
 }
 
@@ -74,7 +74,7 @@ const std::string&  ROSOutAppender::getLastError() const
 
 void ROSOutAppender::log(::ros::console::Level level, const char* str, const char* file, const char* function, int line)
 {
-  rosgraph_msgs::LogPtr msg(new rosgraph_msgs::Log);
+  rosgraph_msgs::LogPtr msg(boost::make_shared<rosgraph_msgs::Log>());
 
   msg->header.stamp = ros::Time::now();
   if (level == ros::console::levels::Debug)

--- a/clients/roscpp/src/libros/service.cpp
+++ b/clients/roscpp/src/libros/service.cpp
@@ -47,7 +47,7 @@ bool service::exists(const std::string& service_name, bool print_failure_reason)
 
   if (ServiceManager::instance()->lookupService(mapped_name, host, port))
   {
-    TransportTCPPtr transport(new TransportTCP(0, TransportTCP::SYNCHRONOUS));
+    TransportTCPPtr transport(boost::make_shared<TransportTCP>(static_cast<ros::PollSet*>(NULL), TransportTCP::SYNCHRONOUS));
 
     if (transport->connect(host, port))
     {

--- a/clients/roscpp/src/libros/service_manager.cpp
+++ b/clients/roscpp/src/libros/service_manager.cpp
@@ -61,7 +61,7 @@ const ServiceManagerPtr& ServiceManager::instance()
     boost::mutex::scoped_lock lock(g_service_manager_mutex);
     if (!g_service_manager)
     {
-      g_service_manager.reset(new ServiceManager);
+      g_service_manager = boost::make_shared<ServiceManager>();
     }
   }
 
@@ -148,7 +148,7 @@ bool ServiceManager::advertiseService(const AdvertiseServiceOptions& ops)
       return false;
     }
 
-    ServicePublicationPtr pub(new ServicePublication(ops.service, ops.md5sum, ops.datatype, ops.req_datatype, ops.res_datatype, ops.helper, ops.callback_queue, ops.tracked_object));
+    ServicePublicationPtr pub(boost::make_shared<ServicePublication>(ops.service, ops.md5sum, ops.datatype, ops.req_datatype, ops.res_datatype, ops.helper, ops.callback_queue, ops.tracked_object));
     service_publications_.push_back(pub);
   }
 
@@ -262,17 +262,17 @@ ServiceServerLinkPtr ServiceManager::createServiceServerLink(const std::string& 
     return ServiceServerLinkPtr();
   }
 
-  TransportTCPPtr transport(new TransportTCP(&poll_manager_->getPollSet()));
+  TransportTCPPtr transport(boost::make_shared<TransportTCP>(&poll_manager_->getPollSet()));
 
   // Make sure to initialize the connection *before* transport->connect()
   // is called, otherwise we might miss a connect error (see #434).
-  ConnectionPtr connection(new Connection());
+  ConnectionPtr connection(boost::make_shared<Connection>());
   connection_manager_->addConnection(connection);
   connection->initialize(transport, false, HeaderReceivedFunc());
 
   if (transport->connect(serv_host, serv_port))
   {
-    ServiceServerLinkPtr client(new ServiceServerLink(service, persistent, request_md5sum, response_md5sum, header_values));
+    ServiceServerLinkPtr client(boost::make_shared<ServiceServerLink>(service, persistent, request_md5sum, response_md5sum, header_values));
 
     {
       boost::mutex::scoped_lock lock(service_server_links_mutex_);

--- a/clients/roscpp/src/libros/service_publication.cpp
+++ b/clients/roscpp/src/libros/service_publication.cpp
@@ -157,7 +157,7 @@ private:
 
 void ServicePublication::processRequest(boost::shared_array<uint8_t> buf, size_t num_bytes, const ServiceClientLinkPtr& link)
 {
-  CallbackInterfacePtr cb(new ServiceCallback(helper_, buf, num_bytes, link, has_tracked_object_, tracked_object_));
+  CallbackInterfacePtr cb(boost::make_shared<ServiceCallback>(helper_, buf, num_bytes, link, has_tracked_object_, tracked_object_));
   callback_queue_->addCallback(cb, (uint64_t)this);
 }
 

--- a/clients/roscpp/src/libros/service_server.cpp
+++ b/clients/roscpp/src/libros/service_server.cpp
@@ -56,10 +56,10 @@ void ServiceServer::Impl::unadvertise()
 }
 
 ServiceServer::ServiceServer(const std::string& service, const NodeHandle& node_handle)
-: impl_(new Impl)
+: impl_(boost::make_shared<Impl>())
 {
   impl_->service_ = service;
-  impl_->node_handle_ = NodeHandlePtr(new NodeHandle(node_handle));
+  impl_->node_handle_ = boost::make_shared<NodeHandle>(node_handle);
 }
 
 ServiceServer::ServiceServer(const ServiceServer& rhs)

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -323,7 +323,7 @@ void ServiceServerLink::processNextCall()
 
 bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& resp)
 {
-  CallInfoPtr info(new CallInfo);
+  CallInfoPtr info(boost::make_shared<CallInfo>());
   info->req_ = req;
   info->resp_ = &resp;
   info->success_ = false;

--- a/clients/roscpp/src/libros/subscriber.cpp
+++ b/clients/roscpp/src/libros/subscriber.cpp
@@ -60,10 +60,10 @@ namespace ros
 
   Subscriber::Subscriber(const std::string& topic, const NodeHandle& node_handle, 
 			 const SubscriptionCallbackHelperPtr& helper)
-  : impl_(new Impl)
+  : impl_(boost::make_shared<Impl>())
   {
     impl_->topic_ = topic;
-    impl_->node_handle_ = NodeHandlePtr(new NodeHandle(node_handle));
+    impl_->node_handle_ = boost::make_shared<NodeHandle>(node_handle);
     impl_->helper_ = helper;
   }
 

--- a/clients/roscpp/src/libros/subscription.cpp
+++ b/clients/roscpp/src/libros/subscription.cpp
@@ -185,8 +185,8 @@ void Subscription::addLocalConnection(const PublicationPtr& pub)
 
   ROSCPP_LOG_DEBUG("Creating intraprocess link for topic [%s]", name_.c_str());
 
-  IntraProcessPublisherLinkPtr pub_link(new IntraProcessPublisherLink(shared_from_this(), XMLRPCManager::instance()->getServerURI(), transport_hints_));
-  IntraProcessSubscriberLinkPtr sub_link(new IntraProcessSubscriberLink(pub));
+  IntraProcessPublisherLinkPtr pub_link(boost::make_shared<IntraProcessPublisherLink>(shared_from_this(), XMLRPCManager::instance()->getServerURI(), transport_hints_));
+  IntraProcessSubscriberLinkPtr sub_link(boost::make_shared<IntraProcessSubscriberLink>(pub));
   pub_link->setPublisher(sub_link);
   sub_link->setSubscriber(pub_link);
 
@@ -355,7 +355,7 @@ bool Subscription::negotiateConnection(const std::string& xmlrpc_uri)
     if (*it == "UDP")
     {
       int max_datagram_size = transport_hints_.getMaxDatagramSize();
-      udp_transport = TransportUDPPtr(new TransportUDP(&PollManager::instance()->getPollSet()));
+      udp_transport = boost::make_shared<TransportUDP>(&PollManager::instance()->getPollSet());
       if (!max_datagram_size)
         max_datagram_size = udp_transport->getMaxDatagramSize();
       udp_transport->createIncoming(0, false);
@@ -419,7 +419,7 @@ bool Subscription::negotiateConnection(const std::string& xmlrpc_uri)
 
   // The PendingConnectionPtr takes ownership of c, and will delete it on
   // destruction.
-  PendingConnectionPtr conn(new PendingConnection(c, udp_transport, shared_from_this(), xmlrpc_uri));
+  PendingConnectionPtr conn(boost::make_shared<PendingConnection>(c, udp_transport, shared_from_this(), xmlrpc_uri));
 
   XMLRPCManager::instance()->addASyncConnection(conn);
   // Put this connection on the list that we'll look at later.
@@ -505,11 +505,11 @@ void Subscription::pendingConnectionDone(const PendingConnectionPtr& conn, XmlRp
     int pub_port = proto[2];
     ROSCPP_LOG_DEBUG("Connecting via tcpros to topic [%s] at host [%s:%d]", name_.c_str(), pub_host.c_str(), pub_port);
 
-    TransportTCPPtr transport(new TransportTCP(&PollManager::instance()->getPollSet()));
+    TransportTCPPtr transport(boost::make_shared<TransportTCP>(&PollManager::instance()->getPollSet()));
     if (transport->connect(pub_host, pub_port))
     {
-      ConnectionPtr connection(new Connection());
-      TransportPublisherLinkPtr pub_link(new TransportPublisherLink(shared_from_this(), xmlrpc_uri, transport_hints_));
+      ConnectionPtr connection(boost::make_shared<Connection>());
+      TransportPublisherLinkPtr pub_link(boost::make_shared<TransportPublisherLink>(shared_from_this(), xmlrpc_uri, transport_hints_));
 
       connection->initialize(transport, false, HeaderReceivedFunc());
       pub_link->initialize(connection);
@@ -545,7 +545,7 @@ void Subscription::pendingConnectionDone(const PendingConnectionPtr& conn, XmlRp
     int conn_id = proto[3];
     int max_datagram_size = proto[4];
     std::vector<char> header_bytes = proto[5];
-    boost::shared_array<uint8_t> buffer = boost::shared_array<uint8_t>(new uint8_t[header_bytes.size()]);
+    boost::shared_array<uint8_t> buffer(new uint8_t[header_bytes.size()]);
     memcpy(buffer.get(), &header_bytes[0], header_bytes.size());
     Header h;
     std::string err;
@@ -565,10 +565,10 @@ void Subscription::pendingConnectionDone(const PendingConnectionPtr& conn, XmlRp
       return;
     }
 
-    TransportPublisherLinkPtr pub_link(new TransportPublisherLink(shared_from_this(), xmlrpc_uri, transport_hints_));
+    TransportPublisherLinkPtr pub_link(boost::make_shared<TransportPublisherLink>(shared_from_this(), xmlrpc_uri, transport_hints_));
     if (pub_link->setHeader(h))
     {
-      ConnectionPtr connection(new Connection());
+      ConnectionPtr connection(boost::make_shared<Connection>());
       connection->initialize(udp_transport, false, NULL);
       connection->setHeader(h);
       pub_link->initialize(connection);
@@ -700,10 +700,10 @@ bool Subscription::addCallback(const SubscriptionCallbackHelperPtr& helper, cons
   {
     boost::mutex::scoped_lock lock(callbacks_mutex_);
 
-    CallbackInfoPtr info(new CallbackInfo);
+    CallbackInfoPtr info(boost::make_shared<CallbackInfo>());
     info->helper_ = helper;
     info->callback_queue_ = queue;
-    info->subscription_queue_.reset(new SubscriptionQueue(name_, queue_size, allow_concurrent_callbacks));
+    info->subscription_queue_ = boost::make_shared<SubscriptionQueue>(name_, queue_size, allow_concurrent_callbacks);
     info->tracked_object_ = tracked_object;
     info->has_tracked_object_ = false;
     if (tracked_object)
@@ -736,7 +736,7 @@ bool Subscription::addCallback(const SubscriptionCallbackHelperPtr& helper, cons
           {
             const LatchInfo& latch_info = des_it->second;
 
-            MessageDeserializerPtr des(new MessageDeserializer(helper, latch_info.message, latch_info.connection_header));
+            MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, latch_info.message, latch_info.connection_header));
             bool was_full = false;
             info->subscription_queue_->push(info->helper_, des, info->has_tracked_object_, info->tracked_object_, true, latch_info.receipt_time, &was_full);
             if (!was_full)

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -62,7 +62,7 @@ const TopicManagerPtr& TopicManager::instance()
     boost::mutex::scoped_lock lock(g_topic_manager_mutex);
     if (!g_topic_manager)
     {
-      g_topic_manager.reset(new TopicManager);
+      g_topic_manager = boost::make_shared<TopicManager>();
     }
   }
 
@@ -281,7 +281,7 @@ bool TopicManager::subscribe(const SubscribeOptions& ops)
   const std::string& md5sum = ops.md5sum;
   std::string datatype = ops.datatype;
 
-  SubscriptionPtr s(new Subscription(ops.topic, md5sum, datatype, ops.transport_hints));
+  SubscriptionPtr s(boost::make_shared<Subscription>(ops.topic, md5sum, datatype, ops.transport_hints));
   s->addCallback(ops.helper, ops.md5sum, ops.callback_queue, ops.queue_size, ops.tracked_object, ops.allow_concurrent_callbacks);
 
   if (!registerSubscriber(s, ops.datatype))
@@ -357,7 +357,7 @@ bool TopicManager::advertise(const AdvertiseOptions& ops, const SubscriberCallba
       return true;
     }
 
-    pub = PublicationPtr(new Publication(ops.topic, ops.datatype, ops.md5sum, ops.message_definition, ops.queue_size, ops.latch, ops.has_header));
+    pub = PublicationPtr(boost::make_shared<Publication>(ops.topic, ops.datatype, ops.md5sum, ops.message_definition, ops.queue_size, ops.latch, ops.has_header));
     pub->addCallbacks(callbacks);
     advertised_topics_.push_back(pub);
   }
@@ -635,7 +635,7 @@ bool TopicManager::requestTopic(const string &topic,
         return false;
       }
       std::vector<char> header_bytes = proto[1];
-      boost::shared_array<uint8_t> buffer = boost::shared_array<uint8_t>(new uint8_t[header_bytes.size()]);
+      boost::shared_array<uint8_t> buffer(new uint8_t[header_bytes.size()]);
       memcpy(buffer.get(), &header_bytes[0], header_bytes.size());
       Header h;
       string err;

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -626,7 +626,7 @@ TransportTCPPtr TransportTCP::accept()
   {
     ROSCPP_LOG_DEBUG("Accepted connection on socket [%d], new socket [%d]", sock_, new_sock);
 
-    TransportTCPPtr transport(new TransportTCP(poll_set_, flags_));
+    TransportTCPPtr transport(boost::make_shared<TransportTCP>(poll_set_, flags_));
     if (!transport->setSocket(new_sock))
     {
       ROS_ERROR("Failed to set socket on transport for socket %d", new_sock);

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -686,7 +686,7 @@ TransportUDPPtr TransportUDP::createOutgoing(std::string host, int port, int con
 {
   ROS_ASSERT(is_server_);
   
-  TransportUDPPtr transport(new TransportUDP(poll_set_, flags_, max_datagram_size));
+  TransportUDPPtr transport(boost::make_shared<TransportUDP>(poll_set_, flags_, max_datagram_size));
   if (!transport->connect(host, port, connection_id))
   {
     ROS_ERROR("Failed to create outgoing connection");

--- a/clients/roscpp/src/libros/transport_publisher_link.cpp
+++ b/clients/roscpp/src/libros/transport_publisher_link.cpp
@@ -221,10 +221,10 @@ void TransportPublisherLink::onRetryTimer(const ros::WallTimerEvent&)
 
       ROSCPP_LOG_DEBUG("Retrying connection to [%s:%d] for topic [%s]", host.c_str(), port, topic.c_str());
 
-      TransportTCPPtr transport(new TransportTCP(&PollManager::instance()->getPollSet()));
+      TransportTCPPtr transport(boost::make_shared<TransportTCP>(&PollManager::instance()->getPollSet()));
       if (transport->connect(host, port))
       {
-        ConnectionPtr connection(new Connection);
+        ConnectionPtr connection(boost::make_shared<Connection>());
         connection->initialize(transport, false, HeaderReceivedFunc());
         initialize(connection);
 

--- a/test/test_rosbag/test/test_bag.cpp.in
+++ b/test/test_rosbag/test/test_bag.cpp.in
@@ -131,8 +131,8 @@ TEST_F(BagTest, different_writes) {
     b1.open(filename, rosbag::bagmode::Write | rosbag::bagmode::Read);
 
     std_msgs::String msg1;
-    std_msgs::String::Ptr msg2 = boost::shared_ptr<std_msgs::String>(new std_msgs::String);
-    std_msgs::String::ConstPtr msg3 = boost::shared_ptr<std_msgs::String const>(new std_msgs::String);
+    std_msgs::String::Ptr msg2 = boost::make_shared<std_msgs::String>();
+    std_msgs::String::ConstPtr msg3 = boost::make_shared<std_msgs::String const>();
     
     rosbag::View view;
     view.addQuery(b1);

--- a/test/test_roscpp/perf/src/intra.cpp
+++ b/test/test_roscpp/perf/src/intra.cpp
@@ -179,7 +179,7 @@ void ThroughputTest::sendThread(boost::barrier* all_connected)
     }
   }
 
-  test_roscpp::ThroughputMessagePtr msg(new test_roscpp::ThroughputMessage);
+  test_roscpp::ThroughputMessagePtr msg(boost::make_shared<test_roscpp::ThroughputMessage>());
   msg->array.resize(message_size_);
 
   all_connected->wait();
@@ -443,7 +443,7 @@ void LatencyTest::sendThread(boost::barrier* all_connected, uint32_t thread_inde
   std::vector<test_roscpp::LatencyMessagePtr> messages;
   for (uint32_t i = 0; i < streams_; ++i)
   {
-    test_roscpp::LatencyMessagePtr msg(new test_roscpp::LatencyMessage);
+    test_roscpp::LatencyMessagePtr msg(boost::make_shared<test_roscpp::LatencyMessage>());
     msg->thread_index = thread_index;
     msg->array.resize(message_size_);
     messages.push_back(msg);
@@ -670,7 +670,7 @@ STLatencyResult STLatencyTest::run()
 
   ROS_INFO("All connections established");
 
-  test_roscpp::LatencyMessagePtr msg(new test_roscpp::LatencyMessage);
+  test_roscpp::LatencyMessagePtr msg(boost::make_shared<test_roscpp::LatencyMessage>());
   msg->publish_time = ros::WallTime::now().toSec();
   send_pub.publish(msg);
   while (msg->count < message_count_)

--- a/test/test_roscpp/test/src/handles.cpp
+++ b/test/test_roscpp/test/src/handles.cpp
@@ -442,7 +442,7 @@ TEST(RoscppHandles, trackedObjectWithAdvertiseSubscriberCallback)
 {
   ros::NodeHandle n;
 
-  boost::shared_ptr<char> tracked(new char);
+  boost::shared_ptr<char> tracked(boost::make_shared<char>());
 
   ros::Publisher pub = n.advertise<test_roscpp::TestArray>("/test", 0, connectedCallback, SubscriberStatusCallback(), tracked);
 
@@ -533,7 +533,7 @@ TEST(RoscppHandles, trackedObjectWithServiceCallback)
   n.setCallbackQueue(&queue);
   boost::thread th(boost::bind(pump, &queue));
 
-  boost::shared_ptr<ServiceClass> tracked(new ServiceClass);
+  boost::shared_ptr<ServiceClass> tracked(boost::make_shared<ServiceClass>());
   ros::ServiceServer srv = n.advertiseService("/test_srv", &ServiceClass::serviceCallback, tracked);
 
   TestStringString t;
@@ -551,7 +551,7 @@ TEST(RoscppHandles, trackedObjectWithSubscriptionCallback)
 {
   ros::NodeHandle n;
 
-  boost::shared_ptr<SubscribeHelper> tracked(new SubscribeHelper);
+  boost::shared_ptr<SubscribeHelper> tracked(boost::make_shared<SubscribeHelper>());
 
   g_recv_count = 0;
   ros::Subscriber sub = n.subscribe("/test", 0, &SubscribeHelper::callback, tracked);

--- a/test/test_roscpp/test/src/intraprocess_subscriptions.cpp
+++ b/test/test_roscpp/test/src/intraprocess_subscriptions.cpp
@@ -190,7 +190,7 @@ TEST(IntraprocessSubscriptions, noCopy)
   ros::Subscriber sub = nh.subscribe("test", 0, messageCallback);
   ros::Publisher pub = nh.advertise<Msg>("test", 0);
 
-  MsgConstPtr msg(new Msg);
+  MsgConstPtr msg(boost::make_shared<Msg>());
 
   while (pub.getNumSubscribers() == 0)
   {
@@ -221,7 +221,7 @@ TEST(IntraprocessSubscriptions, differentRTTI)
   ros::Subscriber sub = nh.subscribe("test", 0, messageCallback);
   ros::Publisher pub = nh.advertise<Msg2>("test", 0);
 
-  Msg2ConstPtr msg(new Msg2);
+  Msg2ConstPtr msg(boost::make_shared<Msg2>());
 
   while (pub.getNumSubscribers() == 0)
   {
@@ -259,7 +259,7 @@ TEST(IntraprocessSubscriptions, noCopyAndDifferentRTTI)
   ros::Subscriber sub2 = nh.subscribe("test", 0, messageCallback2);
   ros::Publisher pub = nh.advertise<Msg2>("test", 0);
 
-  Msg2ConstPtr msg(new Msg2);
+  Msg2ConstPtr msg(boost::make_shared<Msg2>());
 
   while (pub.getNumSubscribers() == 0)
   {

--- a/test/test_roscpp/test/src/nonconst_subscriptions.cpp
+++ b/test/test_roscpp/test/src/nonconst_subscriptions.cpp
@@ -71,7 +71,7 @@ TEST(NonConstSubscriptions, oneNonConstSubscriber)
   ros::Subscriber sub = nh.subscribe("test", 0, &NonConstHelper::callback, &h);
   ros::Publisher pub = nh.advertise<test_roscpp::TestEmpty>("test", 0);
 
-  test_roscpp::TestEmptyPtr msg(new test_roscpp::TestEmpty);
+  test_roscpp::TestEmptyPtr msg(boost::make_shared<test_roscpp::TestEmpty>());
   pub.publish(msg);
   ros::spinOnce();
 
@@ -88,7 +88,7 @@ TEST(NonConstSubscriptions, oneConstOneNonConst)
   ros::Subscriber sub2 = nh.subscribe("test", 0, &ConstHelper::callback, &h2);
   ros::Publisher pub = nh.advertise<test_roscpp::TestEmpty>("test", 0);
 
-  test_roscpp::TestEmptyPtr msg(new test_roscpp::TestEmpty);
+  test_roscpp::TestEmptyPtr msg(boost::make_shared<test_roscpp::TestEmpty>());
   pub.publish(msg);
   ros::spinOnce();
 
@@ -106,7 +106,7 @@ TEST(NonConstSubscriptions, twoNonConst)
   ros::Subscriber sub2 = nh.subscribe("test", 0, &NonConstHelper::callback, &h2);
   ros::Publisher pub = nh.advertise<test_roscpp::TestEmpty>("test", 0);
 
-  test_roscpp::TestEmptyPtr msg(new test_roscpp::TestEmpty);
+  test_roscpp::TestEmptyPtr msg(boost::make_shared<test_roscpp::TestEmpty>());
   pub.publish(msg);
   ros::spinOnce();
 
@@ -123,7 +123,7 @@ TEST(NonConstSubscriptions, twoConst)
   ros::Subscriber sub2 = nh.subscribe("test", 0, &ConstHelper::callback, &h2);
   ros::Publisher pub = nh.advertise<test_roscpp::TestEmpty>("test", 0);
 
-  test_roscpp::TestEmptyPtr msg(new test_roscpp::TestEmpty);
+  test_roscpp::TestEmptyPtr msg(boost::make_shared<test_roscpp::TestEmpty>());
   pub.publish(msg);
   ros::spinOnce();
 

--- a/test/test_roscpp/test/src/subscribe_star.cpp
+++ b/test/test_roscpp/test/src/subscribe_star.cpp
@@ -114,7 +114,7 @@ TEST(SubscribeStar, simpleSubFirstIntra)
   EXPECT_EQ(pub.getNumSubscribers(), 1U);
   EXPECT_EQ(sub.getNumPublishers(), 1U);
 
-  AnyMessagePtr msg(new AnyMessage);
+  AnyMessagePtr msg(boost::make_shared<AnyMessage>());
   pub.publish(msg);
   ros::spinOnce();
   EXPECT_EQ(h.count, 1U);
@@ -130,7 +130,7 @@ TEST(SubscribeStar, simplePubFirstIntra)
   EXPECT_EQ(pub.getNumSubscribers(), 1U);
   EXPECT_EQ(sub.getNumPublishers(), 1U);
 
-  AnyMessagePtr msg(new AnyMessage);
+  AnyMessagePtr msg(boost::make_shared<AnyMessage>());
   pub.publish(msg);
   ros::spinOnce();
   EXPECT_EQ(h.count, 1U);

--- a/test/test_roscpp/test/src/timer_callbacks.cpp
+++ b/test/test_roscpp/test/src/timer_callbacks.cpp
@@ -606,7 +606,7 @@ TEST(RoscppTimerCallbacks, trackedObject)
   Time now(1, 0);
   Time::setNow(now);
 
-  boost::shared_ptr<Tracked> tracked(new Tracked);
+  boost::shared_ptr<Tracked> tracked(boost::make_shared<Tracked>());
   Timer timer = n.createTimer(Duration(0.001), &Tracked::callback, tracked);
 
   now += Duration(0.1);

--- a/test/test_roscpp/test/test_callback_queue.cpp
+++ b/test/test_roscpp/test/test_callback_queue.cpp
@@ -67,7 +67,7 @@ typedef boost::shared_ptr<CountingCallback> CountingCallbackPtr;
 
 TEST(CallbackQueue, singleCallback)
 {
-  CountingCallbackPtr cb(new CountingCallback);
+  CountingCallbackPtr cb(boost::make_shared<CountingCallback>());
   CallbackQueue queue;
   queue.addCallback(cb, 1);
   queue.callOne();
@@ -88,7 +88,7 @@ TEST(CallbackQueue, singleCallback)
 
 TEST(CallbackQueue, multipleCallbacksCallAvailable)
 {
-  CountingCallbackPtr cb(new CountingCallback);
+  CountingCallbackPtr cb(boost::make_shared<CountingCallback>());
   CallbackQueue queue;
   for (uint32_t i = 0; i < 1000; ++i)
   {
@@ -102,7 +102,7 @@ TEST(CallbackQueue, multipleCallbacksCallAvailable)
 
 TEST(CallbackQueue, multipleCallbacksCallOne)
 {
-  CountingCallbackPtr cb(new CountingCallback);
+  CountingCallbackPtr cb(boost::make_shared<CountingCallback>());
   CallbackQueue queue;
   for (uint32_t i = 0; i < 1000; ++i)
   {
@@ -118,8 +118,8 @@ TEST(CallbackQueue, multipleCallbacksCallOne)
 
 TEST(CallbackQueue, remove)
 {
-  CountingCallbackPtr cb1(new CountingCallback);
-  CountingCallbackPtr cb2(new CountingCallback);
+  CountingCallbackPtr cb1(boost::make_shared<CountingCallback>());
+  CountingCallbackPtr cb2(boost::make_shared<CountingCallback>());
   CallbackQueue queue;
   queue.addCallback(cb1, 1);
   queue.addCallback(cb2, 2);
@@ -158,8 +158,8 @@ typedef boost::shared_ptr<SelfRemovingCallback> SelfRemovingCallbackPtr;
 TEST(CallbackQueue, removeSelf)
 {
   CallbackQueue queue;
-  SelfRemovingCallbackPtr cb1(new SelfRemovingCallback(&queue, 1));
-  CountingCallbackPtr cb2(new CountingCallback());
+  SelfRemovingCallbackPtr cb1(boost::make_shared<SelfRemovingCallback>(&queue, 1));
+  CountingCallbackPtr cb2(boost::make_shared<CountingCallback>());
   queue.addCallback(cb1, 1);
   queue.addCallback(cb2, 1);
   queue.addCallback(cb2, 1);
@@ -212,7 +212,7 @@ typedef boost::shared_ptr<RecursiveCallback> RecursiveCallbackPtr;
 TEST(CallbackQueue, recursive1)
 {
   CallbackQueue queue;
-  RecursiveCallbackPtr cb(new RecursiveCallback(&queue, true));
+  RecursiveCallbackPtr cb(boost::make_shared<RecursiveCallback>(&queue, true));
   queue.addCallback(cb, 1);
   queue.addCallback(cb, 1);
   queue.addCallback(cb, 1);
@@ -224,7 +224,7 @@ TEST(CallbackQueue, recursive1)
 TEST(CallbackQueue, recursive2)
 {
   CallbackQueue queue;
-  RecursiveCallbackPtr cb(new RecursiveCallback(&queue, false));
+  RecursiveCallbackPtr cb(boost::make_shared<RecursiveCallback>(&queue, false));
   queue.addCallback(cb, 1);
   queue.addCallback(cb, 1);
   queue.addCallback(cb, 1);
@@ -236,7 +236,7 @@ TEST(CallbackQueue, recursive2)
 TEST(CallbackQueue, recursive3)
 {
   CallbackQueue queue;
-  RecursiveCallbackPtr cb(new RecursiveCallback(&queue, false));
+  RecursiveCallbackPtr cb(boost::make_shared<RecursiveCallback>(&queue, false));
   queue.addCallback(cb, 1);
   queue.addCallback(cb, 1);
   queue.addCallback(cb, 1);
@@ -248,7 +248,7 @@ TEST(CallbackQueue, recursive3)
 TEST(CallbackQueue, recursive4)
 {
   CallbackQueue queue;
-  RecursiveCallbackPtr cb(new RecursiveCallback(&queue, true));
+  RecursiveCallbackPtr cb(boost::make_shared<RecursiveCallback>(&queue, true));
   queue.addCallback(cb, 1);
   queue.addCallback(cb, 1);
   queue.addCallback(cb, 1);
@@ -297,7 +297,7 @@ size_t runThreadedTest(const CountingCallbackPtr& cb, const boost::function<void
 
 TEST(CallbackQueue, threadedCallAvailable)
 {
-  CountingCallbackPtr cb(new CountingCallback);
+  CountingCallbackPtr cb(boost::make_shared<CountingCallback>());
   size_t i = runThreadedTest(cb, callAvailableThread);
   ROS_INFO_STREAM(i);
   EXPECT_EQ(cb->count, i);
@@ -313,7 +313,7 @@ void callOneThread(CallbackQueue* queue, bool& done)
 
 TEST(CallbackQueue, threadedCallOne)
 {
-  CountingCallbackPtr cb(new CountingCallback);
+  CountingCallbackPtr cb(boost::make_shared<CountingCallback>());
   size_t i = runThreadedTest(cb, callOneThread);
   ROS_INFO_STREAM(i);
   EXPECT_EQ(cb->count, i);
@@ -378,7 +378,7 @@ TEST(CallbackQueue, recursiveTimer)
   ros::Time::init();
   CallbackQueue queue;
   recursiveTimerQueue = &queue;
-  TimerRecursionCallbackPtr cb(new TimerRecursionCallback(&queue));
+  TimerRecursionCallbackPtr cb(boost::make_shared<TimerRecursionCallback>(&queue));
   queue.addCallback(cb, 1);
 
   boost::thread_group tg;

--- a/test/test_roscpp/test/test_subscription_queue.cpp
+++ b/test/test_roscpp/test/test_subscription_queue.cpp
@@ -66,7 +66,7 @@ public:
 
   virtual VoidConstPtr deserialize(const SubscriptionCallbackHelperDeserializeParams&)
   {
-    return VoidConstPtr(new FakeMessage);
+    return boost::make_shared<FakeMessage>();
   }
 
   virtual std::string getMD5Sum() { return ""; }
@@ -100,8 +100,8 @@ TEST(SubscriptionQueue, queueSize)
 {
   SubscriptionQueue queue("blah", 1, false);
 
-  FakeSubHelperPtr helper(new FakeSubHelper);
-  MessageDeserializerPtr des(new MessageDeserializer(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+  FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
   ASSERT_FALSE(queue.full());
 
@@ -133,8 +133,8 @@ TEST(SubscriptionQueue, infiniteQueue)
 {
   SubscriptionQueue queue("blah", 0, false);
 
-  FakeSubHelperPtr helper(new FakeSubHelper);
-  MessageDeserializerPtr des(new MessageDeserializer(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+  FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
   ASSERT_FALSE(queue.full());
 
@@ -164,8 +164,8 @@ TEST(SubscriptionQueue, clearCall)
 {
   SubscriptionQueue queue("blah", 1, false);
 
-  FakeSubHelperPtr helper(new FakeSubHelper);
-  MessageDeserializerPtr des(new MessageDeserializer(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+  FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
   queue.push(helper, des, false, VoidConstWPtr(), true);
   queue.clear();
@@ -176,8 +176,8 @@ TEST(SubscriptionQueue, clearThenAddAndCall)
 {
   SubscriptionQueue queue("blah", 1, false);
 
-  FakeSubHelperPtr helper(new FakeSubHelper);
-  MessageDeserializerPtr des(new MessageDeserializer(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+  FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
   queue.push(helper, des, false, VoidConstWPtr(), true);
   queue.clear();
@@ -194,8 +194,8 @@ TEST(SubscriptionQueue, clearInCallback)
 {
   SubscriptionQueue queue("blah", 1, false);
 
-  FakeSubHelperPtr helper(new FakeSubHelper);
-  MessageDeserializerPtr des(new MessageDeserializer(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+  FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
   helper->cb_ = boost::bind(clearInCallbackCallback, boost::ref(queue));
   queue.push(helper, des, false, VoidConstWPtr(), true);
@@ -218,8 +218,8 @@ TEST(SubscriptionQueue, clearWhileThreadIsBlocking)
 {
   SubscriptionQueue queue("blah", 1, false);
 
-  FakeSubHelperPtr helper(new FakeSubHelper);
-  MessageDeserializerPtr des(new MessageDeserializer(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+  FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
   bool done = false;
   boost::barrier barrier(2);
@@ -241,8 +241,8 @@ void waitForBarrier(boost::barrier* bar)
 TEST(SubscriptionQueue, concurrentCallbacks)
 {
   SubscriptionQueue queue("blah", 0, true);
-  FakeSubHelperPtr helper(new FakeSubHelper);
-  MessageDeserializerPtr des(new MessageDeserializer(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+  FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
   boost::barrier bar(2);
   helper->cb_ = boost::bind(waitForBarrier, &bar);
@@ -264,8 +264,8 @@ void waitForASecond()
 TEST(SubscriptionQueue, nonConcurrentOrdering)
 {
   SubscriptionQueue queue("blah", 0, false);
-  FakeSubHelperPtr helper(new FakeSubHelper);
-  MessageDeserializerPtr des(new MessageDeserializer(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+  FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
   helper->cb_ = waitForASecond;
   queue.push(helper, des, false, VoidConstWPtr(), true);

--- a/test/test_roscpp/test/test_transport_tcp.cpp
+++ b/test/test_roscpp/test/test_transport_tcp.cpp
@@ -58,8 +58,8 @@ protected:
 
   virtual void SetUp()
   {
-    transports_[0] = TransportTCPPtr(new TransportTCP(NULL, TransportTCP::SYNCHRONOUS));
-    transports_[1] = TransportTCPPtr(new TransportTCP(NULL, TransportTCP::SYNCHRONOUS));
+    transports_[0] = boost::make_shared<TransportTCP>(static_cast<ros::PollSet*>(NULL), TransportTCP::SYNCHRONOUS);
+    transports_[1] = boost::make_shared<TransportTCP>(static_cast<ros::PollSet*>(NULL), TransportTCP::SYNCHRONOUS);
 
     if (!transports_[0]->listen(0, 100, TransportTCP::AcceptCallback()))
     {
@@ -251,8 +251,8 @@ protected:
     disconnected_[1] = false;
     disconnected_[2] = false;
 
-    transports_[0] = TransportTCPPtr(new TransportTCP(&poll_set_));
-    transports_[1] = TransportTCPPtr(new TransportTCP(&poll_set_));
+    transports_[0] = boost::make_shared<TransportTCP>(&poll_set_);
+    transports_[1] = boost::make_shared<TransportTCP>(&poll_set_);
 
     if (!transports_[0]->listen(0, 100, boost::bind(&Polled::connectionReceived, this, _1)))
     {

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -126,7 +126,7 @@ void Player::publish() {
 
         try
         {
-            shared_ptr<Bag> bag(new Bag);
+            shared_ptr<Bag> bag(boost::make_shared<Bag>());
             bag->open(filename, bagmode::Read);
             bags_.push_back(bag);
         }

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -209,19 +209,17 @@ shared_ptr<ros::Subscriber> Recorder::subscribe(string const& topic) {
 	ROS_INFO("Subscribing to %s", topic.c_str());
 
     ros::NodeHandle nh;
-    shared_ptr<int> count(new int(options_.limit));
-    shared_ptr<ros::Subscriber> sub(new ros::Subscriber);
+    shared_ptr<int> count(boost::make_shared<int>(options_.limit));
+    shared_ptr<ros::Subscriber> sub(boost::make_shared<ros::Subscriber>());
 
     ros::SubscribeOptions ops;
     ops.topic = topic;
     ops.queue_size = 100;
     ops.md5sum = ros::message_traits::md5sum<topic_tools::ShapeShifter>();
     ops.datatype = ros::message_traits::datatype<topic_tools::ShapeShifter>();
-    ops.helper = ros::SubscriptionCallbackHelperPtr(
-        new ros::SubscriptionCallbackHelperT<const ros::MessageEvent<topic_tools::ShapeShifter const>& >(
-            boost::bind(&Recorder::doQueue, this, _1, topic, sub, count)
-        )
-    );
+    ops.helper = boost::make_shared<ros::SubscriptionCallbackHelperT<
+        const ros::MessageEvent<topic_tools::ShapeShifter const> &> >(
+            boost::bind(&Recorder::doQueue, this, _1, topic, sub, count));
     *sub = nh.subscribe(ops);
 
     currently_recording_.insert(topic);

--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -403,7 +403,7 @@ boost::shared_ptr<T> Bag::instantiateBuffer(IndexEntry const& index_entry) const
             throw BagFormatException((boost::format("Unknown connection ID: %1%") % connection_id).str());
         ConnectionInfo* connection_info = connection_iter->second;
 
-        boost::shared_ptr<T> p = boost::shared_ptr<T>(new T());
+        boost::shared_ptr<T> p = boost::make_shared<T>();
 
         ros::serialization::PreDeserializeParams<T> predes_params;
         predes_params.message = p;
@@ -440,10 +440,10 @@ boost::shared_ptr<T> Bag::instantiateBuffer(IndexEntry const& index_entry) const
             throw BagFormatException((boost::format("Unknown connection ID: %1%") % connection_id).str());
         ConnectionInfo* connection_info = connection_iter->second;
 
-        boost::shared_ptr<T> p = boost::shared_ptr<T>(new T());
+        boost::shared_ptr<T> p = boost::make_shared<T>();
 
         // Create a new connection header, updated with the latching and callerid values
-        boost::shared_ptr<ros::M_string> message_header(new ros::M_string);
+        boost::shared_ptr<ros::M_string> message_header(boost::make_shared<ros::M_string>());
         for (ros::M_string::const_iterator i = connection_info->header->begin(); i != connection_info->header->end(); i++)
             (*message_header)[i->first] = i->second;
         (*message_header)["latching"] = latching;
@@ -534,7 +534,7 @@ void Bag::doWrite(std::string const& topic, ros::Time const& time, T const& msg,
                 connection_info->header = connection_header;
             }
             else {
-                connection_info->header = boost::shared_ptr<ros::M_string>(new ros::M_string);
+                connection_info->header = boost::make_shared<ros::M_string>();
                 (*connection_info->header)["type"]               = connection_info->datatype;
                 (*connection_info->header)["md5sum"]             = connection_info->md5sum;
                 (*connection_info->header)["message_definition"] = connection_info->msg_def;

--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -685,7 +685,7 @@ void Bag::readConnectionRecord() {
         ConnectionInfo* connection_info = new ConnectionInfo();
         connection_info->id       = id;
         connection_info->topic    = topic;
-        connection_info->header = shared_ptr<M_string>(new M_string);
+        connection_info->header = boost::make_shared<M_string>();
         for (M_string::const_iterator i = connection_header.getValues()->begin(); i != connection_header.getValues()->end(); i++)
             (*connection_info->header)[i->first] = i->second;
         connection_info->msg_def  = (*connection_info->header)["message_definition"];
@@ -733,7 +733,7 @@ void Bag::readMessageDefinitionRecord102() {
     connection_info->msg_def  = message_definition;
     connection_info->datatype = datatype;
     connection_info->md5sum   = md5sum;
-    connection_info->header = boost::shared_ptr<ros::M_string>(new ros::M_string);
+    connection_info->header = boost::make_shared<ros::M_string>();
     (*connection_info->header)["type"]               = connection_info->datatype;
     (*connection_info->header)["md5sum"]             = connection_info->md5sum;
     (*connection_info->header)["message_definition"] = connection_info->msg_def;

--- a/tools/rosbag_storage/src/chunked_file.cpp
+++ b/tools/rosbag_storage/src/chunked_file.cpp
@@ -37,6 +37,7 @@
 #include <iostream>
 
 #include <boost/format.hpp>
+#include <boost/make_shared.hpp>
 
 //#include <ros/ros.h>
 #ifdef _WIN32
@@ -67,7 +68,7 @@ ChunkedFile::ChunkedFile() :
     unused_(NULL),
     nUnused_(0)
 {
-    stream_factory_ = boost::shared_ptr<StreamFactory>(new StreamFactory(this));
+    stream_factory_ = boost::make_shared<StreamFactory>(this);
 }
 
 ChunkedFile::~ChunkedFile() {
@@ -116,8 +117,8 @@ void ChunkedFile::open(string const& filename, string const& mode) {
     if (!file_)
         throw BagIOException((format("Error opening file: %1%") % filename.c_str()).str());
 
-    read_stream_  = shared_ptr<Stream>(new UncompressedStream(this));
-    write_stream_ = shared_ptr<Stream>(new UncompressedStream(this));
+    read_stream_  = boost::make_shared<UncompressedStream>(this);
+    write_stream_ = boost::make_shared<UncompressedStream>(this);
     filename_     = filename;
     offset_       = ftello(file_);
 }

--- a/tools/rosconsole/src/rosconsole/rosconsole.cpp
+++ b/tools/rosconsole/src/rosconsole/rosconsole.cpp
@@ -258,38 +258,38 @@ TokenPtr createTokenFromType(const std::string& type)
 {
   if (type == "severity")
   {
-    return TokenPtr(new SeverityToken());
+    return TokenPtr(boost::make_shared<SeverityToken>());
   }
   else if (type == "message")
   {
-    return TokenPtr(new MessageToken());
+    return TokenPtr(boost::make_shared<MessageToken>());
   }
   else if (type == "time")
   {
-    return TokenPtr(new TimeToken());
+    return TokenPtr(boost::make_shared<TimeToken>());
   }
   else if (type == "thread")
   {
-    return TokenPtr(new ThreadToken());
+    return TokenPtr(boost::make_shared<ThreadToken>());
   }
   else if (type == "logger")
   {
-    return TokenPtr(new LoggerToken());
+    return TokenPtr(boost::make_shared<LoggerToken>());
   }
   else if (type == "file")
   {
-    return TokenPtr(new FileToken());
+    return TokenPtr(boost::make_shared<FileToken>());
   }
   else if (type == "line")
   {
-    return TokenPtr(new LineToken());
+    return TokenPtr(boost::make_shared<LineToken>());
   }
   else if (type == "function")
   {
-    return TokenPtr(new FunctionToken());
+    return TokenPtr(boost::make_shared<FunctionToken>());
   }
 
-  return TokenPtr(new FixedMapToken(type));
+  return TokenPtr(boost::make_shared<FixedMapToken>(type));
 }
 
 void Formatter::init(const char* fmt)
@@ -314,7 +314,7 @@ void Formatter::init(const char* fmt)
 
     std::string token = results[1];
     last_suffix = results.suffix();
-    tokens_.push_back(TokenPtr(new FixedToken(results.prefix())));
+    tokens_.push_back(TokenPtr(boost::make_shared<FixedToken>(results.prefix())));
     tokens_.push_back(createTokenFromType(token));
 
     start = results[0].second;
@@ -323,11 +323,11 @@ void Formatter::init(const char* fmt)
 
   if (matched_once)
   {
-    tokens_.push_back(TokenPtr(new FixedToken(last_suffix)));
+    tokens_.push_back(TokenPtr(boost::make_shared<FixedToken>(last_suffix)));
   }
   else
   {
-    tokens_.push_back(TokenPtr(new FixedToken(format_)));
+    tokens_.push_back(TokenPtr(boost::make_shared<FixedToken>(format_)));
   }
 }
 

--- a/tools/rosconsole/src/rosconsole/rosconsole.cpp
+++ b/tools/rosconsole/src/rosconsole/rosconsole.cpp
@@ -40,6 +40,7 @@
 #include <boost/thread.hpp>
 #include <boost/shared_array.hpp>
 #include <boost/regex.hpp>
+#include <boost/make_shared.hpp>
 
 #include <cstdarg>
 #include <cstdlib>

--- a/tools/topic_tools/include/topic_tools/shape_shifter.h
+++ b/tools/topic_tools/include/topic_tools/shape_shifter.h
@@ -205,7 +205,7 @@ boost::shared_ptr<M> ShapeShifter::instantiate() const
   if (ros::message_traits::md5sum<M>() != getMD5Sum())
     throw ShapeShifterException("Tried to instantiate message without matching md5sum.");
   
-  boost::shared_ptr<M> p(new M());
+  boost::shared_ptr<M> p(boost::make_shared<M>());
 
   ros::serialization::IStream s(msgBuf, msgBufUsed);
   ros::serialization::deserialize(s, *p);

--- a/utilities/message_filters/include/message_filters/chain.h
+++ b/utilities/message_filters/include/message_filters/chain.h
@@ -92,8 +92,8 @@ void myCallback(const MsgConstPtr& msg)
 }
 
 Chain<Msg> c;
-c.addFilter(boost::shared_ptr<PassThrough<Msg> >(new PassThrough<Msg>));
-c.addFilter(boost::shared_ptr<PassThrough<Msg> >(new PassThrough<Msg>));
+c.addFilter(boost::make_shared<PassThrough<Msg> >());
+c.addFilter(boost::make_shared<PassThrough<Msg> >());
 c.registerCallback(myCallback);
 \endverbatim
 
@@ -156,7 +156,7 @@ public:
     FilterInfo info;
     info.add_func = boost::bind((void(F::*)(const EventType&))&F::add, filter.get(), _1);
     info.filter = filter;
-    info.passthrough.reset(new PassThrough<M>);
+    info.passthrough = boost::make_shared<PassThrough<M> >();
 
     last_filter_connection_.disconnect();
     info.passthrough->connectInput(*filter);

--- a/utilities/message_filters/test/msg_cache_unittest.cpp
+++ b/utilities/message_filters/test/msg_cache_unittest.cpp
@@ -209,7 +209,7 @@ TEST(Cache, eventInEventOut)
   EventHelper h;
   c1.registerCallback(&EventHelper::cb, &h);
 
-  ros::MessageEvent<Msg const> evt(MsgConstPtr(new Msg), ros::Time(4));
+  ros::MessageEvent<Msg const> evt(boost::make_shared<Msg const>(), ros::Time(4));
   c0.add(evt);
 
   EXPECT_EQ(h.event_.getReceiptTime(), evt.getReceiptTime());

--- a/utilities/message_filters/test/test_approximate_time_policy.cpp
+++ b/utilities/message_filters/test/test_approximate_time_policy.cpp
@@ -120,13 +120,13 @@ public:
     {
       if (input_[i].second == 0)
       {
-        MsgPtr p(new Msg);
+        MsgPtr p(boost::make_shared<Msg>());
         p->header.stamp = input_[i].first;
         sync_.add<0>(p);
       }
       else
       {
-        MsgPtr q(new Msg);
+        MsgPtr q(boost::make_shared<Msg>());
         q->header.stamp = input_[i].first;
         sync_.add<1>(q);
       }
@@ -180,7 +180,7 @@ public:
   {
     for (unsigned int i = 0; i < input_.size(); i++)
     {
-      MsgPtr p(new Msg);
+      MsgPtr p(boost::make_shared<Msg>());
       p->header.stamp = input_[i].first;
       switch (input_[i].second)
       {

--- a/utilities/message_filters/test/test_chain.cpp
+++ b/utilities/message_filters/test/test_chain.cpp
@@ -67,12 +67,12 @@ TEST(Chain, simple)
 {
   Helper h;
   Chain<Msg> c;
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
   c.registerCallback(boost::bind(&Helper::cb, &h));
 
-  c.add(MsgPtr(new Msg));
+  c.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
-  c.add(MsgPtr(new Msg));
+  c.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -80,15 +80,15 @@ TEST(Chain, multipleFilters)
 {
   Helper h;
   Chain<Msg> c;
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
   c.registerCallback(boost::bind(&Helper::cb, &h));
 
-  c.add(MsgPtr(new Msg));
+  c.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
-  c.add(MsgPtr(new Msg));
+  c.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -96,17 +96,17 @@ TEST(Chain, addingFilters)
 {
   Helper h;
   Chain<Msg> c;
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
   c.registerCallback(boost::bind(&Helper::cb, &h));
 
-  c.add(MsgPtr(new Msg));
+  c.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
 
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
 
-  c.add(MsgPtr(new Msg));
+  c.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -114,15 +114,15 @@ TEST(Chain, inputFilter)
 {
   Helper h;
   Chain<Msg> c;
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
   c.registerCallback(boost::bind(&Helper::cb, &h));
 
   PassThrough<Msg> p;
   c.connectInput(p);
-  p.add(MsgPtr(new Msg));
+  p.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
 
-  p.add(MsgPtr(new Msg));
+  p.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -134,9 +134,9 @@ TEST(Chain, nonSharedPtrFilter)
   c.addFilter(&p);
   c.registerCallback(boost::bind(&Helper::cb, &h));
 
-  c.add(MsgPtr(new Msg));
+  c.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 1);
-  c.add(MsgPtr(new Msg));
+  c.add(boost::make_shared<Msg>());
   EXPECT_EQ(h.count_, 2);
 }
 
@@ -146,7 +146,7 @@ TEST(Chain, retrieveFilter)
 
   ASSERT_FALSE(c.getFilter<PassThrough<Msg> >(0));
 
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
 
   ASSERT_TRUE(c.getFilter<PassThrough<Msg> >(0));
   ASSERT_FALSE(c.getFilter<PassThrough<Msg> >(1));
@@ -159,7 +159,7 @@ TEST(Chain, retrieveFilterThroughBaseClass)
 
   ASSERT_FALSE(cb->getFilter<PassThrough<Msg> >(0));
 
-  c.addFilter(PassThroughPtr(new PassThrough<Msg>));
+  c.addFilter(boost::make_shared<PassThrough<Msg> >());
 
   ASSERT_TRUE(cb->getFilter<PassThrough<Msg> >(0));
   ASSERT_FALSE(cb->getFilter<PassThrough<Msg> >(1));
@@ -173,7 +173,7 @@ struct PTDerived : public PassThrough<Msg>
 TEST(Chain, retrieveBaseClass)
 {
   Chain<Msg> c;
-  c.addFilter(PassThroughPtr(new PTDerived));
+  c.addFilter(boost::make_shared<PTDerived>());
   ASSERT_TRUE(c.getFilter<PassThrough<Msg> >(0));
   ASSERT_TRUE(c.getFilter<PTDerived>(0));
 }

--- a/utilities/message_filters/test/test_exact_time_policy.cpp
+++ b/utilities/message_filters/test/test_exact_time_policy.cpp
@@ -106,13 +106,13 @@ TEST(ExactTime, multipleTimes)
   Sync3 sync(2);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time();
 
   sync.add<0>(m);
   ASSERT_EQ(h.count_, 0);
 
-  m.reset(new Msg);
+  m = boost::make_shared<Msg>();
   m->header.stamp = ros::Time(0.1);
   sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
@@ -127,7 +127,7 @@ TEST(ExactTime, queueSize)
   Sync3 sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time();
 
   sync.add<0>(m);
@@ -135,12 +135,12 @@ TEST(ExactTime, queueSize)
   sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
 
-  m.reset(new Msg);
+  m = boost::make_shared<Msg>();
   m->header.stamp = ros::Time(0.1);
   sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
 
-  m.reset(new Msg);
+  m = boost::make_shared<Msg>();
   m->header.stamp = ros::Time(0);
   sync.add<1>(m);
   ASSERT_EQ(h.count_, 0);
@@ -154,7 +154,7 @@ TEST(ExactTime, dropCallback)
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
   sync.getPolicy()->registerDropCallback(boost::bind(&Helper::dropcb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time();
 
   sync.add<0>(m);
@@ -182,7 +182,7 @@ TEST(ExactTime, eventInEventOut)
   Sync2 sync(2);
   EventHelper h;
   sync.registerCallback(&EventHelper::callback, &h);
-  ros::MessageEvent<Msg const> evt(MsgPtr(new Msg), ros::Time(4));
+  ros::MessageEvent<Msg const> evt(boost::make_shared<Msg>(), ros::Time(4));
 
   sync.add<0>(evt);
   sync.add<1>(evt);

--- a/utilities/message_filters/test/test_simple.cpp
+++ b/utilities/message_filters/test/test_simple.cpp
@@ -120,7 +120,7 @@ TEST(SimpleFilter, callbackTypes)
   f.registerCallback<MsgPtr>(boost::bind(&Helper::cb6, &h, _1));
   f.registerCallback<const ros::MessageEvent<Msg>&>(boost::bind(&Helper::cb7, &h, _1));
 
-  f.add(Filter::EventType(MsgPtr(new Msg)));
+  f.add(Filter::EventType(boost::make_shared<Msg>()));
   EXPECT_EQ(h.counts_[0], 1);
   EXPECT_EQ(h.counts_[1], 1);
   EXPECT_EQ(h.counts_[2], 1);

--- a/utilities/message_filters/test/test_subscriber.cpp
+++ b/utilities/message_filters/test/test_subscriber.cpp
@@ -105,7 +105,7 @@ TEST(Subscriber, subInChain)
   ros::NodeHandle nh;
   Helper h;
   Chain<Msg> c;
-  c.addFilter(boost::make_shared<Subscriber<Msg> >(nh, "test_topic", 0));
+  c.addFilter(boost::make_shared<Subscriber<Msg> >(boost::ref(nh), "test_topic", 0));
   c.registerCallback(boost::bind(&Helper::cb, &h, _1));
   ros::Publisher pub = nh.advertise<Msg>("test_topic", 0);
 

--- a/utilities/message_filters/test/test_subscriber.cpp
+++ b/utilities/message_filters/test/test_subscriber.cpp
@@ -105,7 +105,7 @@ TEST(Subscriber, subInChain)
   ros::NodeHandle nh;
   Helper h;
   Chain<Msg> c;
-  c.addFilter(boost::shared_ptr<Subscriber<Msg> >(new Subscriber<Msg>(nh, "test_topic", 0)));
+  c.addFilter(boost::make_shared<Subscriber<Msg> >(nh, "test_topic", 0));
   c.registerCallback(boost::bind(&Helper::cb, &h, _1));
   ros::Publisher pub = nh.advertise<Msg>("test_topic", 0);
 
@@ -147,7 +147,7 @@ TEST(Subscriber, singleNonConstCallback)
   Subscriber<Msg> sub(nh, "test_topic", 0);
   sub.registerCallback(&NonConstHelper::cb, &h);
   ros::Publisher pub = nh.advertise<Msg>("test_topic", 0);
-  MsgPtr msg(new Msg);
+  MsgPtr msg(boost::make_shared<Msg>());
   pub.publish(msg);
 
   ros::spinOnce();
@@ -164,7 +164,7 @@ TEST(Subscriber, multipleNonConstCallbacksFilterSubscriber)
   sub.registerCallback(&NonConstHelper::cb, &h);
   sub.registerCallback(&NonConstHelper::cb, &h2);
   ros::Publisher pub = nh.advertise<Msg>("test_topic", 0);
-  MsgPtr msg(new Msg);
+  MsgPtr msg(boost::make_shared<Msg>());
   pub.publish(msg);
 
   ros::spinOnce();
@@ -184,7 +184,7 @@ TEST(Subscriber, multipleCallbacksSomeFilterSomeDirect)
   sub.registerCallback(&NonConstHelper::cb, &h);
   ros::Subscriber sub2 = nh.subscribe("test_topic", 0, &NonConstHelper::cb, &h2);
   ros::Publisher pub = nh.advertise<Msg>("test_topic", 0);
-  MsgPtr msg(new Msg);
+  MsgPtr msg(boost::make_shared<Msg>());
   pub.publish(msg);
 
   ros::spinOnce();

--- a/utilities/message_filters/test/test_synchronizer.cpp
+++ b/utilities/message_filters/test/test_synchronizer.cpp
@@ -265,7 +265,7 @@ TEST(Synchronizer, compileMethod8)
 TEST(Synchronizer, add2)
 {
   Synchronizer<Policy2> sync;
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -278,7 +278,7 @@ TEST(Synchronizer, add2)
 TEST(Synchronizer, add3)
 {
   Synchronizer<Policy3> sync;
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -294,7 +294,7 @@ TEST(Synchronizer, add3)
 TEST(Synchronizer, add4)
 {
   Synchronizer<Policy4> sync;
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -313,7 +313,7 @@ TEST(Synchronizer, add4)
 TEST(Synchronizer, add5)
 {
   Synchronizer<Policy5> sync;
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -335,7 +335,7 @@ TEST(Synchronizer, add5)
 TEST(Synchronizer, add6)
 {
   Synchronizer<Policy6> sync;
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -360,7 +360,7 @@ TEST(Synchronizer, add6)
 TEST(Synchronizer, add7)
 {
   Synchronizer<Policy7> sync;
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -388,7 +388,7 @@ TEST(Synchronizer, add7)
 TEST(Synchronizer, add8)
 {
   Synchronizer<Policy8> sync;
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);
@@ -419,7 +419,7 @@ TEST(Synchronizer, add8)
 TEST(Synchronizer, add9)
 {
   Synchronizer<Policy9> sync;
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
 
   ASSERT_EQ(sync.added_[0], 0);
   sync.add<0>(m);

--- a/utilities/message_filters/test/time_sequencer_unittest.cpp
+++ b/utilities/message_filters/test/time_sequencer_unittest.cpp
@@ -88,7 +88,7 @@ TEST(TimeSequencer, simple)
   TimeSequencer<Msg> seq(ros::Duration(1.0), ros::Duration(0.01), 10);
   Helper h;
   seq.registerCallback(boost::bind(&Helper::cb, &h, _1));
-  MsgPtr msg(new Msg);
+  MsgPtr msg(boost::make_shared<Msg>());
   msg->header.stamp = ros::Time::now();
   seq.add(msg);
 
@@ -129,7 +129,7 @@ TEST(TimeSequencer, eventInEventOut)
   EventHelper h;
   seq2.registerCallback(&EventHelper::cb, &h);
 
-  ros::MessageEvent<Msg const> evt(MsgConstPtr(new Msg), ros::Time::now());
+  ros::MessageEvent<Msg const> evt(boost::make_shared<Msg const>(), ros::Time::now());
   seq.add(evt);
 
   ros::Time::setNow(ros::Time::now() + ros::Duration(2));

--- a/utilities/message_filters/test/time_synchronizer_unittest.cpp
+++ b/utilities/message_filters/test/time_synchronizer_unittest.cpp
@@ -263,7 +263,7 @@ TEST(TimeSynchronizer, immediate2)
   TimeSynchronizer<Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   sync.add0(m);
@@ -277,7 +277,7 @@ TEST(TimeSynchronizer, immediate3)
   TimeSynchronizer<Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   sync.add0(m);
@@ -293,7 +293,7 @@ TEST(TimeSynchronizer, immediate4)
   TimeSynchronizer<Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   sync.add0(m);
@@ -311,7 +311,7 @@ TEST(TimeSynchronizer, immediate5)
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   sync.add0(m);
@@ -331,7 +331,7 @@ TEST(TimeSynchronizer, immediate6)
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   sync.add0(m);
@@ -353,7 +353,7 @@ TEST(TimeSynchronizer, immediate7)
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   sync.add0(m);
@@ -377,7 +377,7 @@ TEST(TimeSynchronizer, immediate8)
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   sync.add0(m);
@@ -403,7 +403,7 @@ TEST(TimeSynchronizer, immediate9)
   TimeSynchronizer<Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   sync.add0(m);
@@ -435,13 +435,13 @@ TEST(TimeSynchronizer, multipleTimes)
   TimeSynchronizer<Msg, Msg, Msg> sync(2);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time();
 
   sync.add0(m);
   ASSERT_EQ(h.count_, 0);
 
-  m.reset(new Msg);
+  m = boost::make_shared<Msg>();
   m->header.stamp = ros::Time(0.1);
   sync.add1(m);
   ASSERT_EQ(h.count_, 0);
@@ -456,7 +456,7 @@ TEST(TimeSynchronizer, queueSize)
   TimeSynchronizer<Msg, Msg, Msg> sync(1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time();
 
   sync.add0(m);
@@ -464,12 +464,12 @@ TEST(TimeSynchronizer, queueSize)
   sync.add1(m);
   ASSERT_EQ(h.count_, 0);
 
-  m.reset(new Msg);
+  m = boost::make_shared<Msg>();
   m->header.stamp = ros::Time(0.1);
   sync.add1(m);
   ASSERT_EQ(h.count_, 0);
 
-  m.reset(new Msg);
+  m = boost::make_shared<Msg>();
   m->header.stamp = ros::Time(0);
   sync.add1(m);
   ASSERT_EQ(h.count_, 0);
@@ -483,7 +483,7 @@ TEST(TimeSynchronizer, dropCallback)
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
   sync.registerDropCallback(boost::bind(&Helper::dropcb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time();
 
   sync.add0(m);
@@ -511,7 +511,7 @@ TEST(TimeSynchronizer, eventInEventOut)
   TimeSynchronizer<Msg, Msg> sync(2);
   EventHelper h;
   sync.registerCallback(&EventHelper::callback, &h);
-  ros::MessageEvent<Msg const> evt(MsgPtr(new Msg), ros::Time(4));
+  ros::MessageEvent<Msg const> evt(boost::make_shared<Msg>(), ros::Time(4));
 
   sync.add<0>(evt);
   sync.add<1>(evt);
@@ -528,7 +528,7 @@ TEST(TimeSynchronizer, connectConstructor)
   TimeSynchronizer<Msg, Msg> sync(pt1, pt2, 1);
   Helper h;
   sync.registerCallback(boost::bind(&Helper::cb, &h));
-  MsgPtr m(new Msg);
+  MsgPtr m(boost::make_shared<Msg>());
   m->header.stamp = ros::Time::now();
 
   pt1.add(m);


### PR DESCRIPTION
As per https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rh-make_shared
