### PR TITLE
[rostopic] Fix rostopic echo for list of ROS message to fix #868

### DIFF
--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1362,7 +1362,8 @@ def create_value_transform(echo_nostr, echo_noarr):
                 try:
                     msg_class = genpy.message.get_message_class(t)
                     if msg_class is None:
-                        continue
+                        # happens for list of ROS messages like std_msgs/String[]
+                        raise ValueError
                     nested_transformed = value_transform(f_val)
                     setattr(val_trans, f, nested_transformed)
                 except ValueError:


### PR DESCRIPTION
Fix #868

The output will be like below:

```
% rostopic echo /tf
transforms: 
  - 
    header: 
      seq: 0
      stamp: 
        secs: 1471928060
        nsecs: 475493655
      frame_id: world
    child_frame_id: base_link
    transform: 
      translation: 
        x: 0.0
        y: 0.0
        z: 0.0
      rotation: 
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0

% rostopic echo /tf --noarr
transforms: <array type: geometry_msgs/TransformStamped, length: 1>

% rostopic echo /tf --nostr
transforms: 
  - 
    header: 
      seq: 0
      stamp: 
        secs: 1471928069
        nsecs: 386026988
      frame_id: world
    child_frame_id: base_link
    transform: 
      translation: 
        x: 0.0
        y: 0.0
        z: 0.0
      rotation: 
        x: 0.0
        y: 0.0
        z: 0.0
        w: 1.0
```
