### PR TITLE
Record a maximum number of splits and then begin deleting old files

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -160,7 +160,7 @@ private:
 
     std::string                   target_filename_;
     std::string                   write_filename_;
-    std::list<std::string>         current_files_;
+    std::list<std::string>        current_files_;
 
     std::set<std::string>         currently_recording_;  //!< set of currenly recording topics
     int                           num_subscribers_;      //!< used for book-keeping of our number of subscribers

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -45,6 +45,7 @@
 #include <queue>
 #include <string>
 #include <vector>
+#include <list>
 
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
@@ -104,6 +105,7 @@ struct ROSBAG_DECL RecorderOptions
     uint32_t        limit;
     bool            split;
     uint64_t        max_size;
+    uint32_t        max_splits;
     ros::Duration   max_duration;
     std::string     node;
     unsigned long long min_space;
@@ -140,6 +142,7 @@ private:
     //    void doQueue(topic_tools::ShapeShifter::ConstPtr msg, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doRecord();
+    void checkNumSplits();
     bool checkSize();
     bool checkDuration(const ros::Time&);
     void doRecordSnapshotter();
@@ -157,6 +160,7 @@ private:
 
     std::string                   target_filename_;
     std::string                   write_filename_;
+    std::list<std::string>         current_files_;
 
     std::set<std::string>         currently_recording_;  //!< set of currenly recording topics
     int                           num_subscribers_;      //!< used for book-keeping of our number of subscribers

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -62,7 +62,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("bz2,j", "use BZ2 compression")
       ("lz4", "use LZ4 compression")
       ("split", po::value<int>()->implicit_value(0), "Split the bag file and continue recording when maximum size or maximum duration reached.")
-      ("max-splits", po::value<int>()->default_value(0), "Split the bag file at most splits times, then begin erasing the oldest split to keep a constant number of files.")
+      ("max-splits", po::value<int>()->default_value(0), "Keep a maximum of N bag files, when reaching the maximum erase the oldest one to keep a constant number of files.")
       ("topic", po::value< std::vector<std::string> >(), "topic to record")
       ("size", po::value<uint64_t>(), "The maximum size of the bag to record in MB.")
       ("duration", po::value<std::string>(), "Record a bag of maximum duration in seconds, unless 'm', or 'h' is appended.")

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -62,6 +62,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("bz2,j", "use BZ2 compression")
       ("lz4", "use LZ4 compression")
       ("split", po::value<int>()->implicit_value(0), "Split the bag file and continue recording when maximum size or maximum duration reached.")
+      ("max-splits", po::value<int>()->default_value(0), "Split the bag file at most splits times, then begin erasing the oldest split to keep a constant number of files.")
       ("topic", po::value< std::vector<std::string> >(), "topic to record")
       ("size", po::value<uint64_t>(), "The maximum size of the bag to record in MB.")
       ("duration", po::value<std::string>(), "Record a bag of maximum duration in seconds, unless 'm', or 'h' is appended.")
@@ -122,6 +123,17 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
           throw ros::Exception("Split size must be 0 or positive");
         opts.max_size = 1048576 * S;
       }
+    }
+    if(vm.count("max-splits"))
+    {
+        if(!opts.split)
+        {
+            ROS_WARN("--max-splits is ignored without --split");
+        }
+        else
+        {
+            opts.max_splits = vm["max-splits"].as<int>();
+        }
     }
     if (vm.count("buffsize"))
     {

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -393,6 +393,23 @@ void Recorder::stopWriting() {
     rename(write_filename_.c_str(), target_filename_.c_str());
 }
 
+void Recorder::checkNumSplits()
+{
+    if(options_.max_splits>0)
+    {
+        current_files_.push_back(target_filename_);
+        if(current_files_.size()>options_.max_splits)
+        {
+            int err = unlink(current_files_.front().c_str());
+            if(err != 0)
+            {
+                ROS_ERROR("Unable to remove %s: %s", current_files_.front().c_str(), strerror(errno));
+            }
+            current_files_.pop_front();
+        }
+    }
+}
+
 bool Recorder::checkSize()
 {
     if (options_.max_size > 0)
@@ -403,6 +420,7 @@ bool Recorder::checkSize()
             {
                 stopWriting();
                 split_count_++;
+                checkNumSplits();
                 startWriting();
             } else {
                 ros::shutdown();
@@ -425,6 +443,7 @@ bool Recorder::checkDuration(const ros::Time& t)
                 {
                     stopWriting();
                     split_count_++;
+                    checkNumSplits();
                     start_time_ += options_.max_duration;
                     startWriting();
                 }

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -77,6 +77,7 @@ def record_cmd(argv):
     parser.add_option("-o", "--output-prefix", dest="prefix",        default=None,  action="store",               help="prepend PREFIX to beginning of bag name (name will always end with date stamp)")
     parser.add_option("-O", "--output-name",   dest="name",          default=None,  action="store",               help="record to bag with name NAME.bag")
     parser.add_option(      "--split",         dest="split",         default=False, callback=handle_split, action="callback",    help="split the bag when maximum size or duration is reached")
+    parser.add_option(      "--max-splits",    dest="max_splits",                   type='int',   action="store", help="if splitting is enabled, split MAX_SPLITS times and then begin erasing the oldest split to maintain a constant number of files", metavar="MAX_SPLITS")
     parser.add_option(      "--size",          dest="size",                         type='int',   action="store", help="record a bag of maximum size SIZE MB. (Default: infinite)", metavar="SIZE")
     parser.add_option(      "--duration",      dest="duration",                     type='string',action="store", help="record a bag of maximum duration DURATION in seconds, unless 'm', or 'h' is appended.", metavar="DURATION")
     parser.add_option("-b", "--buffsize",      dest="buffsize",      default=256,   type='int',   action="store", help="use an internal buffer of SIZE MB (Default: %default, 0 = infinite)", metavar="SIZE")
@@ -114,6 +115,8 @@ def record_cmd(argv):
         if not options.duration and not options.size:
             parser.error("Split specified without giving a maximum duration or size")
         cmd.extend(["--split"])
+        if options.max_splits:
+            cmd.extend(["--max-splits", str(options.max_splits)])
     if options.duration:    cmd.extend(["--duration", options.duration])
     if options.size:        cmd.extend(["--size", str(options.size)])
     if options.node:

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -77,7 +77,7 @@ def record_cmd(argv):
     parser.add_option("-o", "--output-prefix", dest="prefix",        default=None,  action="store",               help="prepend PREFIX to beginning of bag name (name will always end with date stamp)")
     parser.add_option("-O", "--output-name",   dest="name",          default=None,  action="store",               help="record to bag with name NAME.bag")
     parser.add_option(      "--split",         dest="split",         default=False, callback=handle_split, action="callback",    help="split the bag when maximum size or duration is reached")
-    parser.add_option(      "--max-splits",    dest="max_splits",                   type='int',   action="store", help="if splitting is enabled, split MAX_SPLITS times and then begin erasing the oldest split to maintain a constant number of files", metavar="MAX_SPLITS")
+    parser.add_option(      "--max-splits",    dest="max_splits",                   type='int',   action="store", help="Keep a maximum of N bag files, when reaching the maximum erase the oldest one to keep a constant number of files.", metavar="MAX_SPLITS")
     parser.add_option(      "--size",          dest="size",                         type='int',   action="store", help="record a bag of maximum size SIZE MB. (Default: infinite)", metavar="SIZE")
     parser.add_option(      "--duration",      dest="duration",                     type='string',action="store", help="record a bag of maximum duration DURATION in seconds, unless 'm', or 'h' is appended.", metavar="DURATION")
     parser.add_option("-b", "--buffsize",      dest="buffsize",      default=256,   type='int',   action="store", help="use an internal buffer of SIZE MB (Default: %default, 0 = infinite)", metavar="SIZE")


### PR DESCRIPTION
This patch allows creating a fixed size recording of the most recent data. It add a --max-splits option to rosbag record. When --split is used, after max-splits files have been created, the oldest one is deleted so a fixed size (or fix duration if --duration is used) recording can be made.
