### PR TITLE
Preserve identity of `numpy_msg(T)`

### DIFF
--- a/clients/rospy/src/rospy/numpy_msg.py
+++ b/clients/rospy/src/rospy/numpy_msg.py
@@ -74,20 +74,26 @@ def _deserialize_numpy(self, str):
     # pass in numpy module reference to prevent import in auto-generated code
     return self.deserialize_numpy(str, numpy)
     
+_numpy_msg_types = {}
 ## Use this function to generate message instances using numpy array
 ## types for numerical arrays. 
 ## @msg_type Message class: call this functioning on the message type that you pass
 ## into a Publisher or Subscriber call. 
 ## @returns Message class
 def numpy_msg(msg_type):
-    classdict = { '__slots__': msg_type.__slots__, '_slot_types': msg_type._slot_types,
-                  '_md5sum': msg_type._md5sum, '_type': msg_type._type,
-                  '_has_header': msg_type._has_header, '_full_text': msg_type._full_text,
-                  'serialize': _serialize_numpy, 'deserialize': _deserialize_numpy,
-                  'serialize_numpy': msg_type.serialize_numpy,
-                  'deserialize_numpy': msg_type.deserialize_numpy
-                  }
-
-    # create the numpy message type
-    msg_type_name = "Numpy_%s"%msg_type._type.replace('/', '__')
-    return type(msg_type_name,(msg_type,),classdict)
+    if msg_type in _numpy_msg_types:
+        numpy_type = _numpy_msg_types[msg_type]
+    else:
+        classdict = { '__slots__': msg_type.__slots__, '_slot_types': msg_type._slot_types,
+                      '_md5sum': msg_type._md5sum, '_type': msg_type._type,
+                      '_has_header': msg_type._has_header, '_full_text': msg_type._full_text,
+                      'serialize': _serialize_numpy, 'deserialize': _deserialize_numpy,
+                      'serialize_numpy': msg_type.serialize_numpy,
+                      'deserialize_numpy': msg_type.deserialize_numpy
+                      }
+    
+        # create the numpy message type
+        msg_type_name = "Numpy_%s"%msg_type._type.replace('/', '__')
+        numpy_type = type(msg_type_name,(msg_type,),classdict)
+        _numpy_msg_types[msg_type] = numpy_type
+    return numpy_type

--- a/test/test_rospy/test/unit/test_rospy_numpy.py
+++ b/test/test_rospy/test/unit/test_rospy_numpy.py
@@ -78,3 +78,12 @@ class TestRospyNumpy(unittest.TestCase):
         self.assert_(isinstance(f3.data, numpy.ndarray), type(f3.data))
         v = numpy.equal(f3.data, numpy.array([1.0, 2.1, 3.2, 4.3, 5.4, 6.5], dtype=numpy.float32))
         self.assert_(v.all())
+
+    def test_class_identity(self):
+        from rospy.numpy_msg import numpy_msg
+        self.assert_(isinstance(numpy_msg(Floats)(), numpy_msg(Floats)))
+
+        FloatsNP = numpy_msg(Floats)
+        FloatsNP2 = numpy_msg(Floats)
+
+        self.assert_(FloatsNP is FloatsNP2)


### PR DESCRIPTION
This makes `numpy_msg(T) is numpy_msg(T)` always return true.
Otherwise, it is impossible to check whether a message is of a numpy type or not, since `isinstance(numpy_msg(T)(), numpy_msg(T))` would always return false
