### PR TITLE
Fix rostopic hz for multiple topics without no message

### DIFF
--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -215,7 +215,7 @@ class ROSTopicHz(object):
             stats['max_delta'].append('{:.4}'.format(max_delta))
             stats['std_dev'].append('{:.4}'.format(std_dev))
             stats['window'].append(str(window))
-        if len(stats['topic']) == 1:
+        if len(stats['topic']) <= 1:
             print('no new messages')
             return
         print(_get_ascii_table(header, stats))


### PR DESCRIPTION
To fix below error

```
% rostopic hz /input_0 /input_1
subscribed to [/input_0]
subscribed to [/input_1]
no new messages
no new messages
topic      rate    min_delta   max_delta    std_dev    window
==============================================================
/input_0   9.997    0.0999      0.1002      8.891e-05   7
/input_1   0.9998   0.9995      1.001       0.0005633   7

topic      rate    min_delta   max_delta    std_dev    window
==============================================================
/input_0   9.998    0.0999      0.1002      7.342e-05   17
/input_1   0.9998   0.9995      1.001       0.0004887   17

topic      rate    min_delta   max_delta    std_dev    window
==============================================================
/input_0   9.999    0.09982     0.1002      7.967e-05   21
/input_1   0.9999   0.9995      1.001       0.0004702   21

no new messages
no new messages
no new messages
Traceback (most recent call last):
File "/home/wkentaro/ros/indigo/devel/bin/rostopic", line 6, in <module>
exec(fh.read())
File "<string>", line 35, in <module>
File "<string>", line 1977, in rostopicmain
File "<string>", line 1385, in _rostopic_cmd_hz
File "<string>", line 273, in _rostopic_hz
File "<string>", line 221, in print_hz
File "<string>", line 228, in _get_ascii_table
ValueError: max() arg is an empty sequence
```
