### PR TITLE
Move queue operations to after debug message so that tenses of message match reality.

### DIFF
--- a/clients/roscpp/src/libros/subscription_queue.cpp
+++ b/clients/roscpp/src/libros/subscription_queue.cpp
@@ -59,9 +59,6 @@ void SubscriptionQueue::push(const SubscriptionCallbackHelperPtr& helper, const 
 
   if(fullNoLock())
   {
-    queue_.pop_front();
-    --queue_size_;
-
     if (!full_)
     {
       ROS_DEBUG("Incoming queue full for topic \"%s\".  Discarding oldest message (current queue size [%d])", topic_.c_str(), (int)queue_.size());
@@ -73,6 +70,9 @@ void SubscriptionQueue::push(const SubscriptionCallbackHelperPtr& helper, const 
     {
       *was_full = true;
     }
+
+    queue_.pop_front();
+    --queue_size_;
   }
   else
   {


### PR DESCRIPTION
Before this change a queue with a limit of 1 element would report the following debug message:

Incoming queue full for topic "baz".  Discarding oldest message (current queue size [0])

which implies that the queue is full when it holds 0 elements and that it will discard a message even without elements. 

After this change you'll get the message:

Incoming queue full for topic "baz".  Discarding oldest message (current queue size [1])

(low-pri PR, quality of life only)

@dirk-thomas 
