### PR TITLE
register nosetests only when testing is enabled

### DIFF
--- a/tools/rosmsg/CMakeLists.txt
+++ b/tools/rosmsg/CMakeLists.txt
@@ -5,4 +5,6 @@ catkin_package()
 
 catkin_python_setup()
 
-catkin_add_nosetests(test)
+if(CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test)
+endif()


### PR DESCRIPTION
Only register tests when testing is enabled. This will fix one of the CMake warnings in the devel job. The remaining ones should be addressed by ros/genmsg#65.
