### PR TITLE
Use defusedxml in rosmaster

### DIFF
--- a/tools/rosmaster/package.xml
+++ b/tools/rosmaster/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
   <run_depend>rosgraph</run_depend>
+  <run_depend>python-defusedxml</run_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/tools/rosmaster/src/rosmaster/util.py
+++ b/tools/rosmaster/src/rosmaster/util.py
@@ -45,6 +45,10 @@ try:
 except ImportError:
     from xmlrpclib import ServerProxy
 
+from defusedxml.xmlrpc import monkey_patch
+monkey_patch()
+del monkey_patch
+
 _proxies = {} #cache ServerProxys
 def xmlrpcapi(uri):
     """


### PR DESCRIPTION
I'm not sure if this is the best way to do it (particularly the "del" statement), but anyway defusedxml.monkey_patch() shuts down a bunch of different ways to blow up XML-RPC servers.
