### PR TITLE
fix max elements param for statistics window

### DIFF
--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -45,7 +45,7 @@ void StatisticsLogger::init(const SubscriptionCallbackHelperPtr& helper) {
   hasHeader_ = helper->hasHeader();
   param::param("/enable_statistics", enable_statistics, false);
   param::param("/statistics_window_min_elements", min_elements, 10);
-  param::param("/statistics_window_max_elements", min_elements, 100);
+  param::param("/statistics_window_max_elements", max_elements, 100);
   param::param("/statistics_window_min_size", min_window, 4);
   param::param("/statistics_window_max_size", max_window, 64);
 }


### PR DESCRIPTION
Fix `max_element` parameter for statistics windows. The wrong initialization has been the case since the feature was added in #398.
