### PR TITLE
writing rosbags adds a newline

### DIFF
--- a/test/test_rosbag/test/test_bag.py
+++ b/test/test_rosbag/test/test_bag.py
@@ -33,10 +33,12 @@
 #
 # test_bag.py
 
+import hashlib
 import heapq
 import os
 import shutil
 import sys
+import tempfile
 import time
 import unittest
 
@@ -187,6 +189,33 @@ class TestRosbag(unittest.TestCase):
         msgs = list(rosbag.Bag(outbag_filename).read_messages())
 
         self.assertEquals(len(msgs), 5)
+
+    # Regression test for issue #736
+    def test_trivial_rosbag_filter(self):
+        tempdir = tempfile.mkdtemp()
+        try: 
+            inbag_filename = os.path.join(tempdir, 'test_rosbag_filter__1.bag') 
+            outbag1_filename = os.path.join(tempdir, 'test_rosbag_filter__2.bag') 
+            outbag2_filename = os.path.join(tempdir, 'test_rosbag_filter__3.bag') 
+
+            with rosbag.Bag(inbag_filename, 'w') as b:
+                for i in range(30):
+                    msg = ColorRGBA()
+                    t = genpy.Time.from_sec(i)
+                    b.write('/ints' + str(i), msg, t)
+
+            # filtering multiple times should not affect the filtered rosbag
+            cmd = 'rosbag filter %s %s "True"'
+            os.system(cmd % (inbag_filename, outbag1_filename))
+            os.system(cmd % (outbag1_filename, outbag2_filename))
+            
+            with open(outbag1_filename, 'r') as h:
+                outbag1_md5 = hashlib.md5(h.read()).hexdigest()
+            with open(outbag2_filename, 'r') as h:
+                outbag2_md5 = hashlib.md5(h.read()).hexdigest()
+            self.assertEquals(outbag1_md5, outbag2_md5)
+        finally:
+            shutil.rmtree(tempdir)
 
     def test_reindex_works(self):
         fn = '/tmp/test_reindex_works.bag'


### PR DESCRIPTION
Potential fix for https://github.com/ros/ros_comm/issues/736 where it was noticed that newlines are added each time rosbag filter is called.

From what I can see a newline is added to the message text [here](https://github.com/ros/genpy/blob/6577cc3d3731801913b3fdf62951609f1bf41b72/src/genpy/generator.py#L773) when writing a message, but it's never accounted for when reading the message. So it should either not be written, or it should be removed when reading.

Have removed the newline in the rosbag code but it may be appropriate to remove it [here](https://github.com/ros/genpy/blob/06cc06b7914174ecdddca641a0490651236a0336/src/genpy/dynamic.py#L127) instead
