### PR TITLE
Fix str conversion in encode_ros_handshake_header

### DIFF
--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -398,10 +398,14 @@ def encode_ros_handshake_header(header):
     str_cls = str if python3 else unicode
     
     # encode all unicode keys in the header. Ideally, the type of these would be specified by the api
-    for k, v in sorted(header.items()):
-        if isinstance(k, str_cls): k = k.encode('utf-8')
-        if isinstance(v, str_cls): v = v.encode('utf-8')
-    
+    for k, v in header.items():
+        if isinstance(k, str_cls):
+            header.pop(k)
+            k = k.encode('utf-8')
+            header[k] = v
+        if isinstance(v, str_cls):
+            header[k] = v.encode('utf-8')
+
     fields = [k + b"=" + v for k, v in sorted(header.items())]
     s = b''.join([struct.pack('<I', len(f)) + f for f in fields])
     

--- a/tools/rosgraph/test/test_network.py
+++ b/tools/rosgraph/test/test_network.py
@@ -71,6 +71,21 @@ class NetworkTest(unittest.TestCase):
         encoded = encoded+struct.pack('<I', len(s))+s        
         assert struct.pack('<I', len(encoded))+encoded == \
             encode_ros_handshake_header(d)
+        if sys.version_info > (3, 0):
+            assert encode_ros_handshake_header({'a': 'b',
+                                                'c': 'd',
+                                                'e': 'f'}) == \
+                encode_ros_handshake_header({b'a': 'b',
+                                             'c': b'd',
+                                             b'e': b'f'})
+        else:
+            assert encode_ros_handshake_header({'a': 'b',
+                                                'c': 'd',
+                                                'e': 'f'}) == \
+                encode_ros_handshake_header({unicode('a'): 'b',
+                                             'c': unicode('d'),
+                                             unicode('e'): unicode('f')})
+
       
     def test_decode_ros_handshake_header(self):
         from rosgraph.network import decode_ros_handshake_header, ROSHandshakeException


### PR DESCRIPTION
The previous code was not properly filtering unicode/str
out of the header. Added the corresponding unit test.
