### PR TITLE
[rospy] Fix wrong type in docstring for rospy.Timer

### DIFF
--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -185,7 +185,7 @@ class Timer(threading.Thread):
         """
         Constructor.
         @param period: desired period between callbacks
-        @type  period: rospy.Time
+        @type  period: rospy.Duration
         @param callback: callback to be called
         @type  callback: function taking rospy.TimerEvent
         @param oneshot: if True, fire only once, otherwise fire continuously until shutdown is called [default: False]


### PR DESCRIPTION
rospy.Time -> rospy.Duration for period.

For https://github.com/ros/ros_tutorials/pull/34#discussion_r76261374
