### PR TITLE
Allow 64-bit sizes to be passed to robag max_size

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -103,7 +103,7 @@ struct ROSBAG_DECL RecorderOptions
     uint32_t        chunk_size;
     uint32_t        limit;
     bool            split;
-    uint32_t        max_size;
+    uint64_t        max_size;
     ros::Duration   max_duration;
     std::string     node;
     unsigned long long min_space;

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -63,7 +63,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("lz4", "use LZ4 compression")
       ("split", po::value<int>()->implicit_value(0), "Split the bag file and continue recording when maximum size or maximum duration reached.")
       ("topic", po::value< std::vector<std::string> >(), "topic to record")
-      ("size", po::value<int>(), "The maximum size of the bag to record in MB.")
+      ("size", po::value<uint64_t>(), "The maximum size of the bag to record in MB.")
       ("duration", po::value<std::string>(), "Record a bag of maximum duration in seconds, unless 'm', or 'h' is appended.")
       ("node", po::value<std::string>(), "Record all topics subscribed to by a specific node.");
 
@@ -217,7 +217,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     }
     if (vm.count("size"))
     {
-      opts.max_size = vm["size"].as<int>() * 1048576;
+      opts.max_size = vm["size"].as<uint64_t>() * 1048576;
       if (opts.max_size <= 0)
         throw ros::Exception("Split size must be 0 or positive");
     }


### PR DESCRIPTION
Internally, bagfile size is 64 bits. However, the types used in command parsing are only 32 bits, making the maximum usable split size 2GB. This patch switches the argument parsing to use 64 bit types.
