### PR TITLE
Add 'Darwin' to unix-like platforms (resolve #845)

### DIFF
--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -102,7 +102,7 @@ def _is_unix_like_platform():
     @rtype: bool
     """
     #return platform.system() in ['Linux', 'Mac OS X', 'Darwin']
-    return platform.system() in ['Linux', 'FreeBSD']
+    return platform.system() in ['Linux', 'FreeBSD', 'Darwin']
 
 def get_address_override():
     """


### PR DESCRIPTION
Prevents issue calling socket.getaddrinfo with the machine name where this is not a known local hostname (e.g. where the machine name hasn't been added to the hosts file).
