### PR TITLE
fix static destruction order

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -148,6 +148,7 @@ void atexitCallback()
   if (ok() && !isShuttingDown())
   {
     ROSCPP_LOG_DEBUG("shutting down due to exit() or end of main() without cleanup of all NodeHandles");
+    g_started = false; // don't shutdown singletons, because they are already destroyed
     shutdown();
   }
 }

--- a/clients/roscpp/src/libros/service_manager.cpp
+++ b/clients/roscpp/src/libros/service_manager.cpp
@@ -52,20 +52,10 @@ using namespace std; // sigh
 namespace ros
 {
 
-ServiceManagerPtr g_service_manager;
-boost::mutex g_service_manager_mutex;
 const ServiceManagerPtr& ServiceManager::instance()
 {
-  if (!g_service_manager)
-  {
-    boost::mutex::scoped_lock lock(g_service_manager_mutex);
-    if (!g_service_manager)
-    {
-      g_service_manager = boost::make_shared<ServiceManager>();
-    }
-  }
-
-  return g_service_manager;
+  static ServiceManagerPtr service_manager = boost::make_shared<ServiceManager>();
+  return service_manager;
 }
 
 ServiceManager::ServiceManager()

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -102,6 +102,9 @@ void TopicManager::shutdown()
     shutting_down_ = true;
   }
 
+  // actually one should call poll_manager_->removePollThreadListener(), but the connection is not stored above
+  poll_manager_->shutdown();
+
   xmlrpc_manager_->unbind("publisherUpdate");
   xmlrpc_manager_->unbind("requestTopic");
   xmlrpc_manager_->unbind("getBusStats");


### PR DESCRIPTION
This is an attempt to fix #870.

According to [C++ standard](http://en.cppreference.com/w/cpp/utility/program/exit) `static` variables and registered `atexit` handlers are destroyed/called in _reverse_ order of their occurence.
The ROS source base seems to assume, that `atexit` handlers are called _before_ destruction of any `static` variables.

For example, the singletons `TopicManager` ... `XMLRPCManager` are created in `ros::start()` after having `ros::init()` registering the `atexit` handler. Hence, they will be destroyed before the call to the `atexit` handler, which attempted to access them and call their shutdown methods after destruction.

Use of global variables should be avoided in general, because their destruction order is determined by library linking. Using singletons the order of destruction can be determined by calling order.

This bug fix should be applied to Indigo and Jade as well and the source base should be checked for similar issues. I tracked the issue down with [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) using`-DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1"`.
