### PR TITLE
Set use_call_available_ to true if the thread count is greater than 1

### DIFF
--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -187,7 +187,7 @@ void AsyncSpinnerImpl::threadFunc()
   disableAllSignalsInThisThread();
 
   CallbackQueue* queue = callback_queue_;
-  bool use_call_available = thread_count_ == 1;
+  bool use_call_available = thread_count_ > 1;
   WallDuration timeout(0.1);
 
   while (continue_ && nh_.ok())


### PR DESCRIPTION
@dirk-thomas 
In `AsyncSpinnerImpl::threadFunc()`, it looks like `use_call_available_` should be true if the thread count is greater than 1. Looking at the if-statement in the while loop starting on 193:

```
bool use_call_available = thread_count_ == 1;
WallDuration timeout(0.1);
while (continue_ && nh_.ok())
  {
    if (use_call_available)
    {
      queue->callAvailable(timeout);
    }
    else
    {
      queue->callOne(timeout);
    }
  }

```

Since `use_call_available` is true when thread_count_ is 1, it is calling `callAvailable` when the thread count is 1, but calling `callOne` otherwise. This seems backwards.
