### PR TITLE
 add_rostest_gtest does now add the created gtest-target as a depende…

### DIFF
--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -83,7 +83,7 @@ function(add_rostest_gtest target launch_file)
     if(TARGET tests)
       add_dependencies(tests ${target})
     endif()
-    add_rostest(${launch_file})
+    add_rostest(${launch_file} DEPENDENCIES ${target})
   endif()
 endfunction()
 


### PR DESCRIPTION
…ncy to the created rostest. This insures that on running catkin_make run_tests_PACKAGE_rostests_TEST underlaying binary is checked for changes and is rebuild if needed. This simplifies developing, because you just have to run the the test and everything will be up-to-date. Form now on you do not need to build and run separately.
