### PR TITLE
[rostest] Add reusable node to test parameters.

### DIFF
--- a/tools/rostest/CMakeLists.txt
+++ b/tools/rostest/CMakeLists.txt
@@ -14,6 +14,8 @@ catkin_python_setup()
 
 catkin_install_python(PROGRAMS nodes/hztest
   DESTINATION  ${CATKIN_PACKAGE_SHARE_DESTINATION}/nodes/hztest)
+catkin_install_python(PROGRAMS nodes/paramtest
+  DESTINATION  ${CATKIN_PACKAGE_SHARE_DESTINATION}/nodes/paramtest)
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   FILES_MATCHING PATTERN "*.h")
@@ -30,4 +32,5 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/hztest.test)
   add_rostest(test/clean_master.test)
   add_rostest(test/distro_version.test)
+  add_rostest(test/param.test)
 endif()

--- a/tools/rostest/nodes/paramtest
+++ b/tools/rostest/nodes/paramtest
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2016, TORK (Tokyo Opensource Robotics Kyokai Association)
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of TORK nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Original copied from hztest node
+# https://github.com/ros/ros_comm/blob/24e45419bdd4b0d588321e3b376650c7a51bf11c/tools/rostest/nodes/hztest
+# Integration test node that checks if a designated parameter is already
+# registered at the Parameter Server. Following parameters must be set:
+#
+#  * ~/param_name_target: expected parameter name
+#  * ~/test_duration: time (in secs) to run test
+#
+
+from __future__ import print_function
+
+import sys
+import threading
+import time
+import unittest
+
+import rospy
+import rostest
+
+CLASSNAME = 'paramtest'
+
+
+class ParamTest(unittest.TestCase):
+    def __init__(self, *args):
+        super(ParamTest, self).__init__(*args)
+        rospy.init_node(CLASSNAME)
+
+        self.lock = threading.Lock()
+        self.parameter_obtained = False
+
+    def setUp(self):
+        self.errors = []
+
+    def test_param(self):
+        # performs two tests of a node, first with /rostime off,
+        # then with /rostime on
+
+        # Fetch parameters
+        try:
+            # Param to test
+            param_name_target = rospy.get_param('~param_name_target')
+            # length of test
+            test_duration = float(rospy.get_param('~test_duration'))
+            # time to wait before
+            wait_time = rospy.get_param('~wait_time', 20.)
+        except KeyError as e:
+            self.fail('ParamTest not initialized properly. Parameter [%s] not set. debug[%s] debug[%s]'%(str(e), rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
+
+        print("""Parameter: %s Test Duration: %s""" % (param_name_target, test_duration))
+
+        self._test_param(param_name_target, test_duration, wait_time)
+
+    def _test_param(self, param_name_target, test_duration, wait_time):
+        self.assert_(test_duration > 0.0, "bad parameter (test_duration)")
+        self.assert_(len(param_name_target), "bad parameter (param_name_target)")
+        param_obtained = None
+
+        print("Waiting for parameters")
+        # we have to wait until the first message is received before measuring
+        # the rate as time can advance too much before publisher is up
+
+        # - give the test 20 seconds to start,
+        # may parameterize this in the future
+        wallclock_timeout_t = time.time() + wait_time
+        while not self.parameter_obtained and time.time() < wallclock_timeout_t:
+            time.sleep(0.1)
+
+        # Start actual test
+        try:
+            param_obtained = rospy.get_param(param_name_target)
+            rospy.loginfo('Content of the obtained parameter: {}'.format(param_obtained))
+        except KeyError as e:
+            self.fail('Designated parameter [%s] is not registered. debug[%s] debug[%s]'%(target_param, rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
+
+        self.assertIsNotNone(param_obtained)
+
+if __name__ == '__main__':
+    # A dirty hack that is taken from hztest and not sure if it's necessary
+    # for paramtest as well.
+    time.sleep(0.75)
+    try:
+        rostest.run('rostest', CLASSNAME, ParamTest, sys.argv)
+    except KeyboardInterrupt:
+        pass
+    print("{} exiting".format(CLASSNAME))

--- a/tools/rostest/nodes/paramtest
+++ b/tools/rostest/nodes/paramtest
@@ -70,42 +70,37 @@ class ParamTest(unittest.TestCase):
 
         # Fetch parameters
         try:
-            # Param to test
-            param_name_target = rospy.get_param("~param_name_target")
+            # Getting the attributes of the test.
+            testattr_paramname_target = rospy.get_param("~param_name_target")
+            paramvalue_expected = rospy.get_param("~param_value_expected", None)  # This is the expected param value.
             # length of test
-            test_duration = float(rospy.get_param("~test_duration"))
+            testattr_duration = float(rospy.get_param("~test_duration", 5))
             # time to wait before
-            wait_time = rospy.get_param("~wait_time", 20.)
+            wait_time = rospy.get_param("~wait_time", 20)
         except KeyError as e:
             self.fail("ParamTest not initialized properly. Parameter [%s] not set. Caller ID: [%s] Resolved name: [%s]"%(str(e), rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
+        print("Parameter: %s Test Duration: %s" % (testattr_paramname_target, testattr_duration))
+        self._test_param(testattr_paramname_target, testattr_duration, wait_time, paramvalue_expected)
 
-        print("Parameter: %s Test Duration: %s" % (param_name_target, test_duration))
-
-        self._test_param(param_name_target, test_duration, wait_time)
-
-    def _test_param(self, param_name_target, test_duration, wait_time):
-        self.assert_(test_duration > 0.0, "bad parameter (test_duration)")
-        self.assert_(len(param_name_target), "bad parameter (param_name_target)")
-        param_obtained = None
+    def _test_param(self, testattr_paramname_target, testattr_duration, wait_time, paramvalue_expected=None):
+        self.assert_(testattr_duration > 0.0, "bad parameter (test_duration)")
+        self.assert_(len(testattr_paramname_target), "bad parameter (testattr_paramname_target)")
 
         print("Waiting for parameters")
-        # we have to wait until the first message is received before measuring
-        # the rate as time can advance too much before publisher is up
 
-        # - give the test 20 seconds to start,
-        # may parameterize this in the future
         wallclock_timeout_t = time.time() + wait_time
-        while not self.parameter_obtained and time.time() < wallclock_timeout_t:
+        param_obtained = None
+        while not param_obtained and time.time() < wallclock_timeout_t:
+            try:
+                param_obtained = rospy.get_param(testattr_paramname_target)
+            except KeyError as e:
+                print('Designated parameter [%s] is not registered yet, will wait. Caller ID: [%s] Resolved name: [%s]'%(testattr_paramname_target, rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
             time.sleep(0.1)
 
-        # Start actual test
-        try:
-            param_obtained = rospy.get_param(param_name_target)
-            rospy.loginfo('Content of the obtained parameter: {}'.format(param_obtained))
-        except KeyError as e:
-            self.fail('Designated parameter [%s] is not registered. Caller ID: [%s] Resolved name: [%s]'%(target_param, rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
-
-        self.assertIsNotNone(param_obtained)
+        if paramvalue_expected:
+            self.assertEqual(paramvalue_expected, param_obtained)
+        else:
+            self.assertIsNotNone(param_obtained)
 
 if __name__ == '__main__':
     try:

--- a/tools/rostest/nodes/paramtest
+++ b/tools/rostest/nodes/paramtest
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # Software License Agreement (BSD License)
 #
-# Copyright (c) 2016, TORK (Tokyo Opensource Robotics Kyokai Association)
+# Copyright (c) 2008, Willow Garage, Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -14,7 +14,7 @@
 #    copyright notice, this list of conditions and the following
 #    disclaimer in the documentation and/or other materials provided
 #    with the distribution.
-#  * Neither the name of TORK nor the names of its
+#  * Neither the name of Willow Garage, Inc. nor the names of its
 #    contributors may be used to endorse or promote products derived
 #    from this software without specific prior written permission.
 #
@@ -71,15 +71,15 @@ class ParamTest(unittest.TestCase):
         # Fetch parameters
         try:
             # Param to test
-            param_name_target = rospy.get_param('~param_name_target')
+            param_name_target = rospy.get_param("~param_name_target")
             # length of test
-            test_duration = float(rospy.get_param('~test_duration'))
+            test_duration = float(rospy.get_param("~test_duration"))
             # time to wait before
-            wait_time = rospy.get_param('~wait_time', 20.)
+            wait_time = rospy.get_param("~wait_time", 20.)
         except KeyError as e:
-            self.fail('ParamTest not initialized properly. Parameter [%s] not set. debug[%s] debug[%s]'%(str(e), rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
+            self.fail("ParamTest not initialized properly. Parameter [%s] not set. Caller ID: [%s] Resolved name: [%s]"%(str(e), rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
 
-        print("""Parameter: %s Test Duration: %s""" % (param_name_target, test_duration))
+        print("Parameter: %s Test Duration: %s" % (param_name_target, test_duration))
 
         self._test_param(param_name_target, test_duration, wait_time)
 
@@ -103,14 +103,11 @@ class ParamTest(unittest.TestCase):
             param_obtained = rospy.get_param(param_name_target)
             rospy.loginfo('Content of the obtained parameter: {}'.format(param_obtained))
         except KeyError as e:
-            self.fail('Designated parameter [%s] is not registered. debug[%s] debug[%s]'%(target_param, rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
+            self.fail('Designated parameter [%s] is not registered. Caller ID: [%s] Resolved name: [%s]'%(target_param, rospy.get_caller_id(), rospy.resolve_name(e.args[0])))
 
         self.assertIsNotNone(param_obtained)
 
 if __name__ == '__main__':
-    # A dirty hack that is taken from hztest and not sure if it's necessary
-    # for paramtest as well.
-    time.sleep(0.75)
     try:
         rostest.run('rostest', CLASSNAME, ParamTest, sys.argv)
     except KeyboardInterrupt:

--- a/tools/rostest/test/param.test
+++ b/tools/rostest/test/param.test
@@ -1,0 +1,25 @@
+<launch>
+  <!-- These parameters are registered to Parameter Server and
+       will be accessed by the test cases. -->
+  <param name="param_nonempty" value="This param is not empty." />
+  <param name="param_empty" value="" />
+
+  <test pkg="rostest" type="paramtest" name="paramtest_nonempty"
+        test-name="paramtest_nonempty">
+    <rosparam>
+      param_name_target: param_nonempty
+      test_duration: 5.0
+      wait_time: 30.0
+    </rosparam>
+  </test>
+
+  <test pkg="rostest" type="paramtest" name="paramtest_empty"
+        test-name="paramtest_empty">
+    <rosparam>
+      param_name_target: param_empty
+      test_duration: 5.0
+      wait_time: 30.0
+    </rosparam>
+  </test>
+
+</launch>

--- a/tools/rostest/test/param.test
+++ b/tools/rostest/test/param.test
@@ -3,12 +3,13 @@
        will be accessed by the test cases. -->
   <param name="param_nonempty" value="This param is not empty." />
   <param name="param_empty" value="" />
+  <param name="param_value_specific" value="Opensource Robotics is forever." />
 
   <test pkg="rostest" type="paramtest" name="paramtest_nonempty"
         test-name="paramtest_nonempty">
     <param name="param_name_target" value="param_nonempty" />
     <param name="test_duration" value="5.0" />
-    <param name="wait_time" value="30.0" />
+    <param name="wait_time" value="20.0" />
   </test>
 
   <test pkg="rostest" type="paramtest" name="paramtest_empty"
@@ -18,18 +19,10 @@
     <param name="wait_time" value="30.0" />
   </test>
 
-  <test pkg="rostest" type="paramtest" name="paramtest_value_simple"
-        test-name="paramtest_value_simple">
-    <param name="param_name_target" value="param_empty" />
-    <param name="param_value_target" value="Opensource Robotics is forever." />
-    <param name="test_duration" value="5.0" />
-    <param name="wait_time" value="30.0" />
-  </test>
-
-  <test pkg="rostest" type="paramtest" name="paramtest_value_urdf"
-        test-name="paramtest_value_urdf">
-    <param name="param_name_target" value="param_empty" />
-    <param name="param_value_target" value="***TODO add urdf***" />
+  <test pkg="rostest" type="paramtest" name="paramtest_value_specific_correct"
+        test-name="paramtest_value_specific_correct">
+    <param name="param_name_target" value="param_value_specific" />
+    <param name="param_value_expected" value="Opensource Robotics is forever." />
     <param name="test_duration" value="5.0" />
     <param name="wait_time" value="30.0" />
   </test>

--- a/tools/rostest/test/param.test
+++ b/tools/rostest/test/param.test
@@ -6,20 +6,32 @@
 
   <test pkg="rostest" type="paramtest" name="paramtest_nonempty"
         test-name="paramtest_nonempty">
-    <rosparam>
-      param_name_target: param_nonempty
-      test_duration: 5.0
-      wait_time: 30.0
-    </rosparam>
+    <param name="param_name_target" value="param_nonempty" />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="30.0" />
   </test>
 
   <test pkg="rostest" type="paramtest" name="paramtest_empty"
         test-name="paramtest_empty">
-    <rosparam>
-      param_name_target: param_empty
-      test_duration: 5.0
-      wait_time: 30.0
-    </rosparam>
+    <param name="param_name_target" value="param_empty" />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="30.0" />
+  </test>
+
+  <test pkg="rostest" type="paramtest" name="paramtest_value_simple"
+        test-name="paramtest_value_simple">
+    <param name="param_name_target" value="param_empty" />
+    <param name="param_value_target" value="Opensource Robotics is forever." />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="30.0" />
+  </test>
+
+  <test pkg="rostest" type="paramtest" name="paramtest_value_urdf"
+        test-name="paramtest_value_urdf">
+    <param name="param_name_target" value="param_empty" />
+    <param name="param_value_target" value="***TODO add urdf***" />
+    <param name="test_duration" value="5.0" />
+    <param name="wait_time" value="30.0" />
   </test>
 
 </launch>


### PR DESCRIPTION
Adding a node `paramtest`, a [reusable `rostest` node](http://wiki.ros.org/rostest/Nodes) that checks if a designated parameter is registered and non-empty. 

**Inspired by**: `hztest`, and the implementation and the usage is similar to hztest.

**Motivation**: It's cumbersome to write your own test node when you simply want to check if a parameter is registered and/or is not null.

**Usage**: Hopefully the usage is obvious enough from [a test file that's also added in this PR](https://github.com/130s/ros_comm/blob/f2fb87e93a1826ef69be041a69b09ce67a74055c/tools/rostest/test/param.test).
