### PR TITLE
reenabled roswtf tests

### DIFF
--- a/utilities/roswtf/CMakeLists.txt
+++ b/utilities/roswtf/CMakeLists.txt
@@ -6,6 +6,6 @@ catkin_python_setup()
 
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest)
-  # add_rostest(test/roswtf.test)
-  # catkin_add_nosetests(test)
+  add_rostest(test/roswtf.test)
+  catkin_add_nosetests(test)
 endif()

--- a/utilities/roswtf/test/check_roswtf_command_line_online.py
+++ b/utilities/roswtf/test/check_roswtf_command_line_online.py
@@ -107,15 +107,27 @@ class TestRostopicOnline(unittest.TestCase):
         # every package in the ROS stack, which doesn't work.
 
         output, err = Popen([cmd], **kwds).communicate()
-        self.assert_('No errors or warnings' in output, "OUTPUT[%s]\nstderr[%s}"%(output, err))
-        self.assert_('ERROR' not in output, "CMD [%s] KWDS[%s] OUTPUT[%s]"%(cmd, kwds, output))
+        self._check_output([cmd], output, err)
 
         # run roswtf on a simple launch file online
         rospack = rospkg.RosPack()
         p = os.path.join(rospack.get_path('roswtf'), 'test', 'min.launch')
         output = Popen([cmd, p], **kwds).communicate()[0]
-        self.assert_('No errors or warnings' in output, "CMD[%s] OUTPUT[%s]"%([cmd, p], output))
-        self.assert_('ERROR' not in output, "OUTPUT[%s]"%output)        
-        
+        self._check_output([cmd, p], output)
+
+    def _check_output(self, cmd, output, error=None):
+        # do both a positive and negative test
+        self.assert_(
+            'No errors or warnings' in output or 'Found 1 error' in output,
+            'CMD[%s] OUTPUT[%s]%s' %
+            (' '.join(cmd), output, '\nstderr[%s]' % error if error else ''))
+        if 'No errors or warnings' in output:
+            self.assert_('ERROR' not in output, 'OUTPUT[%s]' % output)
+        if 'Found 1 error' in output:
+            self.assert_(output.count('ERROR') == 1, 'OUTPUT[%s]' % output)
+            self.assert_(
+                'Error: the rosdep view is empty' not in output,
+                'OUTPUT[%s]' % output)
+
 if __name__ == '__main__':
     rostest.run(PKG, NAME, TestRostopicOnline, sys.argv)

--- a/utilities/roswtf/test/test_roswtf_command_line_offline.py
+++ b/utilities/roswtf/test/test_roswtf_command_line_offline.py
@@ -94,13 +94,26 @@ class TestRoswtfOffline(unittest.TestCase):
         # run roswtf nakedly
         output = Popen([cmd], **kwds).communicate()
         output = [o.decode() for o in output]
-        # - due both a positive and negative test
-        self.assert_('No errors or warnings' in output[0], "OUTPUT[%s]"%str(output))
-        self.assert_('ERROR' not in output[0], "OUTPUT[%s]"%str(output))
+
+        # there should either be no errors or warnings or
+        # there should be exactly one error about rosdep not being initialized
+        self._check_output(output[0])
 
         # run roswtf on a simple launch file offline
         p = os.path.join(get_test_path(), 'min.launch')
         output = Popen([cmd, p], **kwds).communicate()[0]
         output = output.decode()
-        self.assert_('No errors or warnings' in output, "OUTPUT[%s]"%output)
-        self.assert_('ERROR' not in output, "OUTPUT[%s]"%output)        
+        self._check_output(output)
+
+    def _check_output(self, output):
+        # do both a positive and negative test
+        self.assert_(
+            'No errors or warnings' in output or 'Found 1 error' in output,
+            'OUTPUT[%s]' % output)
+        if 'No errors or warnings' in output:
+            self.assert_('ERROR' not in output, 'OUTPUT[%s]' % output)
+        if 'Found 1 error' in output:
+            self.assert_(output.count('ERROR') == 1, 'OUTPUT[%s]' % output)
+            self.assert_(
+                'Error: the rosdep view is empty' not in output,
+                'OUTPUT[%s]' % output)


### PR DESCRIPTION
Revert #752.

Should pass for Kinetic. For Indigo and Jade it still requires the new catkin version to be built.
