### PR TITLE
[rostopic] Show topic field type with rostopic type

### DIFF
--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1291,7 +1291,7 @@ def _optparse_topic_only(cmd, argv):
 
 def _rostopic_cmd_type(argv):
     parser = argparse.ArgumentParser(prog='%s type' % NAME)
-    parser.add_argument('topic_or_field', help='Topic or filed name')
+    parser.add_argument('topic_or_field', help='Topic or field name')
     args = parser.parse_args(argv[2:])
     _rostopic_type(rosgraph.names.script_resolve_name('rostopic', args.topic_or_field))
 

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -38,6 +38,7 @@ from __future__ import division, print_function
 
 NAME='rostopic'
 
+import argparse
 import os
 import sys
 import math
@@ -1289,15 +1290,10 @@ def _optparse_topic_only(cmd, argv):
     return rosgraph.names.script_resolve_name('rostopic', args[0])
 
 def _rostopic_cmd_type(argv):
-    args = argv[2:]
-    from optparse import OptionParser
-    parser = OptionParser(usage="usage: %prog type /topic_or_field", prog=NAME)
-    (options, args) = parser.parse_args(args)
-    if len(args) == 0:
-        parser.error("topic or field must be specified")
-    if len(args) > 1:
-        parser.error("you may only specify one input topic or field")
-    _rostopic_type(rosgraph.names.script_resolve_name('rostopic', args[0]))
+    parser = argparse.ArgumentParser(prog='%s type' % NAME)
+    parser.add_argument('topic_or_field', help='Topic or filed name')
+    args = parser.parse_args(argv[2:])
+    _rostopic_type(rosgraph.names.script_resolve_name('rostopic', args.topic_or_field))
 
 def _rostopic_cmd_hz(argv):
     args = argv[2:]

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -843,12 +843,19 @@ def _rostopic_type(topic):
     Print ROS message type of topic to screen
     :param topic: topic name, ``str``
     """
-    t, _, _ = get_topic_type(topic, blocking=False)
-    if t:
-        print(t)
-    else:
+    topic_type, topic_real_name, _ = get_topic_type(topic, blocking=False)
+    if topic_type is None:
         sys.stderr.write('unknown topic type [%s]\n'%topic)
         sys.exit(1)
+    elif topic == topic_real_name:
+        print(topic_type)
+    else:
+        field = topic[len(topic_real_name)+1:]
+        field_type = topic_type
+        for current_field in field.split('/'):
+            msg_class = roslib.message.get_message_class(field_type)
+            field_type = msg_class._slot_types[msg_class.__slots__.index(current_field)]
+        print('%s %s %s'%(topic_type, field, field_type))
 
 def _rostopic_echo_bag(callback_echo, bag_file):
     """

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1289,8 +1289,16 @@ def _optparse_topic_only(cmd, argv):
     return rosgraph.names.script_resolve_name('rostopic', args[0])
 
 def _rostopic_cmd_type(argv):
-    _rostopic_type(_optparse_topic_only('type', argv))
-    
+    args = argv[2:]
+    from optparse import OptionParser
+    parser = OptionParser(usage="usage: %prog type /topic_or_field", prog=NAME)
+    (options, args) = parser.parse_args(args)
+    if len(args) == 0:
+        parser.error("topic or field must be specified")
+    if len(args) > 1:
+        parser.error("you may only specify one input topic or field")
+    _rostopic_type(rosgraph.names.script_resolve_name('rostopic', args[0]))
+
 def _rostopic_cmd_hz(argv):
     args = argv[2:]
     from optparse import OptionParser
@@ -1901,7 +1909,7 @@ Commands:
 \trostopic info\tprint information about active topic
 \trostopic list\tlist active topics
 \trostopic pub\tpublish data to topic
-\trostopic type\tprint topic type
+\trostopic type\tprint topic or field type
 
 Type rostopic <command> -h for more detailed usage, e.g. 'rostopic echo -h'
 """)

--- a/tools/rostopic/test/check_rostopic_command_line_online.py
+++ b/tools/rostopic/test/check_rostopic_command_line_online.py
@@ -91,6 +91,10 @@ class TestRostopicOnline(unittest.TestCase):
             output = Popen([cmd, 'type', name], stdout=PIPE).communicate()[0]
             output = output.decode()
             self.assertEquals('std_msgs/String', output.strip())
+            # check type of topic field
+            output = Popen([cmd, 'type', name + '/data'], stdout=PIPE).communicate()[0]
+            output = output.decode()
+            self.assertEquals('std_msgs/String data string', output.strip())
 
             # find
             output = Popen([cmd, 'find', 'std_msgs/String'], stdout=PIPE).communicate()[0]

--- a/tools/rostopic/test/test_rostopic.py
+++ b/tools/rostopic/test/test_rostopic.py
@@ -131,6 +131,10 @@ class TestRostopic(unittest.TestCase):
                 rostopic.rostopicmain([cmd, 'type', s])
                 v = b.getvalue().strip()
                 self.assertEquals('std_msgs/String', v)
+                # check type of topic field
+                rostopic.rostopicmain([cmd, 'type', s + '/data'])
+                v = b.getvalue().strip()
+                self.assertEquals('std_msgs/String data string', v)
 
     def test_main(self):
         import rostopic


### PR DESCRIPTION
For https://github.com/jsk-ros-pkg/jsk_visualization/issues/625#issuecomment-238793703

As shown below:

``` bash
% rostopic type /raw_image_bgr/image_color/foo
unknown topic type [/raw_image_bgr/image_color/foo]

% rostopic type /raw_image_bgr/image_color/header
sensor_msgs/Image header std_msgs/Header

% rostopic type /raw_image_bgr/image_color/header/frame_id
sensor_msgs/Image header/frame_id string

% rostopic type /raw_image_bgr/image_color
sensor_msgs/Image
```

The current behavior is below:

``` bash
% rostopic type /raw_image_bgr/image_color/foo
unknown topic type [/raw_image_bgr/image_color/foo]

% rostopic type /raw_image_bgr/image_color/header
sensor_msgs/Image

% rostopic type /raw_image_bgr/image_color
sensor_msgs/Image
```
