### PR TITLE
Indigo devel fix rospy reconnect

### DIFF
--- a/clients/rospy/src/rospy/impl/registration.py
+++ b/clients/rospy/src/rospy/impl/registration.py
@@ -316,13 +316,22 @@ class RegManager(RegistrationListener):
                     t.start()
 
     def _connect_topic_thread(self, topic, uri):
-        try:
-            code, msg, _ = self.handler._connect_topic(topic, uri)
-            if code != 1:
-                logdebug("Unable to connect subscriber to publisher [%s] for topic [%s]: %s", uri, topic, msg)
-        except Exception as e:
-            if not is_shutdown():
-                logdebug("Unable to connect to publisher [%s] for topic [%s]: %s"%(uri, topic, traceback.format_exc()))
+        interval = 0.5 # seconds
+        success = False
+        while not success and not is_shutdown():
+            try:
+                code, msg, _ = self.handler._connect_topic(topic, uri)
+                if code != 1:
+                    logdebug("Unable to connect subscriber to publisher [%s] for topic [%s]: %s", uri, topic, msg)
+                else:
+                  success = True
+            except Exception as e:
+                if not is_shutdown():
+                    logdebug("Unable to connect to publisher [%s] for topic [%s]: %s"%(uri, topic, traceback.format_exc()))
+                # exponential backoff
+                if interval < 60.0:
+                  interval = interval * 2
+                time.sleep(interval)
         
     def cleanup(self, reason):
         """

--- a/clients/rospy/src/rospy/impl/registration.py
+++ b/clients/rospy/src/rospy/impl/registration.py
@@ -316,22 +316,13 @@ class RegManager(RegistrationListener):
                     t.start()
 
     def _connect_topic_thread(self, topic, uri):
-        interval = 0.5 # seconds
-        success = False
-        while not success and not is_shutdown():
-            try:
-                code, msg, _ = self.handler._connect_topic(topic, uri)
-                if code != 1:
-                    logdebug("Unable to connect subscriber to publisher [%s] for topic [%s]: %s", uri, topic, msg)
-                else:
-                  success = True
-            except Exception as e:
-                if not is_shutdown():
-                    logdebug("Unable to connect to publisher [%s] for topic [%s]: %s"%(uri, topic, traceback.format_exc()))
-                # exponential backoff
-                if interval < 60.0:
-                  interval = interval * 2
-                time.sleep(interval)
+        try:
+            code, msg, _ = self.handler._connect_topic(topic, uri)
+            if code != 1:
+                logdebug("Unable to connect subscriber to publisher [%s] for topic [%s]: %s", uri, topic, msg)
+        except Exception as e:
+            if not is_shutdown():
+                logdebug("Unable to connect to publisher [%s] for topic [%s]: %s"%(uri, topic, traceback.format_exc()))
         
     def cleanup(self, reason):
         """

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -740,7 +740,7 @@ class TCPROSTransport(Transport):
             except TransportInitError:
                 self.socket = None
                 
-            if self.socket is None:
+            if self.socket is None and interval < 30.:
                 # exponential backoff
                 interval = interval * 2
                 

--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -173,7 +173,8 @@ def robust_connect_subscriber(conn, dest_addr, dest_port, pub_uri, receive_cb, r
                 conn.done = True
                 break
             rospyerr("unable to create subscriber transport: %s.  Will try again in %ss", e, interval)
-            if interval < 60.0:
+            if interval < 30.0:
+              # exponential backoff (maximum 32 seconds)
               interval = interval * 2
             time.sleep(interval)
             

--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -173,7 +173,8 @@ def robust_connect_subscriber(conn, dest_addr, dest_port, pub_uri, receive_cb, r
                 conn.done = True
                 break
             rospyerr("unable to create subscriber transport: %s.  Will try again in %ss", e, interval)
-            interval = interval * 2
+            if interval < 60.0:
+              interval = interval * 2
             time.sleep(interval)
             
             # check to see if publisher state has changed


### PR DESCRIPTION
1. while roscpp reconnects on timeout or temporary 'No route to host'
   errors the rospy does it not. So on connection problems longer than 3
   min the connection between subscriber and publisher goes.
   I added some exceptions if these occurs rospy does not close the socket
   and reconnect now.
2. since rospy reconnects on timeout now, the reconnects goes very fast in
   times where it easier to restart the ros node then wait for a reconnect.
   So I added a maximal backoff time.
3. on connection problems while node start the subscription to a publisher
   will be stopped after 3 tries. Now the reconnection is stopped on
   shutdown of the node.
