### PR TITLE
Enable and fix rosmsg tests

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(roscpp)
 
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   cpp_common message_generation rosconsole roscpp_serialization roscpp_traits rosgraph_msgs rostime std_msgs xmlrpcpp
 )

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -742,7 +742,7 @@ bool getParamNames(std::vector<std::string>& keys)
   keys.resize(parameters.size());
 
   // Fill the output vector with the answer
-  for (size_t i = 0; i < parameters.size(); ++i) {
+  for (int i = 0; i < parameters.size(); ++i) {
     if (parameters[i].getType() != XmlRpc::XmlRpcValue::TypeString) {
       return false;
     }

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -156,17 +156,16 @@ logfatal = logging.getLogger('rosout').critical
 MASTER_NAME = "master" #master is a reserved node name for the central master
 
 import warnings
+import functools
 def deprecated(func):
     """This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emmitted
     when the function is used."""
+    @functools.wraps(func)
     def newFunc(*args, **kwargs):
         warnings.warn("Call to deprecated function %s." % func.__name__,
                       category=DeprecationWarning, stacklevel=2)
         return func(*args, **kwargs)
-    newFunc.__name__ = func.__name__
-    newFunc.__doc__ = func.__doc__
-    newFunc.__dict__.update(func.__dict__)
     return newFunc
 
 @deprecated

--- a/clients/rospy/src/rospy/rostime.py
+++ b/clients/rospy/src/rospy/rostime.py
@@ -87,7 +87,7 @@ class Duration(genpy.Duration):
         @param nsecs: nanoseconds
         @type  nsecs: int
         """
-        genpy.Duration.__init__(self, secs, nsecs)
+        super(Duration, self).__init__(secs, nsecs)
 
     def __repr__(self):
         return 'rospy.Duration[%d]' % self.to_nsec()
@@ -135,7 +135,7 @@ class Time(genpy.Time):
         @param nsecs: nanoseconds since seconds (since epoch)
         @type  nsecs: int
         """
-        genpy.Time.__init__(self, secs, nsecs)
+        super(Time, self).__init__(secs, nsecs)
         
     def __repr__(self):
         return 'rospy.Time[%d]' % self.to_nsec()

--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -191,7 +191,7 @@ class Timer(threading.Thread):
         @param oneshot: if True, fire only once, otherwise fire continuously until shutdown is called [default: False]
         @type  oneshot: bool
         """
-        threading.Thread.__init__(self)
+        super(Timer, self).__init__()
         self._period   = period
         self._callback = callback
         self._oneshot  = oneshot

--- a/test/test_rosbag/CMakeLists.txt
+++ b/test/test_rosbag/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 
 project(test_rosbag)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS message_generation rosbag rosconsole roscpp rosgraph_msgs rostest rosunit topic_tools xmlrpcpp)
 
 if(CATKIN_ENABLE_TESTING)

--- a/test/test_roscpp/CMakeLists.txt
+++ b/test/test_roscpp/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(test_roscpp)
 
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   message_generation roscpp rostest rosunit std_srvs
 )

--- a/test/test_rosparam/test/test_rosparam_command_line_offline.py
+++ b/test/test_rosparam/test/test_rosparam_command_line_offline.py
@@ -70,7 +70,7 @@ class TestRosparamOffline(unittest.TestCase):
             self.assert_("%s %s"%(cmd, c) in output[0].decode(), "%s: %s" % (c, output[0].decode()))
             
         # test no args on commands that require args
-        for c in ['set', 'get', 'load', 'dump', 'delete']:
+        for c in ['set', 'get', 'load', 'delete']:
             output = Popen([cmd, c], stdout=PIPE, stderr=PIPE).communicate()
             self.assert_("Usage:" in output[0].decode() or "Usage:" in output[1].decode(), "%s\n%s"%(output, c))
             self.assert_("%s %s"%(cmd, c) in output[1].decode())

--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosbag)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp topic_tools xmlrpcpp)
 find_package(Boost REQUIRED COMPONENTS date_time regex program_options filesystem)
 find_package(BZip2 REQUIRED)

--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(rosbag_storage)
 
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(console_bridge REQUIRED)
 find_package(catkin REQUIRED COMPONENTS cpp_common roscpp_serialization roscpp_traits rostime roslz4)
 find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options regex)

--- a/tools/rosconsole/CMakeLists.txt
+++ b/tools/rosconsole/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosconsole)
 
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS cpp_common rostime rosunit)
 
 find_package(Boost COMPONENTS regex system thread)

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -43,7 +43,7 @@ import logging.config
 import rospkg
 from rospkg.environment import ROS_LOG_DIR
 
-class LoggingException: pass
+class LoggingException(Exception): pass
 
 def renew_latest_logdir(logfile_dir):
     log_dir = os.path.dirname(logfile_dir)

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -247,7 +247,7 @@ def remap_localhost_uri(uri, force_localhost=False):
 ##################################################################
 # DATA STRUCTURES
 
-class Master:
+class Master(object):
     """
     Data structure for representing and querying state of master 
     """

--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -193,6 +193,7 @@ def check_roslaunch(f):
     except roslaunch.core.RLException as e:
         return str(e)
     
+    rospack = rospkg.RosPack()
     errors = []
     # check for missing deps
     try:
@@ -206,8 +207,21 @@ def check_roslaunch(f):
         missing = {}
         file_deps = {}
     for pkg, miss in missing.items():
-        if miss:
+        # even if the pkgs is not found in packges.xml, if other package.xml provdes that pkgs, then it will be ok
+        all_pkgs = []
+        try:
+            for file_dep in file_deps.keys():
+                file_pkg = rospkg.get_package_name(file_dep)
+                all_pkgs.extend(rospack.get_depends(file_pkg,implicit=False))
+                miss_all = list(set(miss) - set(all_pkgs))
+        except Exception as e:
+            print(e, file=sys.stderr)
+            miss_all = True
+        if miss_all:
+            print("Missing package dependencies: %s/package.xml: %s"%(pkg, ', '.join(miss)), file=sys.stderr)
             errors.append("Missing package dependencies: %s/package.xml: %s"%(pkg, ', '.join(miss)))
+        elif miss:
+            print("Missing package dependencies: %s/package.xml: %s (notify upstream maintainer)"%(pkg, ', '.join(miss)), file=sys.stderr)
     
     # load all node defs
     nodes = []
@@ -215,7 +229,6 @@ def check_roslaunch(f):
         nodes.extend(rldeps.nodes)
 
     # check for missing packages
-    rospack = rospkg.RosPack()
     for pkg, node_type in nodes:
         try:
             rospack.get_path(pkg)

--- a/tools/roslaunch/test/xml/test-arg-all.xml
+++ b/tools/roslaunch/test/xml/test-arg-all.xml
@@ -1,0 +1,48 @@
+<launch>
+
+  <arg name="required" />
+  <arg name="optional" default="not_set" />
+  <arg name="grounded" value="parent" />
+  <arg name="include_arg" value="dontcare" />
+  <arg name="if_test" value="dontcare" />
+
+  <arg name="param1_name" value="p1" />
+  <arg name="param2_name" value="p2" />
+  <arg name="param3_name" value="p3" />
+
+  <arg name="param1_value" value="$(arg required)" />
+  <arg name="param2_value" value="$(arg optional)" />
+  <arg name="param3_value" value="$(arg grounded)" />
+
+  <param name="$(arg param1_name)_test" value="$(arg param1_value)" />
+  <param name="$(arg param2_name)_test" value="$(arg param2_value)" />
+  <param name="$(arg param3_name)_test" value="$(arg param3_value)" />
+
+  <!-- Normal include: explicitly set args -->
+  <include ns="notall" file="$(find roslaunch)/test/xml/test-arg-include.xml">
+    <arg name="required" value="$(arg required)" />
+    <arg name="include_arg" value="$(arg include_arg)" />
+    <arg name="if_test" value="$(arg if_test)" />
+  </include>
+
+  <!-- Normal include: explicitly set args, including an optional one -->
+  <include ns="notall_optional" file="$(find roslaunch)/test/xml/test-arg-include.xml">
+    <arg name="required" value="$(arg required)" />
+    <arg name="optional" value="$(arg optional)" />
+    <arg name="include_arg" value="$(arg include_arg)" />
+    <arg name="if_test" value="$(arg if_test)" />
+  </include>
+
+  <!-- Include with passing in all args in my namespace -->
+  <include ns="all" file="$(find roslaunch)/test/xml/test-arg-include.xml"
+           pass_all_args="true">
+  </include>
+
+  <!-- Include with passing in all args in my namespace, and then override one
+       of them explicitly -->
+  <include ns="all_override" file="$(find roslaunch)/test/xml/test-arg-include.xml"
+           pass_all_args="true">
+    <arg name="required" value="override" />
+  </include>
+
+</launch>

--- a/tools/roslaunch/test/xml/test-arg-invalid-include.xml
+++ b/tools/roslaunch/test/xml/test-arg-invalid-include.xml
@@ -1,0 +1,5 @@
+<launch>
+  <include file="$(find roslaunch)/test/xml/test-arg-invalid-included.xml">
+    <arg name="grounded" value="not_set"/>
+  </include>
+</launch>

--- a/tools/roslaunch/test/xml/test-arg-invalid-include2.xml
+++ b/tools/roslaunch/test/xml/test-arg-invalid-include2.xml
@@ -1,0 +1,6 @@
+<launch>
+  <include file="$(find roslaunch)/test/xml/test-arg-invalid-included.xml" pass_all_args="true">
+    <arg name="grounded" value="not_set"/>
+  </include>
+</launch>
+

--- a/tools/roslaunch/test/xml/test-arg-invalid-included.xml
+++ b/tools/roslaunch/test/xml/test-arg-invalid-included.xml
@@ -1,0 +1,3 @@
+<launch>
+  <arg name="grounded" value="set"/>
+</launch>

--- a/tools/roslaunch/test/xml/test-arg-valid-include.xml
+++ b/tools/roslaunch/test/xml/test-arg-valid-include.xml
@@ -1,0 +1,5 @@
+<launch>
+  <arg name="grounded" value="not_set"/>
+  <include file="$(find roslaunch)/test/xml/test-arg-invalid-included.xml" pass_all_args="true"/>
+</launch>
+

--- a/tools/rosmaster/src/rosmaster/threadpool.py
+++ b/tools/rosmaster/src/rosmaster/threadpool.py
@@ -46,7 +46,7 @@ for gobbling up all of our threads
 import threading, logging, traceback
 from time import sleep
 
-class MarkedThreadPool:
+class MarkedThreadPool(object):
 
     """Flexible thread pool class.  Creates a pool of threads, then
     accepts tasks that will be dispatched to the next available

--- a/tools/rosmsg/CMakeLists.txt
+++ b/tools/rosmsg/CMakeLists.txt
@@ -4,3 +4,5 @@ find_package(catkin)
 catkin_package()
 
 catkin_python_setup()
+
+catkin_add_nosetests(test)

--- a/tools/rosmsg/package.xml
+++ b/tools/rosmsg/package.xml
@@ -25,6 +25,8 @@
   <run_depend>rosbag</run_depend>
   <run_depend>roslib</run_depend>
 
+  <test_depend>geometry_msgs</test_depend>
+
   <export>
     <rosdoc config="rosdoc.yaml"/>
     <architecture_independent/>

--- a/tools/rosmsg/test/RosmsgC_raw.txt
+++ b/tools/rosmsg/test/RosmsgC_raw.txt
@@ -1,2 +1,4 @@
 test_rosmaster/String s1
+  string data
 test_rosmaster/String s2
+  string data

--- a/tools/rosmsg/test/msg/RosmsgB.msg
+++ b/tools/rosmsg/test/msg/RosmsgB.msg
@@ -1,1 +1,1 @@
-std_msgs/Empty empty
+test_rosmaster/Empty empty

--- a/tools/rosmsg/test/msg/RosmsgC.msg
+++ b/tools/rosmsg/test/msg/RosmsgC.msg
@@ -1,2 +1,2 @@
-std_msgs/String s1
-std_msgs/String s2
+test_rosmaster/String s1
+test_rosmaster/String s2

--- a/tools/rosmsg/test/srv/RossrvB.srv
+++ b/tools/rosmsg/test/srv/RossrvB.srv
@@ -1,3 +1,3 @@
-std_msgs/Empty empty
+test_rosmaster/Empty empty
 ---
-std_msgs/Empty empty
+test_rosmaster/Empty empty

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -133,16 +133,19 @@ test_rosmaster/String s2
     def test_get_srv_text(self):
         d = get_test_path()
         srv_d = os.path.join(d, 'srv')
-        with open(os.path.join(srv_d, 'RossrvA.srv'), 'r') as f:
-            text = f.read()
-        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvA', raw=False))
-        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvA', raw=True))
-
-        # std_msgs/empty / std_msgs/empty
-        with open(os.path.join(srv_d, 'RossrvB.srv'), 'r') as f:
-            text = f.read()
-        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvB', raw=False))
-        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvB', raw=True))
+        
+        test_srv_package = 'test_rosmaster'
+        rospack = rospkg.RosPack()
+        srv_raw_d = os.path.join(rospack.get_path(test_srv_package), 'srv')
+        for t in ['RossrvA', 'RossrvB']:
+            with open(os.path.join(srv_d, '%s.srv'%t), 'r') as f:
+                text = f.read()
+            with open(os.path.join(srv_raw_d, '%s.srv'%t), 'r') as f:
+                text_raw = f.read()
+                
+            type_ = test_srv_package+'/'+t
+            self.assertEquals(text, rosmsg.get_srv_text(type_, raw=False))
+            self.assertEquals(text_raw, rosmsg.get_srv_text(type_, raw=True))
 
     def test_rosmsg_cmd_packages(self):
         from rosmsg import rosmsg_cmd_packages, MODE_MSG, MODE_SRV

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -39,6 +39,8 @@ try:
 except ImportError:
     from io import StringIO
 import time
+
+import rospkg
         
 import rosmsg
 
@@ -66,19 +68,26 @@ class TestRosmsg(unittest.TestCase):
     def test_get_msg_text(self):
         d = get_test_path()
         msg_d = os.path.join(d, 'msg')
+        
+        test_message_package = 'test_rosmaster'
+        rospack = rospkg.RosPack()
+        msg_raw_d = os.path.join(rospack.get_path(test_message_package), 'msg')
         for t in ['RosmsgA', 'RosmsgB']:
             with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
                 text = f.read()
-            type_ = 'test_rosmaster/'+t
+            with open(os.path.join(msg_raw_d, '%s.msg'%t), 'r') as f:
+                text_raw = f.read()
+                
+            type_ = test_message_package+'/'+t
             self.assertEquals(text, rosmsg.get_msg_text(type_, raw=False))
-            self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
+            self.assertEquals(text_raw, rosmsg.get_msg_text(type_, raw=True))
             
         # test recursive types
         t = 'RosmsgC'
-        with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
-            text = f.read()
+        with open(os.path.join(msg_raw_d, '%s.msg'%t), 'r') as f:
+            text_raw = f.read()
         type_ = 'test_rosmaster/'+t
-        self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
+        self.assertEquals(text_raw, rosmsg.get_msg_text(type_, raw=True))
         self.assertEquals("""test_rosmaster/String s1
   string data
 test_rosmaster/String s2

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -84,14 +84,14 @@ class TestRosmsg(unittest.TestCase):
             
         # test recursive types
         t = 'RosmsgC'
+        with open(os.path.join(d, '%s_raw.txt'%t), 'r') as f:
+            text = f.read()
         with open(os.path.join(msg_raw_d, '%s.msg'%t), 'r') as f:
             text_raw = f.read()
-        type_ = 'test_rosmaster/'+t
+        type_ = test_message_package+'/'+t
+        
+        self.assertEquals(text, rosmsg.get_msg_text(type_, raw=False))
         self.assertEquals(text_raw, rosmsg.get_msg_text(type_, raw=True))
-        self.assertEquals("""test_rosmaster/String s1
-  string data
-test_rosmaster/String s2
-  string data""", rosmsg.get_msg_text(type_, raw=False).strip())
 
     def test_iterate_packages(self):
         from rosmsg import iterate_packages, MODE_MSG, MODE_SRV

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -79,9 +79,9 @@ class TestRosmsg(unittest.TestCase):
             text = f.read()
         type_ = 'test_rosmaster/'+t
         self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
-        self.assertEquals("""std_msgs/String s1
+        self.assertEquals("""test_rosmaster/String s1
   string data
-std_msgs/String s2
+test_rosmaster/String s2
   string data""", rosmsg.get_msg_text(type_, raw=False).strip())
 
     def test_iterate_packages(self):

--- a/tools/rosmsg/test/test_rosmsg.py
+++ b/tools/rosmsg/test/test_rosmsg.py
@@ -69,7 +69,7 @@ class TestRosmsg(unittest.TestCase):
         for t in ['RosmsgA', 'RosmsgB']:
             with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
                 text = f.read()
-            type_ = 'test_ros/'+t
+            type_ = 'test_rosmaster/'+t
             self.assertEquals(text, rosmsg.get_msg_text(type_, raw=False))
             self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
             
@@ -77,7 +77,7 @@ class TestRosmsg(unittest.TestCase):
         t = 'RosmsgC'
         with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
             text = f.read()
-        type_ = 'test_ros/'+t
+        type_ = 'test_rosmaster/'+t
         self.assertEquals(text, rosmsg.get_msg_text(type_, raw=True))
         self.assertEquals("""std_msgs/String s1
   string data
@@ -111,14 +111,14 @@ std_msgs/String s2
         # test msgs
         l = rosmsg.list_types('rospy', mode='.msg')
         self.assertEquals([], l)
-        l = rosmsg.list_types('test_ros', mode='.msg')
-        for t in ['test_ros/RosmsgA', 'test_ros/RosmsgB', 'test_ros/RosmsgC']:
+        l = rosmsg.list_types('test_rosmaster', mode='.msg')
+        for t in ['test_rosmaster/RosmsgA', 'test_rosmaster/RosmsgB', 'test_rosmaster/RosmsgC']:
             assert t in l
         
         l = rosmsg.list_types('rospy', mode='.srv')
         self.assertEquals([], l)        
-        l = rosmsg.list_types('test_ros', mode='.srv')
-        for t in ['test_ros/RossrvA', 'test_ros/RossrvB']:
+        l = rosmsg.list_types('test_rosmaster', mode='.srv')
+        for t in ['test_rosmaster/RossrvA', 'test_rosmaster/RossrvB']:
             assert t in l
 
     def test_get_srv_text(self):
@@ -126,14 +126,14 @@ std_msgs/String s2
         srv_d = os.path.join(d, 'srv')
         with open(os.path.join(srv_d, 'RossrvA.srv'), 'r') as f:
             text = f.read()
-        self.assertEquals(text, rosmsg.get_srv_text('test_ros/RossrvA', raw=False))
-        self.assertEquals(text, rosmsg.get_srv_text('test_ros/RossrvA', raw=True))
+        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvA', raw=False))
+        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvA', raw=True))
 
         # std_msgs/empty / std_msgs/empty
         with open(os.path.join(srv_d, 'RossrvB.srv'), 'r') as f:
             text = f.read()
-        self.assertEquals(text, rosmsg.get_srv_text('test_ros/RossrvB', raw=False))
-        self.assertEquals(text, rosmsg.get_srv_text('test_ros/RossrvB', raw=True))
+        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvB', raw=False))
+        self.assertEquals(text, rosmsg.get_srv_text('test_rosmaster/RossrvB', raw=True))
 
     def test_rosmsg_cmd_packages(self):
         from rosmsg import rosmsg_cmd_packages, MODE_MSG, MODE_SRV

--- a/tools/rosmsg/test/test_rosmsg_command_line.py
+++ b/tools/rosmsg/test/test_rosmsg_command_line.py
@@ -75,7 +75,7 @@ class TestRosmsg(unittest.TestCase):
         l1 = [x for x in output1.split() if x]
         l2 = [x.strip() for x in output2.split('\n') if x.strip()]
         self.assertEquals(l1, l2)
-        for p in ['std_msgs', 'test_ros']:
+        for p in ['std_msgs', 'test_rosmaster']:
             self.assert_(p in l1)
         for p in ['std_srvs', 'rosmsg']:
             self.assert_(p not in l1)
@@ -85,7 +85,7 @@ class TestRosmsg(unittest.TestCase):
         l1 = [x for x in output1.split() if x]
         l2 = [x.strip() for x in output2.split('\n') if x.strip()]
         self.assertEquals(l1, l2)
-        for p in ['std_srvs', 'test_ros']:
+        for p in ['std_srvs', 'test_rosmaster']:
             self.assert_(p in l1)
         for p in ['std_msgs', 'rospy']:
             self.assert_(p not in l1)
@@ -94,7 +94,7 @@ class TestRosmsg(unittest.TestCase):
         # - multi-line
         output1 = Popen([os.path.join(_SCRIPT_FOLDER,'rosmsg'), 'list'], stdout=PIPE).communicate()[0]
         l1 = [x.strip() for x in output1.split('\n') if x.strip()]
-        for p in ['std_msgs/String', 'test_ros/Floats']:
+        for p in ['std_msgs/String', 'test_rosmaster/Floats']:
             self.assert_(p in l1)
         for p in ['std_srvs/Empty', 'roscpp/Empty']:
             self.assert_(p not in l1)
@@ -103,31 +103,31 @@ class TestRosmsg(unittest.TestCase):
         l1 = [x.strip() for x in output1.split('\n') if x.strip()]
         for p in ['std_srvs/Empty', 'roscpp/Empty']:
             self.assert_(p in l1)
-        for p in ['std_msgs/String', 'test_ros/Floats']:
+        for p in ['std_msgs/String', 'test_rosmaster/Floats']:
             self.assert_(p not in l1)
         
     def test_cmd_package(self):
         # this test is obviously very brittle, but should stabilize as the tests stabilize
         # - single line output
-        output1 = Popen(['rosmsg', 'package', '-s', 'test_ros'], stdout=PIPE).communicate()[0]
+        output1 = Popen(['rosmsg', 'package', '-s', 'test_rosmaster'], stdout=PIPE).communicate()[0]
         # - multi-line output
-        output2 = Popen(['rosmsg', 'package', 'test_ros'], stdout=PIPE).communicate()[0]
+        output2 = Popen(['rosmsg', 'package', 'test_rosmaster'], stdout=PIPE).communicate()[0]
         l = set([x for x in output1.split() if x])        
         l2 = set([x.strip() for x in output2.split('\n') if x.strip()])
         self.assertEquals(l, l2)
         
-        for m in ['test_ros/RosmsgA',
-                  'test_ros/RosmsgB',
-                  'test_ros/RosmsgC']:
+        for m in ['test_rosmaster/RosmsgA',
+                  'test_rosmaster/RosmsgB',
+                  'test_rosmaster/RosmsgC']:
             self.assertTrue(m in l, l)
         
-        output = Popen(['rossrv', 'package', '-s', 'test_ros'], stdout=PIPE).communicate()[0]
-        output2 = Popen(['rossrv', 'package','test_ros'], stdout=PIPE).communicate()[0]        
+        output = Popen(['rossrv', 'package', '-s', 'test_rosmaster'], stdout=PIPE).communicate()[0]
+        output2 = Popen(['rossrv', 'package','test_rosmaster'], stdout=PIPE).communicate()[0]        
         l = set([x for x in output.split() if x])
         l2 = set([x.strip() for x in output2.split('\n') if x.strip()])
         self.assertEquals(l, l2)
         
-        for m in ['test_ros/RossrvA', 'test_ros/RossrvB']:
+        for m in ['test_rosmaster/RossrvA', 'test_rosmaster/RossrvB']:
             self.assertTrue(m in l, l)
         
     ## test that the rosmsg/rossrv show command works
@@ -139,19 +139,19 @@ class TestRosmsg(unittest.TestCase):
         self.assertEquals('---', output.strip())
         output = Popen(['rossrv', 'show', 'std_srvs/Empty'], stdout=PIPE).communicate()[0]
         self.assertEquals('---', output.strip())
-        output = Popen(['rossrv', 'show', 'test_ros/AddTwoInts'], stdout=PIPE).communicate()[0]
+        output = Popen(['rossrv', 'show', 'test_rosmaster/AddTwoInts'], stdout=PIPE).communicate()[0]
         self.assertEquals('int64 a\nint64 b\n---\nint64 sum', output.strip())
 
         # test against test_rosmsg package
         rospack = rospkg.RosPack()
-        d = rospack.get_path('test_ros')
+        d = rospack.get_path('test_rosmaster')
         msg_d = os.path.join(d, 'msg')
         # - test with non-recursive types, which should have identical raw/non-raw
         for t in ['RosmsgA', 'RosmsgB']:
             with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
                 text = f.read()
             text = text+'\n' # running command adds one new line
-            type_ ='test_ros/'+t
+            type_ ='test_rosmaster/'+t
             output = Popen(['rosmsg', 'show', type_], stdout=PIPE).communicate()[0]
             self.assertEquals(text, output)
             output = Popen(['rosmsg', 'show', '-r',type_], stdout=PIPE, stderr=PIPE).communicate()
@@ -161,7 +161,7 @@ class TestRosmsg(unittest.TestCase):
 
             # test as search
             type_ = t
-            text = "[test_ros/%s]:\n%s"%(t, text)
+            text = "[test_rosmaster/%s]:\n%s"%(t, text)
             output = Popen(['rosmsg', 'show', type_], stdout=PIPE).communicate()[0]
             self.assertEquals(text, output)
             output = Popen(['rosmsg', 'show', '-r',type_], stdout=PIPE, stderr=PIPE).communicate()

--- a/tools/rosmsg/test/test_rosmsg_command_line.py
+++ b/tools/rosmsg/test/test_rosmsg_command_line.py
@@ -143,28 +143,36 @@ class TestRosmsg(unittest.TestCase):
         self.assertEquals('int64 a\nint64 b\n---\nint64 sum', output.strip())
 
         # test against test_rosmsg package
-        rospack = rospkg.RosPack()
-        d = rospack.get_path('test_rosmaster')
+        d = os.path.abspath(os.path.dirname(__file__))
         msg_d = os.path.join(d, 'msg')
-        # - test with non-recursive types, which should have identical raw/non-raw
+        
+        test_message_package = 'test_rosmaster'
+        rospack = rospkg.RosPack()
+        msg_raw_d = os.path.join(rospack.get_path(test_message_package), 'msg')
+        
+        # - test with non-recursive types
         for t in ['RosmsgA', 'RosmsgB']:
             with open(os.path.join(msg_d, '%s.msg'%t), 'r') as f:
                 text = f.read()
+            with open(os.path.join(msg_raw_d, '%s.msg'%t), 'r') as f:
+                text_raw = f.read()
             text = text+'\n' # running command adds one new line
-            type_ ='test_rosmaster/'+t
+            text_raw = text_raw+'\n'
+            type_ =test_message_package+'/'+t
             output = Popen(['rosmsg', 'show', type_], stdout=PIPE).communicate()[0]
             self.assertEquals(text, output)
-            output = Popen(['rosmsg', 'show', '-r',type_], stdout=PIPE, stderr=PIPE).communicate()
-            self.assertEquals(text, output[0], "Failed: %s"%(str(output)))
+            output = Popen(['rosmsg', 'show', '-r',type_], stdout=PIPE).communicate()[0]
+            self.assertEquals(text_raw, output)
             output = Popen(['rosmsg', 'show', '--raw', type_], stdout=PIPE).communicate()[0]
-            self.assertEquals(text, output)
+            self.assertEquals(text_raw, output)
 
             # test as search
             type_ = t
             text = "[test_rosmaster/%s]:\n%s"%(t, text)
+            text_raw = "[test_rosmaster/%s]:\n%s"%(t, text_raw)
             output = Popen(['rosmsg', 'show', type_], stdout=PIPE).communicate()[0]
             self.assertEquals(text, output)
             output = Popen(['rosmsg', 'show', '-r',type_], stdout=PIPE, stderr=PIPE).communicate()
-            self.assertEquals(text, output[0], "Failed: %s"%(str(output)))
+            self.assertEquals(text_raw, output[0], "Failed: %s"%(str(output)))
             output = Popen(['rosmsg', 'show', '--raw', type_], stdout=PIPE).communicate()[0]
-            self.assertEquals(text, output)
+            self.assertEquals(text_raw, output)

--- a/tools/rosout/CMakeLists.txt
+++ b/tools/rosout/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosout)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS roscpp)
 
 catkin_package()

--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -47,7 +47,7 @@ function(add_rostest file)
     endforeach()
     set(_testname "${_testname}${_ext}")
   endif()
-  
+
   string(REPLACE "/" "_" _testname ${_testname})
 
   get_filename_component(_output_name ${_testname} NAME_WE)

--- a/tools/rostest/src/rostest/__init__.py
+++ b/tools/rostest/src/rostest/__init__.py
@@ -136,7 +136,7 @@ def rosrun(package, test_name, test, sysargs=None):
     suite = None
     if issubclass(test, unittest.TestCase):
         suite = unittest.TestLoader().loadTestsFromTestCase(test)
-    elif:
+    else:
         suite = unittest.TestLoader().loadTestsFromName(test)
 
     if text_mode:

--- a/tools/rostest/src/rostest/__init__.py
+++ b/tools/rostest/src/rostest/__init__.py
@@ -128,7 +128,7 @@ def rosrun(package, test_name, test, sysargs=None):
     text_mode = '--text' in sysargs
     coverage_mode = '--cov' in sysargs
     if coverage_mode:
-        _start_coverage(package)
+        _start_coverage([package])
 
     import unittest
     import rospy
@@ -144,7 +144,7 @@ def rosrun(package, test_name, test, sysargs=None):
     else:
         result = rosunit.create_xml_runner(package, test_name, result_file).run(suite)
     if coverage_mode:
-        _stop_coverage(package)
+        _stop_coverage([package])
     rosunit.print_unittest_summary(result)
     
     # shutdown any node resources in case test forgets to

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -97,7 +97,7 @@ class ROSTopicHz(object):
     """
     ROSTopicHz receives messages for a topic and computes frequency stats
     """
-    def __init__(self, window_size, filter_expr=None):
+    def __init__(self, window_size, filter_expr=None, use_wtime=False):
         import threading
         self.lock = threading.Lock()
         self.last_printed_tn = 0
@@ -105,6 +105,7 @@ class ROSTopicHz(object):
         self.msg_tn = 0
         self.times =[]
         self.filter_expr = filter_expr
+        self.use_wtime = use_wtime
         
         # can't have infinite window size due to memory restrictions
         if window_size < 0:
@@ -120,7 +121,8 @@ class ROSTopicHz(object):
         if self.filter_expr is not None and not self.filter_expr(m):
             return
         with self.lock:
-            curr_rostime = rospy.get_rostime()
+            curr_rostime = rospy.get_rostime() if not self.use_wtime else \
+                    rospy.Time.from_sec(time.time())
 
             # time reset
             if curr_rostime.is_zero():
@@ -129,7 +131,8 @@ class ROSTopicHz(object):
                     self.times = []
                 return
             
-            curr = curr_rostime.to_sec()
+            curr = curr_rostime.to_sec() if not self.use_wtime else \
+                    rospy.Time.from_sec(time.time()).to_sec()
             if self.msg_t0 < 0 or self.msg_t0 > curr:
                 self.msg_t0 = curr
                 self.msg_tn = curr
@@ -179,7 +182,7 @@ class ROSTopicHz(object):
 def _sleep(duration):
     rospy.rostime.wallsleep(duration)
 
-def _rostopic_hz(topic, window_size=-1, filter_expr=None):
+def _rostopic_hz(topic, window_size=-1, filter_expr=None, use_wtime=False):
     """
     Periodically print the publishing rate of a topic to console until
     shutdown
@@ -191,7 +194,7 @@ def _rostopic_hz(topic, window_size=-1, filter_expr=None):
     if rospy.is_shutdown():
         return
     rospy.init_node(NAME, anonymous=True)
-    rt = ROSTopicHz(window_size, filter_expr=filter_expr)
+    rt = ROSTopicHz(window_size, filter_expr=filter_expr, use_wtime=use_wtime)
     # we use a large buffer size as we don't know what sort of messages we're dealing with.
     # may parameterize this in the future
     if filter_expr is not None:
@@ -1187,6 +1190,9 @@ def _rostopic_cmd_hz(argv):
     parser.add_option("--filter",
                       dest="filter_expr", default=None,
                       help="only measure messages matching the specified Python expression", metavar="EXPR")
+    parser.add_option("--wall-time",
+                      dest="use_wtime", default=False, action="store_true",
+                      help="calculates rate using wall time which can be helpful when clock isnt published during simulation")
 
     (options, args) = parser.parse_args(args)
     if len(args) == 0:
@@ -1212,7 +1218,8 @@ def _rostopic_cmd_hz(argv):
         filter_expr = expr_eval(options.filter_expr)
     else:
         filter_expr = None
-    _rostopic_hz(topic, window_size=window_size, filter_expr=filter_expr)
+    _rostopic_hz(topic, window_size=window_size, filter_expr=filter_expr,
+                 use_wtime=options.use_wtime)
 
 def _rostopic_cmd_bw(argv=sys.argv):
     args = argv[2:]

--- a/tools/rostopic/test/check_rostopic_command_line_online.py
+++ b/tools/rostopic/test/check_rostopic_command_line_online.py
@@ -117,6 +117,10 @@ class TestRostopicOnline(unittest.TestCase):
                 # hz
                 stdout, stderr = run_for([cmd, 'hz', name], 2.)
                 self.assert_('average rate:' in stdout)
+
+                # delay
+                stdout, stderr = run_for([cmd, 'delay', name], 2.)
+                self.assert_('average rate:' in stdout)
             
         # pub
         #  - pub wait until ctrl-C, so we have to wait then kill it

--- a/tools/rostopic/test/test_rostopic_command_line_offline.py
+++ b/tools/rostopic/test/test_rostopic_command_line_offline.py
@@ -47,25 +47,26 @@ class TestRostopicOffline(unittest.TestCase):
     def test_cmd_help(self):
         cmd = 'rostopic'
 
-        sub = ['bw', 'echo', 'hz', 'info', 'list', 'pub', 'type','find']
+        sub = ['bw', 'echo', 'hz', 'delay', 'info', 'list', 'pub', 'type','find']
         output = Popen([cmd], stdout=PIPE).communicate()[0]
         self.assert_('Commands' in output)
         output = Popen([cmd, '-h'], stdout=PIPE).communicate()[0]
         self.assert_('Commands' in output)
         # make sure all the commands are in the usage
         for c in sub:
-            self.assert_("%s %s"%(cmd, c) in output, output)            
+            cmd_sub = "%s %s"%(cmd, c)
+            self.assert_(cmd_sub in output, "'%s' is not in help: \n%s"%(cmd_sub, output))
 
         for c in sub:
             output = Popen([cmd, c, '-h'], stdout=PIPE, stderr=PIPE).communicate()
-            self.assert_("Usage:" in output[0], output)
+            self.assert_("usage:" in output[0].lower(), output)
             # make sure usage refers to the command
             self.assert_("%s %s"%(cmd, c) in output[0], output)
             
         # test no args on commands that require args
-        for c in ['bw', 'echo', 'hz', 'info', 'pub', 'type', 'find']:
+        for c in ['bw', 'echo', 'hz', 'delay', 'info', 'pub', 'type', 'find']:
             output = Popen([cmd, c], stdout=PIPE, stderr=PIPE).communicate()
-            self.assert_("Usage:" in output[0] or "Usage:" in output[1], output)
+            self.assert_("usage:" in output[0].lower() or "usage:" in output[1].lower(), output)
             # make sure usage refers to the command
             self.assert_("%s %s"%(cmd, c) in output[1], output)
             
@@ -84,6 +85,8 @@ class TestRostopicOffline(unittest.TestCase):
         output = Popen([cmd, 'echo', 'chatter'], **kwds).communicate()
         self.assert_(output[1].endswith(msg))
         output = Popen([cmd, 'hz', 'chatter'], **kwds).communicate()
+        self.assert_(output[1].endswith(msg))
+        output = Popen([cmd, 'delay', 'chatter'], **kwds).communicate()
         self.assert_(output[1].endswith(msg))
         output = Popen([cmd, 'list'], **kwds).communicate()
         self.assert_(output[1].endswith(msg))

--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(topic_tools)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin COMPONENTS cpp_common message_generation rosconsole roscpp rostime std_msgs xmlrpcpp)
 
 include_directories(include)

--- a/utilities/message_filters/CMakeLists.txt
+++ b/utilities/message_filters/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(message_filters)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS roscpp xmlrpcpp rosconsole)
 catkin_package(
   INCLUDE_DIRS include

--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -34,7 +34,7 @@ import itertools
 import threading
 import rospy
 
-class SimpleFilter:
+class SimpleFilter(object):
 
     def __init__(self):
         self.callbacks = {}

--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 
 project(roslz4)
 
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED)
 
 find_path(lz4_INCLUDE_DIRS NAMES lz4.h)

--- a/utilities/xmlrpcpp/CMakeLists.txt
+++ b/utilities/xmlrpcpp/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(xmlrpcpp)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 find_package(catkin REQUIRED COMPONENTS cpp_common)
 catkin_package(
   INCLUDE_DIRS include


### PR DESCRIPTION
As noted in #709, the test suite for `rosmsg` has long been disabled. This PR enables the test suite and updates the tests to make them pass. In some cases, it could be argued that instead the code should be updated instead of the tests. But I feel that's it's less risky to update the tests to match the long-standing behavior of the code.
