### PR TITLE
evaluation of expressions in roslaunch

### DIFF
--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -281,7 +281,8 @@ def _arg(resolved, a, args, context):
 # context.  We disable all the builtins, then add back True and False, and also
 # add true and false for convenience (because we accept those lower-case strings
 # as boolean values in XML).
-_eval_dict=dict(true=True, false=False, __builtins__={'True': True, 'False': False})
+_eval_dict={'true': True, 'false': False, 'True': True, 'False': False, '__builtins__': {},
+            'env': _eval_env, 'optenv': _eval_optenv, 'find': _eval_find}
 
 class _DictWrapper(object):
     def __init__(self, args, functions):
@@ -304,14 +305,14 @@ def _eval(s, context):
     def _eval_anon_context(id): return _eval_anon(id, anons=context['anon'])
     # inject arg context
     def _eval_arg_context(name): return loader.convert_value(_eval_arg(name, args=context['arg']), 'auto')
-    functions = dict(env = _eval_env, optenv = _eval_optenv, find = _eval_find,
-                     anon = _eval_anon_context, arg = _eval_arg_context)
+    functions = dict(anon = _eval_anon_context, arg = _eval_arg_context)
+    functions.update(_eval_dict)
 
     # ignore values containing double underscores (for safety)
     # http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
     if s.find('__') >= 0:
         raise SubstitutionException("$(eval ...) may not contain double underscore expressions")
-    return str(eval(s, _eval_dict, _DictWrapper(context['arg'], functions)))
+    return str(eval(s, {}, _DictWrapper(context['arg'], functions)))
 
 def resolve_args(arg_str, context=None, resolve_anon=True):
     """

--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -46,6 +46,7 @@ except ImportError:
 
 import rosgraph.names
 import rospkg
+import loader
 
 _rospack = None
 
@@ -285,7 +286,7 @@ _eval_dict=dict(true=True, false=False, __builtins__={'True': True, 'False': Fal
 
 def _eval(s, context):
     def _eval_anon_context(id): return _eval_anon(id, context)
-    def _eval_arg_context(name): return _eval_arg(name, context)
+    def _eval_arg_context(name): return loader.convert_value(_eval_arg(name, context), 'auto')
     functions = dict(env = _eval_env, optenv = _eval_optenv,
                      anon = _eval_anon_context, find = _eval_find,
                      arg = _eval_arg_context)

--- a/tools/roslaunch/test/unit/test_substitution_args.py
+++ b/tools/roslaunch/test/unit/test_substitution_args.py
@@ -140,6 +140,7 @@ def test_resolve_args():
         ("$(eval anon('foo'))", 'bar'),
         ("$(eval arg('fuga'))", 'hoge'),
         ('$(eval arg("fuga"))', 'hoge'),
+        ('$(eval fuga)', 'hoge'),
         ]
     for arg, val in tests:
         assert val == resolve_args(arg, context=context)

--- a/tools/roslaunch/test/unit/test_substitution_args.py
+++ b/tools/roslaunch/test/unit/test_substitution_args.py
@@ -95,7 +95,7 @@ def test_resolve_args():
     assert roslaunch_dir
 
     anon_context = {'foo': 'bar'}
-    arg_context = {'fuga': 'hoge', 'car': 'cdr'}
+    arg_context = {'fuga': 'hoge', 'car': 'cdr', 'arg': 'foo', 'True': 'False'}
     context = {'anon': anon_context, 'arg': arg_context }
         
     tests = [
@@ -140,7 +140,13 @@ def test_resolve_args():
         ("$(eval anon('foo'))", 'bar'),
         ("$(eval arg('fuga'))", 'hoge'),
         ('$(eval arg("fuga"))', 'hoge'),
+        ('$(eval arg("arg"))', 'foo'),
+        ('$(eval arg("True"))', 'False'),
+        ('$(eval 1==1)', 'True'),
+        ('$(eval [0,1,2][1])', '1'),
+        # test implicit arg access
         ('$(eval fuga)', 'hoge'),
+        ('$(eval True)', 'False'),
         ]
     for arg, val in tests:
         assert val == resolve_args(arg, context=context)

--- a/tools/roslaunch/test/unit/test_substitution_args.py
+++ b/tools/roslaunch/test/unit/test_substitution_args.py
@@ -130,6 +130,16 @@ def test_resolve_args():
         ('$(arg fuga)$(arg fuga)', 'hogehoge'),
         ('$(arg car)$(arg fuga)', 'cdrhoge'),
         ('$(arg fuga)hoge', 'hogehoge'),
+
+        # $(eval ...) versions of those tests
+        ("$(eval find('roslaunch'))", roslaunch_dir),
+        ("$(eval env('ROS_ROOT'))", os.environ['ROS_ROOT']),
+        ("$(eval optenv('ROS_ROOT', 'alternate text'))", os.environ['ROS_ROOT']),
+        ("$(eval optenv('NOT_ROS_ROOT', 'alternate text'))", "alternate text"),
+        ("$(eval optenv('NOT_ROS_ROOT'))", ""),
+        ("$(eval anon('foo'))", 'bar'),
+        ("$(eval arg('fuga'))", 'hoge'),
+        ('$(eval arg("fuga"))', 'hoge'),
         ]
     for arg, val in tests:
         assert val == resolve_args(arg, context=context)

--- a/tools/roslaunch/test/unit/test_substitution_args.py
+++ b/tools/roslaunch/test/unit/test_substitution_args.py
@@ -146,7 +146,7 @@ def test_resolve_args():
         ('$(eval [0,1,2][1])', '1'),
         # test implicit arg access
         ('$(eval fuga)', 'hoge'),
-        ('$(eval True)', 'False'),
+        ('$(eval True)', 'True'),
         ]
     for arg, val in tests:
         assert val == resolve_args(arg, context=context)

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -873,7 +873,7 @@ class TestXmlLoader(unittest.TestCase):
         filename = os.path.join(self.xml_dir, 'test-arg.xml')
 
         mock = RosLaunchMock()
-        loader.load(filename, mock, argv=["required:=test_arg", "if_test:=0", "py_if_test:=0"])
+        loader.load(filename, mock, argv=["required:=test_arg", "if_test:=0"])
 
         param_d = {}
         for p in mock.params:
@@ -916,7 +916,7 @@ class TestXmlLoader(unittest.TestCase):
 
         # test again with optional value set
         mock = RosLaunchMock()
-        loader.load(filename, mock, argv=["required:=test_arg", "optional:=test_arg2", "if_test:=1", "py_if_test:=1"])
+        loader.load(filename, mock, argv=["required:=test_arg", "optional:=test_arg2", "if_test:=1"])
 
         param_d = {}
         for p in mock.params:

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -816,11 +816,17 @@ class TestXmlLoader(unittest.TestCase):
         for k in keys:
             self.assert_('/'+k+'_pass' in param_d, param_d)
             self.failIf('/'+k+'_fail' in param_d, k)
+            # Also check the result of Python-parsed expressions
+            self.assert_('/py_'+k+'_pass' in param_d, param_d)
+            self.failIf('/py_'+k+'_fail' in param_d, k)
 
         n = mock.nodes[0]
         for k in ['if', 'unless']:
             self.assert_(['from_%s_pass'%k, 'to_%s_pass'%k] in n.remap_args)
             self.failIf(['from_%s_fail'%k, 'to_%s_fail'%k] in n.remap_args)            
+            # Also check the result of Python-parsed expressions
+            self.assert_(['py_from_%s_pass'%k, 'py_to_%s_pass'%k] in n.remap_args)
+            self.failIf(['py_from_%s_fail'%k, 'py_to_%s_fail'%k] in n.remap_args)
         
     def test_if_unless_invalid(self):
         mock = RosLaunchMock()
@@ -867,7 +873,7 @@ class TestXmlLoader(unittest.TestCase):
         filename = os.path.join(self.xml_dir, 'test-arg.xml')
 
         mock = RosLaunchMock()
-        loader.load(filename, mock, argv=["required:=test_arg", "if_test:=0"])
+        loader.load(filename, mock, argv=["required:=test_arg", "if_test:=0", "py_if_test:=0"])
 
         param_d = {}
         for p in mock.params:
@@ -877,11 +883,15 @@ class TestXmlLoader(unittest.TestCase):
         self.assertEquals(param_d['/p2_test'], 'not_set')
         self.assertEquals(param_d['/p3_test'], 'set')
         self.assertEquals(param_d['/succeed'], 'yes')                
+        self.assertEquals(param_d['/py_succeed'], 'yes')
         self.assertEquals(param_d['/if_test'], 'not_ran')                
+        self.assertEquals(param_d['/py_if_test'], 'not_ran')
         self.assertEquals(param_d['/if_param'], False)   
+        self.assertEquals(param_d['/py_if_param'], False)
         self.assertEquals(param_d['/int_param'], 1234)   
         self.assertAlmostEquals(param_d['/float_param'], 3.)   
         self.failIf('/fail' in param_d)
+        self.failIf('/py_fail' in param_d)
 
         # context tests
         #  - args are scoped to their context, and thus can be rebound in a sibling context
@@ -906,7 +916,7 @@ class TestXmlLoader(unittest.TestCase):
 
         # test again with optional value set
         mock = RosLaunchMock()
-        loader.load(filename, mock, argv=["required:=test_arg", "optional:=test_arg2", "if_test:=1"])
+        loader.load(filename, mock, argv=["required:=test_arg", "optional:=test_arg2", "if_test:=1", "py_if_test:=1"])
 
         param_d = {}
         for p in mock.params:
@@ -918,9 +928,13 @@ class TestXmlLoader(unittest.TestCase):
         self.assertEquals(param_d['/context1'], 'group1')
         self.assertEquals(param_d['/context2'], 'group2')                
         self.assertEquals(param_d['/succeed'], 'yes')                
+        self.assertEquals(param_d['/py_succeed'], 'yes')
         self.assertEquals(param_d['/if_test'], 'ran')   
+        self.assertEquals(param_d['/py_if_test'], 'ran')
         self.assertEquals(param_d['/if_param'], True)   
+        self.assertEquals(param_d['/py_if_param'], True)
         self.failIf('/fail' in param_d)
+        self.failIf('/py_fail' in param_d)
 
         # include tests
         self.assertEquals(param_d['/include_test/p1_test'], 'required1')

--- a/tools/roslaunch/test/xml/test-arg.xml
+++ b/tools/roslaunch/test/xml/test-arg.xml
@@ -2,8 +2,7 @@
 
   <arg name="required" />
   <arg name="if_test" />
-  <arg name="py_if_test" />
-  
+
   <arg name="optional" default="not_set" />
   <arg name="grounded" value="set" />
 
@@ -23,8 +22,8 @@
   <arg if="$(arg if_test)" name="if_param_value" value="true" />
   <arg unless="$(arg if_test)" name="if_param_value" value="false" />
 
-  <arg if="$(arg py_if_test)" name="py_if_param_value" value="$(eval 1 == 1)"/>
-  <arg unless="$(arg py_if_test)" name="py_if_param_value" value="$(eval 1 == 0)"/>
+  <arg if="$(arg if_test)" name="py_if_param_value" value="$(eval 1 == 1)"/>
+  <arg unless="$(arg if_test)" name="py_if_param_value" value="$(eval 1 == 0)"/>
 
   <param name="$(arg param1_name)_test" value="$(arg param1_value)" />
   <param name="$(arg param2_name)_test" value="$(arg param2_value)" />
@@ -63,7 +62,7 @@
   </group>
 
   <arg name="py_fail" value="$(eval 0 &gt; 1)"/>
-  <group if="$(eval arg('py_fail') == True)">
+  <group if="$(eval py_fail == True)">
     <param name="py_fail" value="fail" />
   </group>
 
@@ -71,11 +70,11 @@
     <param name="py_succeed" value="yes" />
   </group>
 
-  <group if="$(eval arg('py_if_test') == True)">
+  <group if="$(eval if_test == True)">
     <param name="py_if_test" value="ran" />
   </group>
 
-  <group unless="$(eval arg('py_if_test') == True)">
+  <group unless="$(eval arg('if_test') == True)">
     <param name="py_if_test" value="not_ran" />
   </group>
 

--- a/tools/roslaunch/test/xml/test-arg.xml
+++ b/tools/roslaunch/test/xml/test-arg.xml
@@ -2,6 +2,7 @@
 
   <arg name="required" />
   <arg name="if_test" />
+  <arg name="py_if_test" />
   
   <arg name="optional" default="not_set" />
   <arg name="grounded" value="set" />
@@ -22,11 +23,15 @@
   <arg if="$(arg if_test)" name="if_param_value" value="true" />
   <arg unless="$(arg if_test)" name="if_param_value" value="false" />
 
+  <arg if="$(arg py_if_test)" name="py_if_param_value" value="$(eval 1 == 1)"/>
+  <arg unless="$(arg py_if_test)" name="py_if_param_value" value="$(eval 1 == 0)"/>
+
   <param name="$(arg param1_name)_test" value="$(arg param1_value)" />
   <param name="$(arg param2_name)_test" value="$(arg param2_value)" />
   <param name="$(arg param3_name)_test" value="$(arg param3_value)" />
 
   <param name="if_param" value="$(arg if_param_value)" />
+  <param name="py_if_param" value="$(arg py_if_param_value)" />
   <param name="int_param" value="$(arg int_value)" />
   <param name="float_param" value="$(arg float_value)" />  
   
@@ -57,6 +62,23 @@
     <param name="if_test" value="not_ran" />
   </group>
 
+  <arg name="py_fail" value="$(eval 0 &gt; 1)"/>
+  <group if="$(eval arg('py_fail') == True)">
+    <param name="py_fail" value="fail" />
+  </group>
+
+  <group unless="$(eval arg('py_fail') == True)">
+    <param name="py_succeed" value="yes" />
+  </group>
+
+  <group if="$(eval arg('py_if_test') == True)">
+    <param name="py_if_test" value="ran" />
+  </group>
+
+  <group unless="$(eval arg('py_if_test') == True)">
+    <param name="py_if_test" value="not_ran" />
+  </group>
+
   <include file="$(find roslaunch)/test/xml/test-arg-include.xml">
     <arg name="required" value="required1" />
     <arg name="include_arg" value="$(arg include_arg)" />
@@ -74,6 +96,4 @@
     <arg name="include_arg" value="new3" />
   </include>
   
-
-
 </launch>

--- a/tools/roslaunch/test/xml/test-if-unless.xml
+++ b/tools/roslaunch/test/xml/test-if-unless.xml
@@ -45,18 +45,18 @@
   <arg name="false_upper" value="False"/>
 
   <param name="py_param_if_pass" value="1" if="$(eval arg('true_lower') and (40+2) == 42)"/>
-  <param name="py_param_if_fail" value="1" if="$(eval arg('false_lower') or (40-2) != 38)"/>
+  <param name="py_param_if_fail" value="1" if="$(eval false_lower or (40-2) != 38)"/>
 
   <param name="py_param_unless_pass" value="1" unless="$(eval arg('false_upper') or 1 &lt; 1)"/>
-  <param name="py_param_unless_fail" value="1" unless="$(eval arg('true_upper') and 1 &gt;= 1)"/>
+  <param name="py_param_unless_fail" value="1" unless="$(eval true_upper and 1 &gt;= 1)"/>
 
   <remap from="py_from_if_pass" to="py_to_if_pass" if="$(eval arg('true_upper') == True)"/>
-  <remap from="py_from_if_fail" to="py_to_if_fail" if="$(eval arg('false_upper') != False)"/>
+  <remap from="py_from_if_fail" to="py_to_if_fail" if="$(eval false_upper != False)"/>
 
   <remap from="py_from_unless_pass" to="py_to_unless_pass"
-         unless="$(eval arg('false_lower') or arg('false_upper') or arg('false_upper') != False)"/>
+         unless="$(eval arg('false_lower') or false_upper or arg('false_upper') != False)"/>
   <remap from="py_from_unless_fail" to="py_to_unless_fail"
-         unless="$(eval arg('true_lower') and arg('true_upper') and arg('true_upper') == True)"/>
+         unless="$(eval arg('true_lower') and true_upper and arg('true_upper') == True)"/>
 
   <node name="remap" pkg="rospy" type="talker.py" />
 

--- a/tools/roslaunch/test/xml/test-if-unless.xml
+++ b/tools/roslaunch/test/xml/test-if-unless.xml
@@ -25,6 +25,39 @@
   <remap from="from_unless_pass" to="to_unless_pass" unless="0" />
   <remap from="from_unless_fail" to="to_unless_fail" unless="1" />  
 
+  <!-- Test Python parsing -->
+  <group if="$(eval 1 == 1)">
+     <param name="py_group_if_pass" value="1" />
+  </group>
+  <group if="$(eval 0 == 1)">
+     <param name="py_group_if_fail" value="1" />
+  </group>
+  <group unless="$(eval 0 == 1)">
+     <param name="py_group_unless_pass" value="1" />
+  </group>
+  <group unless="$(eval 1 == 1)">
+     <param name="py_group_unless_fail" value="1" />
+  </group>
+
+  <arg name="true_lower" value="true"/>
+  <arg name="true_upper" value="True"/>
+  <arg name="false_lower" value="false"/>
+  <arg name="false_upper" value="False"/>
+
+  <param name="py_param_if_pass" value="1" if="$(eval arg('true_lower') and (40+2) == 42)"/>
+  <param name="py_param_if_fail" value="1" if="$(eval arg('false_lower') or (40-2) != 38)"/>
+
+  <param name="py_param_unless_pass" value="1" unless="$(eval arg('false_upper') or 1 &lt; 1)"/>
+  <param name="py_param_unless_fail" value="1" unless="$(eval arg('true_upper') and 1 &gt;= 1)"/>
+
+  <remap from="py_from_if_pass" to="py_to_if_pass" if="$(eval arg('true_upper') == True)"/>
+  <remap from="py_from_if_fail" to="py_to_if_fail" if="$(eval arg('false_upper') != False)"/>
+
+  <remap from="py_from_unless_pass" to="py_to_unless_pass"
+         unless="$(eval arg('false_lower') or arg('false_upper') or arg('false_upper') != False)"/>
+  <remap from="py_from_unless_fail" to="py_to_unless_fail"
+         unless="$(eval arg('true_lower') and arg('true_upper') and arg('true_upper') == True)"/>
+
   <node name="remap" pkg="rospy" type="talker.py" />
 
 </launch>


### PR DESCRIPTION
This replaces PR #707, providing a first proof-of-concept implementation of a generic $(eval ...) substitution arg as discussed in #707.

Unfortunately, the new resolve method cannot be seamlessly integrated into the existing `resolve_args` mechanism (as suggested by @gerkey), because the existing code uses the simple parser in `_collect_args`, which cannot handle parentheses within `$(xxx )` expressions. Hence, I handle `$(eval ...)` expressions in a specific fashion before resorting to the other resolve args.
For a similar reason, $(eval ) substitution args can only be handled if they span the whole string.

The branch https://github.com/ubi-agni/ros_comm/tree/roslaunch-eval provides a basic implementation.
The extension branch https://github.com/ubi-agni/ros_comm/tree/implicit-arg-access comprises a simplification to allow implicit access to arg values. Hence, instead of writing
`$(eval arg('my_arg') == 42)`
one can directly write:
`$(eval my_arg == 42)`

What do you think about that implementation?
