### PR TITLE
[rosmsg] List message files only for specified package

### DIFF
--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -683,10 +683,10 @@ def rosmsg_cmd_packages(mode, full, argv=None):
     
 def rosmsg_cmd_list(mode, full, argv=None):
     if argv is None:
-        argv = sys.argv[1:]
+        argv = sys.argv[2:]  # removes 'rosmsg/rossrv' and 'list'.
     parser = argparse.ArgumentParser(usage='ros%s list [package_name]'%mode[1:])
     parser.add_argument('package_name', nargs='?', help='package to list %s files for.'%mode[1:])
-    args = parser.parse_args(argv[1:])
+    args = parser.parse_args(argv)
     package_name = args.package_name
     if mode == MODE_MSG:
         subdir = 'msg'

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -696,11 +696,11 @@ def rosmsg_cmd_list(mode, full, argv=None):
         raise ValueError('Unknown mode for iterate_packages: %s'%mode)
     rospack = rospkg.RosPack()
     packs = sorted([x for x in iterate_packages(rospack, mode)])
-    if (package_name is not None) and (package_name not in zip(*packs)[0]):
+    if package_name and package_name not in zip(*packs)[0]:
         sys.stderr.write('ERROR: requested package [%s] does not exist.\n'%package_name)
         sys.exit(1)
     for (p, direc) in packs:
-        if (package_name is not None) and (p != package_name):
+        if package_name and p != package_name:
             continue  # skip because it's not the requested package
         for file in _list_types(direc, subdir, mode):
             print('%s/%s'%(p, file))

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -683,8 +683,16 @@ def rosmsg_cmd_packages(mode, full, argv=None):
 def rosmsg_cmd_list(mode, full, argv=None):
     if argv is None:
         argv = sys.argv[1:]
-    parser = OptionParser(usage="usage: ros%s list"%mode[1:])
+    parser = OptionParser(usage="usage: ros%s list [package_name]"%mode[1:])
     options, args = parser.parse_args(argv[1:])
+    if len(args) == 0:
+        package_name = None
+    elif len(args) == 1:
+        package_name = args[0]
+    else:
+        sys.stderr.write('ERROR: expected number of arguments is 0 or 1, but passed %d.\n'%len(args))
+        sys.stderr.write(parser.get_usage())
+        sys.exit(2)
     if mode == MODE_MSG:
         subdir = 'msg'
     elif mode == MODE_SRV:
@@ -693,9 +701,16 @@ def rosmsg_cmd_list(mode, full, argv=None):
         raise ValueError('Unknown mode for iterate_packages: %s'%mode)
     rospack = rospkg.RosPack()
     packs = sorted([x for x in iterate_packages(rospack, mode)])
+    msgs_to_show = []
     for (p, direc) in packs:
         for file in _list_types(direc, subdir, mode):
-            print( "%s/%s"%(p, file))
+            if (package_name is not None) and (p != package_name):
+                continue
+            msgs_to_show.append('%s/%s'%(p, file))
+    if not msgs_to_show:
+        sys.stderr.write('WARNING: no %s is found for package [%s]\n'%(mode[1:], package_name))
+        sys.exit(1)
+    print('\n'.join(msgs_to_show))
         
 
 def fullusage(mode):

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -38,6 +38,7 @@ The code API of the rosmsg module is unstable.
 
 from __future__ import print_function
 
+import argparse
 import collections
 import inspect
 import os
@@ -683,16 +684,10 @@ def rosmsg_cmd_packages(mode, full, argv=None):
 def rosmsg_cmd_list(mode, full, argv=None):
     if argv is None:
         argv = sys.argv[1:]
-    parser = OptionParser(usage="usage: ros%s list [package_name]"%mode[1:])
-    options, args = parser.parse_args(argv[1:])
-    if len(args) == 0:
-        package_name = None
-    elif len(args) == 1:
-        package_name = args[0]
-    else:
-        sys.stderr.write('ERROR: expected number of arguments is 0 or 1, but passed %d.\n'%len(args))
-        sys.stderr.write(parser.get_usage())
-        sys.exit(2)
+    parser = argparse.ArgumentParser(usage='ros%s list [package_name]'%mode[1:])
+    parser.add_argument('package_name', nargs='?', help='package to list %s files for.'%mode[1:])
+    args = parser.parse_args(argv[1:])
+    package_name = args.package_name
     if mode == MODE_MSG:
         subdir = 'msg'
     elif mode == MODE_SRV:

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -701,16 +701,14 @@ def rosmsg_cmd_list(mode, full, argv=None):
         raise ValueError('Unknown mode for iterate_packages: %s'%mode)
     rospack = rospkg.RosPack()
     packs = sorted([x for x in iterate_packages(rospack, mode)])
-    msgs_to_show = []
-    for (p, direc) in packs:
-        for file in _list_types(direc, subdir, mode):
-            if (package_name is not None) and (p != package_name):
-                continue
-            msgs_to_show.append('%s/%s'%(p, file))
-    if not msgs_to_show:
-        sys.stderr.write('WARNING: no %s is found for package [%s]\n'%(mode[1:], package_name))
+    if (package_name is not None) and (package_name not in zip(*packs)[0]):
+        sys.stderr.write('ERROR: requested package [%s] does not exist.\n'%package_name)
         sys.exit(1)
-    print('\n'.join(msgs_to_show))
+    for (p, direc) in packs:
+        if (package_name is not None) and (p != package_name):
+            continue  # skip because it's not the requested package
+        for file in _list_types(direc, subdir, mode):
+            print('%s/%s'%(p, file))
         
 
 def fullusage(mode):


### PR DESCRIPTION
As below

```
% rosmsg list --help
Usage: rosmsg list [package_name]

Options:
  -h, --help  show this help message and exit

% rosmsg list std_msgs
std_msgs/Bool
std_msgs/Byte
std_msgs/ByteMultiArray
std_msgs/Char
std_msgs/ColorRGBA
std_msgs/Duration
std_msgs/Empty
std_msgs/Float32
std_msgs/Float32MultiArray

% rosmsg list std_msg
WARNING: no msg is found for package [std_msg]

% rosmsg list
# All messages are listed.
```
