### PR TITLE
[message_filters] Fast approximate time synchronization in message_filters (pure python)

### DIFF
--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -265,11 +265,11 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
         stamps = []
         for queue in search_queues:
             topic_stamps = []
-            for stamp in queue:
-                stamp_delta = abs(stamp - msg.header.stamp)
+            for s in queue:
+                stamp_delta = abs(s - stamp)
                 if stamp_delta > self.slop:
                     continue  # far over the slop
-                topic_stamps.append((stamp, stamp_delta))
+                topic_stamps.append((s, stamp_delta))
             if not topic_stamps:
                 self.lock.release()
                 return
@@ -279,7 +279,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
             vv = list(vv)
             # insert the new message
             if my_queue_index is not None:
-                vv.insert(my_queue_index, msg.header.stamp)
+                vv.insert(my_queue_index, stamp)
             qt = list(zip(self.queues, vv))
             if ( ((max(vv) - min(vv)) < self.slop) and
                 (len([1 for q,t in qt if t not in q]) == 0) ):


### PR DESCRIPTION
Closes #800 
## Result

```
% rostopic hz /join_strings/output
subscribed to [/join_strings/output]
average rate: 0.995
        min: 1.005s max: 1.005s std dev: 0.00000s window: 2
average rate: 0.932
        min: 1.005s max: 1.141s std dev: 0.06805s window: 3
average rate: 0.953
        min: 1.002s max: 1.141s std dev: 0.06469s window: 4
average rate: 0.963
        min: 1.002s max: 1.141s std dev: 0.05930s window: 5
average rate: 0.950
        min: 1.002s max: 1.141s std dev: 0.06099s window: 6
average rate: 0.936
        min: 1.002s max: 1.144s std dev: 0.06516s window: 7
average rate: 0.944
        min: 1.002s max: 1.144s std dev: 0.06444s window: 8
average rate: 0.948
        min: 1.002s max: 1.144s std dev: 0.06143s window: 9
average rate: 0.953
        min: 1.002s max: 1.144s std dev: 0.05997s window: 10
no new messages
average rate: 0.955
        min: 1.002s max: 1.144s std dev: 0.05706s window: 11
average rate: 0.958
        min: 1.002s max: 1.144s std dev: 0.05597s window: 12
average rate: 0.962
        min: 1.002s max: 1.144s std dev: 0.05481s window: 13
average rate: 0.964
        min: 1.002s max: 1.144s std dev: 0.05361s window: 14
average rate: 0.967
        min: 1.002s max: 1.144s std dev: 0.05243s window: 15
average rate: 0.969
        min: 1.002s max: 1.144s std dev: 0.05129s window: 16
average rate: 0.970
        min: 1.002s max: 1.144s std dev: 0.05019s window: 17
average rate: 0.972
        min: 1.002s max: 1.144s std dev: 0.04914s window: 18
average rate: 0.973
        min: 1.002s max: 1.144s std dev: 0.04802s window: 19
average rate: 0.974
        min: 1.002s max: 1.144s std dev: 0.04697s window: 20
```
