### PR TITLE
Drop strict-aliasing warnings from roslz4 file.

### DIFF
--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories(${PYTHON_INCLUDE_PATH})
 add_library(roslz4_py src/_roslz4module.c)
 set_source_files_properties(
   src/_roslz4module.c
-PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers -Wno-unused-variable -Wstrict-aliasing")
+PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers -Wno-unused-variable -Wno-strict-aliasing")
 set_target_properties(
   roslz4_py PROPERTIES OUTPUT_NAME roslz4 PREFIX "_" SUFFIX ".so"
   LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/roslz4)

--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -41,7 +41,7 @@ include_directories(${PYTHON_INCLUDE_PATH})
 add_library(roslz4_py src/_roslz4module.c)
 set_source_files_properties(
   src/_roslz4module.c
-PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers -Wno-unused-variable")
+PROPERTIES COMPILE_FLAGS "-Wno-missing-field-initializers -Wno-unused-variable -Wstrict-aliasing")
 set_target_properties(
   roslz4_py PROPERTIES OUTPUT_NAME roslz4 PREFIX "_" SUFFIX ".so"
   LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/roslz4)


### PR DESCRIPTION
Silences this build warning:

```
00:07:06.610 /tmp/binarydeb/ros-kinetic-roslz4-1.12.2/src/_roslz4module.c: In function ‘init_roslz4’:
00:07:06.610 /tmp/binarydeb/ros-kinetic-roslz4-1.12.2/src/_roslz4module.c:444:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
00:07:06.610    Py_INCREF(&LZ4Compressor_Type);
00:07:06.610    ^
00:07:06.610 /tmp/binarydeb/ros-kinetic-roslz4-1.12.2/src/_roslz4module.c:446:3: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
00:07:06.610    Py_INCREF(&LZ4Decompressor_Type);
00:07:06.610    ^
```

Source: http://build.ros.org/job/Kbin_uX64__roslz4__ubuntu_xenial_amd64__binary/4/console
