### PR TITLE
Fix `rosservice call` for python3.

### DIFF
--- a/tools/rosservice/src/rosservice/__init__.py
+++ b/tools/rosservice/src/rosservice/__init__.py
@@ -50,9 +50,9 @@ import sys
 import socket
 
 try:
-    from cStringIO import StringIO  # Python 2.x
+    from cStringIO import StringIO as BufferType  # Python 2.x
 except ImportError:
-    from io import StringIO  # Python 3.x
+    from io import BytesIO as BufferType  # Python 3.x
 
 import genpy
 
@@ -121,7 +121,7 @@ def get_service_headers(service_name, service_uri):
             header = { 'probe':'1', 'md5sum':'*',
                        'callerid':'/rosservice', 'service':service_name}
             rosgraph.network.write_ros_handshake_header(s, header)
-            return rosgraph.network.read_ros_handshake_header(s, StringIO(), 2048)
+            return rosgraph.network.read_ros_handshake_header(s, BufferType(), 2048)
         except socket.error:
             raise ROSServiceIOException("Unable to communicate with service [%s], address [%s]"%(service_name, service_uri))
     finally:


### PR DESCRIPTION
`rosservice` was mistakenly passing a StringIO as buffer to `rosgraph.network.read_ros_handshake_header` even for python3. For python3 this needs to be a BytesIO object. This PR corrects that.

When running with `python2`, the old `StringIO` type is still used.
