### PR TITLE
[rospy] Refactor talker.py which is rospy test node

### DIFF
--- a/clients/rospy/test_nodes/talker.py
+++ b/clients/rospy/test_nodes/talker.py
@@ -34,20 +34,19 @@
 ## Simple talker demo that published std_msgs/Strings messages
 ## to the 'chatter' topic
 
+
 import rospy
 from std_msgs.msg import String
 
-def talker():
-    pub = rospy.Publisher('chatter', String, queue_size=10)
-    rospy.init_node('talker', anonymous=True)
-    r = rospy.Rate(10) # 10hz
-    while not rospy.is_shutdown():
-        str = "hello world %s"%rospy.get_time()
-        rospy.loginfo(str)
-        pub.publish(str)
-        r.sleep()
-        
+
+def publish_callback(event):
+    string = 'hello world %s' % event.current_real.to_sec()
+    rospy.loginfo(string)
+    pub.publish(string)
+
+
 if __name__ == '__main__':
-    try:
-        talker()
-    except rospy.ROSInterruptException: pass
+    rospy.init_node('talker', anonymous=True)
+    pub = rospy.Publisher('chatter', String, queue_size=10)
+    timer = rospy.Timer(rospy.Duration(1./10), publish_callback)  # 10 Hz
+    rospy.spin()


### PR DESCRIPTION
## What
- Advertise after rospy.init_node
- Use rospy.Timer which is desirable implementation of periodical
  publishing.
## Why
- Advertising after rospy.init causes wrong topic name with private name.
- This node seems a sample for ROS new users, and using timer is better than `while not rospy.is_shutdown()`, this PR improves the sample code.
