### PR TITLE
[rostest] Refactor hztestX.test

### DIFF
--- a/tools/rostest/test/hztest.test
+++ b/tools/rostest/test/hztest.test
@@ -1,14 +1,11 @@
 <launch>
   <node name="talker" pkg="rospy" type="talker.py" />
 
-  <test name="hztest1" test-name="hztest_test" pkg="rostest" type="hztest">
-    <rosparam>
-      topic: chatter
-      hz: 10.0
-      hzerror: 0.5
-      test_duration: 5.0
-      wait_time: 21.0
-    </rosparam>
-  </test>
+  <param name="hztest1/topic" value="chatter" />  
+  <param name="hztest1/hz" value="10.0" />
+  <param name="hztest1/hzerror" value="0.5" />
+  <param name="hztest1/test_duration" value="5.0" />    
+  <param name="hztest1/wait_time" value="21.0" />    
+  <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1" />
 
 </launch>

--- a/tools/rostest/test/hztest.test
+++ b/tools/rostest/test/hztest.test
@@ -1,11 +1,14 @@
 <launch>
   <node name="talker" pkg="rospy" type="talker.py" />
 
-  <param name="hztest1/topic" value="chatter" />  
-  <param name="hztest1/hz" value="10.0" />
-  <param name="hztest1/hzerror" value="0.5" />
-  <param name="hztest1/test_duration" value="5.0" />    
-  <param name="hztest1/wait_time" value="21.0" />    
-  <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1" />
+  <test name="hztest1" test-name="hztest_test" pkg="rostest" type="hztest">
+    <rosparam>
+      topic: chatter
+      hz: 10.0
+      hzerror: 0.5
+      test_duration: 5.0
+      wait_time: 21.0
+    </rosparam>
+  </test>
 
 </launch>

--- a/tools/rostest/test/hztest.test
+++ b/tools/rostest/test/hztest.test
@@ -8,4 +8,17 @@
   <param name="hztest1/wait_time" value="21.0" />    
   <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1" />
 
+  <!-- Below also works:
+
+  <test test-name="hztest_test" pkg="rostest" type="hztest" name="hztest1">
+    <rosparam>
+      topic: chatter
+      hz: 10.0
+      hzerror: 0.5
+      test_duration: 5.0
+      wait_time: 21.0
+    </rosparam>
+  </test>
+
+  -->
 </launch>

--- a/tools/rostest/test/hztest0.test
+++ b/tools/rostest/test/hztest0.test
@@ -1,7 +1,10 @@
 <launch>
   <!-- verify that hztest works with 0 rate. NOTE: there is no test for failure here, which needs to be added somehow -->
-  <param name="hztest0/topic" value="fake" />  
-  <param name="hztest0/hz" value="0.0" />
-  <param name="hztest0/test_duration" value="5.0" />    
-  <test test-name="hz0_test" pkg="rostest" type="hztest" name="hztest0" />
+  <test name="hztest0" test-name="hz0_test" pkg="rostest" type="hztest">
+    <rosparam>
+      topic: fake
+      hz: 0.0
+      test_duration: 5.0
+    </rosparam>
+  </test>
 </launch>

--- a/tools/rostest/test/hztest0.test
+++ b/tools/rostest/test/hztest0.test
@@ -1,10 +1,7 @@
 <launch>
   <!-- verify that hztest works with 0 rate. NOTE: there is no test for failure here, which needs to be added somehow -->
-  <test name="hztest0" test-name="hz0_test" pkg="rostest" type="hztest">
-    <rosparam>
-      topic: fake
-      hz: 0.0
-      test_duration: 5.0
-    </rosparam>
-  </test>
+  <param name="hztest0/topic" value="fake" />  
+  <param name="hztest0/hz" value="0.0" />
+  <param name="hztest0/test_duration" value="5.0" />    
+  <test test-name="hz0_test" pkg="rostest" type="hztest" name="hztest0" />
 </launch>


### PR DESCRIPTION
## Why?

The files hztestX.test are the samples for ROS users for testing nodes.
This PR simplify the test xml to demonstrate how to use `<rosparam>` for private params.
