### PR TITLE
[rospy] Logging function for rospy with node/func named msg

### DIFF
--- a/clients/rospy/src/rospy/__init__.py
+++ b/clients/rospy/src/rospy/__init__.py
@@ -58,6 +58,9 @@ from .core import is_shutdown, signal_shutdown, \
     get_node_uri, get_ros_root, \
     logdebug, logwarn, loginfo, logout, logerr, logfatal, \
     logdebug_throttle, logwarn_throttle, loginfo_throttle, logerr_throttle, logfatal_throttle, \
+    logdebug_func_named, logwarn_func_named, loginfo_func_named, logerr_func_named, logfatal_func_named, \
+    logdebug_node_named, logwarn_node_named, loginfo_node_named, logerr_node_named, logfatal_node_named, \
+    logdebug_node_func_named, logwarn_node_func_named, loginfo_node_func_named, logerr_node_func_named, logfatal_node_func_named, \
     parse_rosrpc_uri
 from .exceptions import *
 from .msg import AnyMsg

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -216,6 +216,82 @@ def logfatal_throttle(period, msg):
     _logging_throttle(caller_id, logfatal, period, msg)
 
 
+def _log_msg_func_named(msg):
+    try:
+        return '[{cls}::{method}] {msg}'.format(
+            cls=inspect.stack()[2][0].f_locals['self'].__class__.__name__,
+            method=inspect.stack()[2][0].f_code.co_name,
+            msg=msg)
+    except KeyError:
+        return '[{func}] {msg}'.format(
+            func=inspect.stack()[2][0].f_code.co_name,
+            msg=msg)
+
+
+def logdebug_func_named(msg, *args):
+    logdebug(*[_log_msg_func_named(msg[0])] + list(msg[1:]))
+
+
+def loginfo_func_named(msg, *args):
+    loginfo(_log_msg_func_named(msg), *args)
+
+
+def logwarn_func_named(msg, *args):
+    logwarn(_log_msg_func_named(msg), *args)
+
+
+def logerr_func_named(msg, *args):
+    logerr(_log_msg_func_named(msg), *args)
+
+
+def logfatal_func_named(msg, *args):
+    logfatal(_log_msg_func_named(msg), *args)
+
+
+def _log_msg_node_named(msg):
+    return '[{node}] {msg}'.format(node=rospy.get_name(), msg=msg)
+
+
+def logdebug_node_named(msg, *args):
+    logdebug(_log_msg_node_named(msg), *args)
+
+
+def loginfo_node_named(msg, *args):
+    loginfo(_log_msg_node_named(msg), *args)
+
+
+def logwarn_node_named(msg, *args):
+    logwarn(_log_msg_node_named(msg), *args)
+
+
+def logerr_node_named(msg, *args):
+    logerr(_log_msg_node_named(msg), *args)
+
+
+def logfatal_node_named(msg, *args):
+    logfatal(_log_msg_node_named(msg), *args)
+
+
+def logdebug_node_func_named(msg, *args):
+    logdebug(_log_msg_node_named(_log_msg_func_named(msg), *args))
+
+
+def loginfo_node_func_named(msg, *args):
+    loginfo(_log_msg_node_named(_log_msg_func_named(msg), *args))
+
+
+def logwarn_node_func_named(msg, *args):
+    logwarn(_log_msg_node_named(_log_msg_func_named(msg), *args))
+
+
+def logerr_node_func_named(msg, *args):
+    logerr(_log_msg_node_named(_log_msg_func_named(msg), *args))
+
+
+def logfatal_node_func_named(msg, *args):
+    logfatal(_log_msg_node_named(_log_msg_func_named(msg), *args))
+
+
 #########################################################
 # CONSTANTS
 


### PR DESCRIPTION
Below line outputs below image:

``` python
#!/usr/bin/env python

import rospy

rospy.init_node('a')

rospy.loginfo_func_named('a')
rospy.logwarn_func_named('a')
rospy.logfatal_func_named('a')
rospy.logerr_func_named('a')

rospy.loginfo_node_named('a')
rospy.logwarn_node_named('a')
rospy.logfatal_node_named('a')
rospy.logerr_node_named('a')

rospy.loginfo_node_func_named('a')
rospy.logwarn_node_func_named('a')
rospy.logfatal_node_func_named('a')
rospy.logerr_node_func_named('a')

rospy.loginfo_func_named('%d', 1)
rospy.logwarn_func_named('%d', 1)
rospy.logfatal_func_named('%d', 1)
rospy.logerr_func_named('%d', 1)

rospy.loginfo_node_named('%d', 1)
rospy.logwarn_node_named('%d', 1)
rospy.logfatal_node_named('%d', 1)
rospy.logerr_node_named('%d', 1)

def main():
    rospy.loginfo_func_named('a')
    rospy.logwarn_func_named('a')
    rospy.loginfo_node_named('a')
    rospy.logwarn_node_named('a')
    rospy.loginfo_node_func_named('a')
    rospy.logwarn_node_func_named('a')
main()

class Test(object):
    def __init__(self):
        rospy.loginfo_func_named('a')
        rospy.logwarn_func_named('a')
        rospy.loginfo_node_named('a')
        rospy.logwarn_node_named('a')
        rospy.loginfo_node_func_named('a')
        rospy.logwarn_node_func_named('a')
Test()
```

<img width="534" alt="screen shot 2016-08-25 at 12 06 56 am" src="https://cloud.githubusercontent.com/assets/4310419/17936005/517db68e-6a58-11e6-83d7-0216dc83830c.png">
