### PR TITLE
Check for pointer return from createOutgoing and fail requestTopic if it is NULL.

### DIFF
--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -656,6 +656,11 @@ bool TopicManager::requestTopic(const string &topic,
       int max_datagram_size = proto[4];
       int conn_id = connection_manager_->getNewConnectionID();
       TransportUDPPtr transport = connection_manager_->getUDPServerTransport()->createOutgoing(host, port, conn_id, max_datagram_size);
+      if (!transport)
+      {
+        ROSCPP_LOG_DEBUG("Error creating outgoing transport for [%s:%d]", host.c_str(), port);
+        return false;
+      }
       connection_manager_->udprosIncomingConnection(transport, h);
 
       XmlRpcValue udpros_params;


### PR DESCRIPTION
It is possible for createOutgoing to return a null smart pointer if the connect fails. Connect can fail if it cannot resolve a hostname (possible in a mesh network if a client disconnects), if a file descriptor limit has been hit or if !isHostAllowed.

`
#6  0x00007fc4b3db5509 in ros::TopicManager::requestTopic (this=this@entry=0x2239060, topic="/move_base/PathTracker/plan_spline", protos=..., ret=...) at ../../../../../roscpp-release-indigo-roscpp-1-11-16-0/src/libros/topic_manager.cpp:669

669 ../../../../../roscpp-release-indigo-roscpp-1-11-16-0/src/libros/topic_manager.cpp: No such file or directory.
(gdb) print(transport)
$39 = {px = 0x0, pn = {pi_ = 0x0}}
`

Note, line 669 mentioned above is

`
      connection_manager_->udprosIncomingConnection(transport, h);
`

in indigo after createOutgoing()

The code in topic_manager assumes that transport is valid but we have encountered a case where it is not and a crash results. The crash happens when the transport sets the read callback in connection.cpp.

@dirk-thomas 

FYI @mikepurvis 
