### PR TITLE
roslaunch: Fix <param command="..." /> for python3.

### DIFF
--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -479,7 +479,7 @@ class Loader(object):
         elif command is not None:
             try:
                 if type(command) == unicode:
-                    command = command.encode('UTF-8') #attempt to force to string for shlex/subprocess
+                    command = command.encode('utf-8') #attempt to force to string for shlex/subprocess
             except NameError:
                 pass
             if verbose:
@@ -488,6 +488,8 @@ class Loader(object):
             try:
                 p = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE)
                 c_value = p.communicate()[0]
+                if not isinstance(c_value, str):
+                    c_value = c_value.decode('utf-8')
                 if p.returncode != 0:
                     raise ValueError("Cannot load command parameter [%s]: command [%s] returned with code [%s]"%(name, command, p.returncode))
             except OSError as e:


### PR DESCRIPTION
In python3, the standard output of the subprocess is of type bytes. That causes the data to be stored as a binary xmlrpc node which ends up base64 encoded when retrieving it later. Additionally, it crashed the `rosparam` command line utility which could not deal with that.

This PR checks if the read command output is not of type `str` and decodes it as UTF-8 in that case. This is a NOP in python2. We can't check if the read output is of type bytes, because in python2 `bytes` is just an alias for `str`.
