### PR TITLE
explicitly declare rosout message dependencies

### DIFF
--- a/tools/rosout/CMakeLists.txt
+++ b/tools/rosout/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT WIN32)
   set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Wextra")
 endif()
 
-find_package(catkin REQUIRED COMPONENTS roscpp)
+find_package(catkin REQUIRED COMPONENTS roscpp rosgraph_msgs)
 
 catkin_package()
 

--- a/tools/rosout/package.xml
+++ b/tools/rosout/package.xml
@@ -16,4 +16,5 @@
   <build_depend>rosgraph_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>
+  <run_depend>rosgraph_msgs</run_depend>
 </package>


### PR DESCRIPTION
rosgraph_msgs was used in rosout.cpp but not included in the find_package() call, and was not declared as a run_depend. I'm not quite sure how it was working before. :confused: :poultry_leg: 
