### PR TITLE
rosbag_storage: make Bag constructor explicit

### DIFF
--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -95,7 +95,7 @@ public:
      *
      * Can throw BagException
      */
-    Bag(std::string const& filename, uint32_t mode = bagmode::Read);
+    explicit Bag(std::string const& filename, uint32_t mode = bagmode::Read);
 
     ~Bag();
 


### PR DESCRIPTION
This is a very small improvement to the rosbag API (adds "explicit" to the bag constructor)

Previously, it was possible to do something like this:

```
std::string bagFile = "...";
rosbag::Bag bag(bagFile);

rosbag::View view;
view.addQuery(bagFile, ...);
```

Note that bagFile is passed to View::addQuery, which does not cause a compiler error, since implicit conversion is allowed by the constructor. Using the view will cause a segfault, since the temporary bag will no longer be around.

I think that there are no good use cases for implicit std::string -> rosbag::Bag conversions, so we should disallow them.
