### PR TITLE
fix multi-threaded spinning

### DIFF
--- a/clients/roscpp/include/ros/spinner.h
+++ b/clients/roscpp/include/ros/spinner.h
@@ -109,10 +109,10 @@ public:
 
 
   /**
-   * \brief Check if the spinner can be started. A spinner can't be started if
-   * another spinner is already running.
+   * \brief Check if the spinner can be started. The spinner can't be started if
+   * another single-threaded spinner is already operating on the callback queue.
    */
-  bool canStart();
+  ROS_DEPRECATED bool canStart();
   /**
    * \brief Start this spinner spinning asynchronously
    */

--- a/clients/roscpp/include/ros/spinner.h
+++ b/clients/roscpp/include/ros/spinner.h
@@ -109,8 +109,10 @@ public:
 
 
   /**
-   * \brief Check if the spinner can be started. The spinner can't be started if
+   * \brief Check if the spinner can be started. The spinner shouldn't be started if
    * another single-threaded spinner is already operating on the callback queue.
+   *
+   * This function is not necessary anymore. start() will always start spinning.
    */
   ROS_DEPRECATED bool canStart();
   /**

--- a/clients/roscpp/include/ros/spinner.h
+++ b/clients/roscpp/include/ros/spinner.h
@@ -112,9 +112,11 @@ public:
    * \brief Check if the spinner can be started. The spinner shouldn't be started if
    * another single-threaded spinner is already operating on the callback queue.
    *
-   * This function is not necessary anymore. start() will always start spinning.
+   * This function is not necessary anymore. start() will always try to start spinning
+   * and throw a std::runtime_error if it failed.
    */
-  ROS_DEPRECATED bool canStart();
+  // TODO: deprecate in L-turtle
+  bool canStart();
   /**
    * \brief Start this spinner spinning asynchronously
    */

--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -153,7 +153,6 @@ void MultiThreadedSpinner::spin(CallbackQueue* queue)
   s.start();
 
   ros::waitForShutdown();
-  s.stop();
 }
 
 class AsyncSpinnerImpl

--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -70,7 +70,7 @@ struct SpinnerMonitor {
     return true;
   }
 
-  /// remove a queue to the list
+  /// remove a queue from the list
   void remove(ros::CallbackQueue* queue)
   {
     boost::mutex::scoped_lock lock(mutex_);
@@ -89,7 +89,7 @@ struct SpinnerMonitor {
 
 SpinnerMonitor spinner_monitor;
 const std::string DEFAULT_ERROR_MESSAGE =
-    "Attempt to spin a callback queue from two spinners, one of them being single-threaded."
+    "Attempt to spin a callback queue from two spinners, one of them being single-threaded. "
     "This will probably result in callbacks being executed out-of-order.";
 }
 

--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -76,7 +76,7 @@ struct SpinnerMonitor
       return false;
 
     if (it == spinning_queues_.end())
-      spinning_queues_.insert(it, std::make_pair(queue, Entry(tid)));
+      it = spinning_queues_.insert(it, std::make_pair(queue, Entry(tid)));
 
     if (!single_threaded) // increment number of multi-threaded spinners
       it->second.num_multi_threaded += 1;

--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -92,7 +92,11 @@ struct SpinnerMonitor
     ROS_ASSERT_MSG(it != spinning_queues_.end(), "Call to SpinnerMonitor::remove() without matching call to add().");
 
     if (it->second.tid != boost::thread::id() && it->second.tid != boost::this_thread::get_id())
-      ROS_ERROR("SpinnerMonitor::remove() called from different thread than add().");
+    {
+      // This doesn't harm, but isn't good practice?
+      // It was enforced by the previous implementation.
+      ROS_WARN("SpinnerMonitor::remove() called from different thread than add().");
+    }
 
     if (single_threaded)
       spinning_queues_.erase(it);

--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -121,7 +121,7 @@ void SingleThreadedSpinner::spin(CallbackQueue* queue)
 
   if (!spinner_monitor.add(queue, true))
   {
-    ROS_ERROR_STREAM("SingleThreadedSpinner: " << DEFAULT_ERROR_MESSAGE);
+    ROS_FATAL_STREAM("SingleThreadedSpinner: " << DEFAULT_ERROR_MESSAGE);
     return;
   }
 
@@ -211,7 +211,7 @@ void AsyncSpinnerImpl::start()
 
   if (!spinner_monitor.add(callback_queue_, false))
   {
-    ROS_ERROR_STREAM("AsyncSpinnerImpl: " << DEFAULT_ERROR_MESSAGE);
+    ROS_FATAL_STREAM("AsyncSpinnerImpl: " << DEFAULT_ERROR_MESSAGE);
     return;
   }
 

--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -50,12 +50,12 @@ namespace {
 struct SpinnerMonitor
 {
   /* store spinner information per callback queue:
-     Only as unique single-threaded spinner is allowed and we store its thread id.
+     Only one unique single-threaded spinner is allowed and we store its thread id.
      As multiple multi-threaded spinners are allowed in parallel, their number is counted.
   */
   struct Entry
   {
-    Entry(const boost::thread::id &tid) : tid(tid) {}
+    Entry(const boost::thread::id &tid) : tid(tid), num_multi_threaded(0) {}
 
     boost::thread::id tid; // thread id of single-threaded spinner
     unsigned int num_multi_threaded; // number of multi-threaded spinners

--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -105,7 +105,10 @@ void SingleThreadedSpinner::spin(CallbackQueue* queue)
   }
 
   if (!spinner_monitor.add(queue, true))
+  {
     ROS_FATAL_STREAM("SingleThreadedSpinner: " << DEFAULT_ERROR_MESSAGE);
+    throw std::runtime_error("There is already another spinner on this queue");
+  }
 
   ros::WallDuration timeout(0.1f);
   ros::NodeHandle n;
@@ -192,7 +195,10 @@ void AsyncSpinnerImpl::start()
     return; // already spinning
 
   if (!spinner_monitor.add(callback_queue_, false))
+  {
     ROS_FATAL_STREAM("AsyncSpinnerImpl: " << DEFAULT_ERROR_MESSAGE);
+    throw std::runtime_error("There is already a single-threaded spinner on this queue");
+  }
 
   continue_ = true;
 

--- a/clients/roscpp/src/libros/spinner.cpp
+++ b/clients/roscpp/src/libros/spinner.cpp
@@ -34,6 +34,11 @@
 
 namespace {
 
+const std::string DEFAULT_ERROR_MESSAGE =
+    "\nAttempt to spin a callback queue from two spinners, one of them being single-threaded."
+    "\nThis will probably result in callbacks being executed out-of-order."
+    "\nIn future this will throw an exception!";
+
 /** class to monitor running single-threaded spinners.
  *
  *  Calling the callbacks of a callback queue _in order_, requires a unique SingleThreadedSpinner
@@ -56,9 +61,11 @@ struct SpinnerMonitor
   */
   struct Entry
   {
-    Entry(const boost::thread::id &tid) : tid(tid), num(0) {}
+    Entry(const boost::thread::id &tid,
+          const boost::thread::id &initial_tid) : tid(tid), initial_tid(initial_tid), num(0) {}
 
     boost::thread::id tid; // proper thread id of single-threaded spinner
+    boost::thread::id initial_tid; // to retain old behaviour, store first spinner's thread id
     unsigned int num; // number of (alike) spinners serving this queue
   };
 
@@ -67,19 +74,35 @@ struct SpinnerMonitor
   {
     boost::mutex::scoped_lock lock(mutex_);
 
+    boost::thread::id current_tid = boost::this_thread::get_id();
     boost::thread::id tid; // current thread id for single-threaded spinners, zero for multi-threaded ones
     if (single_threaded)
-      tid = boost::this_thread::get_id();
+      tid = current_tid;
 
     std::map<ros::CallbackQueue*, Entry>::iterator it = spinning_queues_.find(queue);
     bool can_spin = ( it == spinning_queues_.end() || // we will spin on any new queue
                       it->second.tid == tid ); // otherwise spinner must be alike (all multi-threaded: 0, or single-threaded on same thread id)
 
     if (!can_spin)
-      return false;
+    {
+      // Previous behavior (up to Kinetic) was to accept multiple spinners on a queue
+      // as long as they were started from the same thread. Although this is wrong behavior,
+      // we retain it here for backwards compatibility, i.e. we allow spinning of a
+      // single-threaded spinner after several multi-threaded ones, given that they
+      // were started from the same initial thread
+      if (it->second.initial_tid == tid)
+      {
+        ROS_ERROR_STREAM("SpinnerMonitor: single-threaded spinner after multi-threaded one(s)."
+                         << DEFAULT_ERROR_MESSAGE
+                         << " Only allowed for backwards compatibility.");
+        it->second.tid = tid; // "upgrade" tid to represent single-threaded spinner
+      }
+      else
+        return false;
+    }
 
     if (it == spinning_queues_.end())
-      it = spinning_queues_.insert(it, std::make_pair(queue, Entry(tid)));
+      it = spinning_queues_.insert(it, std::make_pair(queue, Entry(tid, current_tid)));
 
     // increment number of active spinners
     it->second.num += 1;
@@ -112,9 +135,6 @@ struct SpinnerMonitor
 };
 
 SpinnerMonitor spinner_monitor;
-const std::string DEFAULT_ERROR_MESSAGE =
-    "Attempt to spin a callback queue from two spinners, one of them being single-threaded. "
-    "This will probably result in callbacks being executed out-of-order.";
 }
 
 namespace ros
@@ -130,8 +150,8 @@ void SingleThreadedSpinner::spin(CallbackQueue* queue)
 
   if (!spinner_monitor.add(queue, true))
   {
-    ROS_FATAL_STREAM("SingleThreadedSpinner: " << DEFAULT_ERROR_MESSAGE);
-    throw std::runtime_error("There is already another spinner on this queue");
+    ROS_ERROR_STREAM("SingleThreadedSpinner: " << DEFAULT_ERROR_MESSAGE);
+    return;
   }
 
   ros::WallDuration timeout(0.1f);
@@ -220,8 +240,8 @@ void AsyncSpinnerImpl::start()
 
   if (!spinner_monitor.add(callback_queue_, false))
   {
-    ROS_FATAL_STREAM("AsyncSpinnerImpl: " << DEFAULT_ERROR_MESSAGE);
-    throw std::runtime_error("There is already a single-threaded spinner on this queue");
+    ROS_ERROR_STREAM("AsyncSpinnerImpl: " << DEFAULT_ERROR_MESSAGE);
+    return;
   }
 
   continue_ = true;

--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -3,21 +3,6 @@ if(TARGET ${PROJECT_NAME}-test_version)
   target_link_libraries(${PROJECT_NAME}-test_version)
 endif()
 
-# WARNING test_spinners is not actually run.  This is because this
-# infrastructure won't let me pass arguments from here through to
-# these test units.  otherwise one would have to build ten executables.
-# also the output of test_spinners has to be visually inspected
-# because there is no automatic way to ensure that an error condition
-# provokes a particular message.
-if(GTEST_FOUND)
-  include_directories(${GTEST_INCLUDE_DIRS})
-  add_executable(${PROJECT_NAME}-test_spinners EXCLUDE_FROM_ALL test_spinners.cpp)
-  add_dependencies(tests ${PROJECT_NAME}-test_spinners) 
-endif()
-if(TARGET ${PROJECT_NAME}-test_spinners)
-  target_link_libraries(${PROJECT_NAME}-test_spinners ${catkin_LIBRARIES} ${GTEST_LIBRARIES})
-endif()
-
 catkin_add_gtest(${PROJECT_NAME}-test_header test_header.cpp)
 if(TARGET ${PROJECT_NAME}-test_header)
   target_link_libraries(${PROJECT_NAME}-test_header ${catkin_LIBRARIES})
@@ -161,3 +146,6 @@ add_rostest(launch/ns_node_remapping.xml)
 add_rostest(launch/search_param.xml)
 
 add_rostest(launch/stamped_topic_statistics_with_empty_timestamp.xml)
+
+# Test spinners
+add_rostest(launch/spinners.xml)

--- a/test/test_roscpp/test/launch/spinners.xml
+++ b/test/test_roscpp/test/launch/spinners.xml
@@ -1,8 +1,4 @@
 <launch>
   <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_spin" args="--gtest_filter=Spinners.spin"/>
-  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_spinfail" args="--gtest_filter=Spinners.spinfail"/>
-  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_singlefail" args="--gtest_filter=Spinners.singlefail"/>
   <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_multi" args="--gtest_filter=Spinners.multi"/>
-  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_multifail" args="--gtest_filter=Spinners.multifail"/>
-  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_async" args="--gtest_filter=Spinners.async"/>
 </launch>

--- a/test/test_roscpp/test/launch/spinners.xml
+++ b/test/test_roscpp/test/launch/spinners.xml
@@ -1,0 +1,8 @@
+<launch>
+  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_spin" args="--gtest_filter=Spinners.spin"/>
+  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_spinfail" args="--gtest_filter=Spinners.spinfail"/>
+  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_singlefail" args="--gtest_filter=Spinners.singlefail"/>
+  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_multi" args="--gtest_filter=Spinners.multi"/>
+  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_multifail" args="--gtest_filter=Spinners.multifail"/>
+  <test pkg="test_roscpp" type="test_roscpp-spinners" test-name="Spinners_async" args="--gtest_filter=Spinners.async"/>
+</launch>

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -125,6 +125,10 @@ target_link_libraries(${PROJECT_NAME}-namespaces ${GTEST_LIBRARIES} ${catkin_LIB
 add_executable(${PROJECT_NAME}-params EXCLUDE_FROM_ALL params.cpp)
 target_link_libraries(${PROJECT_NAME}-params ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 
+# Test spinners
+add_executable(${PROJECT_NAME}-spinners EXCLUDE_FROM_ALL spinners.cpp)
+target_link_libraries(${PROJECT_NAME}-spinners ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+
 # Test getting information from the master
 add_executable(${PROJECT_NAME}-get_master_information EXCLUDE_FROM_ALL get_master_information.cpp)
 target_link_libraries(${PROJECT_NAME}-get_master_information ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
@@ -251,6 +255,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-name_remapping_with_ns
     ${PROJECT_NAME}-namespaces
     ${PROJECT_NAME}-params
+    ${PROJECT_NAME}-spinners
     ${PROJECT_NAME}-get_master_information
     ${PROJECT_NAME}-multiple_subscriptions
     ${PROJECT_NAME}-check_master
@@ -316,6 +321,7 @@ add_dependencies(${PROJECT_NAME}-name_remapping ${${PROJECT_NAME}_EXPORTED_TARGE
 add_dependencies(${PROJECT_NAME}-name_remapping_with_ns ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-namespaces ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-params ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}-spinners ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-get_master_information ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-multiple_subscriptions ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-check_master ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/test/test_roscpp/test/src/spinners.cpp
+++ b/test/test_roscpp/test/src/spinners.cpp
@@ -144,12 +144,10 @@ TEST(Spinners, async)
   AsyncSpinner as1(2);
   as1.start();
 
-#if 0
   // running another AsyncSpinner is allowed
   AsyncSpinner as2(2);
   as2.start();
   as2.stop();
-#endif
 
   SingleThreadedSpinner ss;
   EXPECT_THROW(ros::spin(ss), std::runtime_error);

--- a/test/test_roscpp/test/src/spinners.cpp
+++ b/test/test_roscpp/test/src/spinners.cpp
@@ -67,76 +67,98 @@ void fire_shutdown(const ros::WallTimerEvent&) {
 TEST(Spinners, spin)
 {
   DOIT();
-  ros::spin();
+  ros::spin(); // will block until ROS shutdown
 }
 
 TEST(Spinners, spinfail)
 {
   DOIT();
   boost::thread th(boost::bind(&ros::spin));
-  ros::spin();
-}
+  ros::WallDuration(0.1).sleep(); // wait for thread to be started
 
-TEST(Spinners, single)
-{
-  DOIT();
-  SingleThreadedSpinner s;
-  ros::spin(s);
+  EXPECT_THROW(ros::spin(), std::runtime_error);
+
+  SingleThreadedSpinner ss;
+  EXPECT_THROW(ros::spin(ss), std::runtime_error);
+  EXPECT_THROW(ss.spin(), std::runtime_error);
+
+  MultiThreadedSpinner ms;
+  EXPECT_THROW(ros::spin(ms), std::runtime_error);
+  EXPECT_THROW(ms.spin(), std::runtime_error);
+
+  AsyncSpinner as(2);
+  EXPECT_THROW(as.start(), std::runtime_error);
+
+  ros::waitForShutdown();
 }
 
 TEST(Spinners, singlefail)
 {
   DOIT();
-  boost::thread th(boost::bind(&ros::spin));
-  SingleThreadedSpinner s;
-  ros::spin(s);
-}
+  SingleThreadedSpinner ss;
+  boost::thread th(boost::bind(&ros::spin, ss));
+  ros::WallDuration(0.1).sleep(); // wait for thread to be started
 
-TEST(Spinners, singlefail2)
-{
-  DOIT();
-  SingleThreadedSpinner s;
-  boost::thread th(boost::bind(&ros::spin, s));
-  ros::spin(s);
+  EXPECT_THROW(ros::spin(), std::runtime_error);
+
+  SingleThreadedSpinner ss2;
+  EXPECT_THROW(ros::spin(ss2), std::runtime_error);
+  EXPECT_THROW(ss2.spin(), std::runtime_error);
+
+  MultiThreadedSpinner ms;
+  EXPECT_THROW(ros::spin(ms), std::runtime_error);
+  EXPECT_THROW(ms.spin(), std::runtime_error);
+
+  AsyncSpinner as(2);
+  EXPECT_THROW(as.start(), std::runtime_error);
+
+  ros::waitForShutdown();
 }
 
 TEST(Spinners, multi)
 {
   DOIT();
-  MultiThreadedSpinner s;
-  ros::spin(s);
+  MultiThreadedSpinner ms;
+  ros::spin(ms); // will block until ROS shutdown
 }
 
 TEST(Spinners, multifail)
 {
   DOIT();
-  boost::thread th(boost::bind(&ros::spin));
-  MultiThreadedSpinner s;
-  ros::spin(s);
-}
+  MultiThreadedSpinner ms;
+  boost::thread th(boost::bind(&ros::spin, ms));
+  ros::WallDuration(0.1).sleep(); // wait for thread to be started
 
-TEST(Spinners, multifail2)
-{
-  DOIT();
-  MultiThreadedSpinner s;
-  boost::thread th(boost::bind(&ros::spin, s));
-  ros::spin(s);
+  SingleThreadedSpinner ss2;
+  EXPECT_THROW(ros::spin(ss2), std::runtime_error);
+  EXPECT_THROW(ss2.spin(), std::runtime_error);
+
+  // running another multi-threaded spinner is allowed
+  MultiThreadedSpinner ms2;
+  ros::spin(ms2); // will block until ROS shutdown
 }
 
 TEST(Spinners, async)
 {
   DOIT();
-  AsyncSpinner s(2);
-  s.start();
-  ros::waitForShutdown();
-}
+  AsyncSpinner as1(2);
+  as1.start();
 
-TEST(Spinners, asyncfail)
-{
-  DOIT();
-  boost::thread th(boost::bind(&ros::spin));
-  AsyncSpinner s(2);
-  s.start();
+#if 0
+  // running another AsyncSpinner is allowed
+  AsyncSpinner as2(2);
+  as2.start();
+  as2.stop();
+#endif
+
+  SingleThreadedSpinner ss;
+  EXPECT_THROW(ros::spin(ss), std::runtime_error);
+  EXPECT_THROW(ss.spin(), std::runtime_error);
+
+  // running a multi-threaded spinner is allowed
+  MultiThreadedSpinner ms;
+  ros::spin(ms); // will block until ROS shutdown
+
   ros::waitForShutdown();
 }
 
@@ -149,5 +171,3 @@ main(int argc, char** argv)
   argv_ = argv;
   return RUN_ALL_TESTS();
 }
-
-


### PR DESCRIPTION
This is an attempt to fix #277 in a more fundamental fashion.

As @po1 pointed out in https://github.com/ros/ros_comm/issues/277#issuecomment-37054768, due to the [global mutex](https://github.com/ros/ros_comm/blob/groovy-devel/clients/roscpp/src/libros/spinner.cpp#L36), only a single thread was allowed to run/start spinners, even if operating on different callback queues.

As @tfoote pointed out in https://github.com/ros/ros_comm/issues/277#issuecomment-238713425, the mutex was probably introduced to prevent interleaving access to a callback queue thus guaranteeing _in-order_ execution of queued callbacks.

Obviously, this protection should be _local per callback queue_ (instead of using a global mutex) and it should only be considered for `SingleThreadedSpinners` as multi-threaded spinners deliberately request asynchronous processing.

This PR attempts to solve that issue by replacing the global mutex with a `SpinnerMonitor` that keeps track of all callback queues that are currently spinning. If a single-threaded spinner wants to spin a queue in parallel to another spinner, an error can be issued. IMHO, this error should be even fatal.

Alternatively, the callback queue should monitor who is spinning it. However, this would require an API change, which is why I decided for the `SpinnerMonitor`.
