### PR TITLE
[roslaunch] Added condition to skip empty ('') <include> paths

### DIFF
--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -147,11 +147,12 @@ def _parse_launch(tags, launch_file, file_deps, verbose, context):
             except KeyError as e:
                 raise RoslaunchDepsException("Cannot load roslaunch <%s> tag: missing required attribute %s.\nXML is %s"%(tag.tagName, str(e), tag.toxml()))
 
-            # Check if an empty file is included, and skip if so.  This will allow a default-empty <include> inside a
+	    # Check if an empty file is included, and skip if so.  This will allow a default-empty <include> inside a
             # conditional to pass
             if sub_launch_file == '':
-                print("WARNING: empty <include> in %s. Skipping <include> of %s" % (launch_file,
-                                                                                    tag.attributes['file'].value))
+                if verbose:
+                    print("Empty <include> in %s. Skipping <include> of %s" % (launch_file,
+                                                                           tag.attributes['file'].value))
             else:
                 if verbose:
                     print("processing included launch %s"%sub_launch_file)
@@ -161,7 +162,7 @@ def _parse_launch(tags, launch_file, file_deps, verbose, context):
                 if sub_pkg is None:
                     print("ERROR: cannot determine package for [%s]"%sub_launch_file, file=sys.stderr)
 
-                elif sub_launch_file not in file_deps[launch_file].includes:
+                if sub_launch_file not in file_deps[launch_file].includes:
                     file_deps[launch_file].includes.append(sub_launch_file)
                 if launch_file_pkg != sub_pkg:
                     file_deps[launch_file].pkgs.append(sub_pkg)

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -146,32 +146,39 @@ def _parse_launch(tags, launch_file, file_deps, verbose, context):
                 sub_launch_file = resolve_args(tag.attributes['file'].value, context)
             except KeyError as e:
                 raise RoslaunchDepsException("Cannot load roslaunch <%s> tag: missing required attribute %s.\nXML is %s"%(tag.tagName, str(e), tag.toxml()))
-                
-            if verbose:
-                print("processing included launch %s"%sub_launch_file)
 
-            # determine package dependency for included file
-            sub_pkg = rospkg.get_package_name(os.path.dirname(os.path.abspath(sub_launch_file)))
-            if sub_pkg is None:
-                print("ERROR: cannot determine package for [%s]"%sub_launch_file, file=sys.stderr)
-            
-            if sub_launch_file not in file_deps[launch_file].includes:
-                file_deps[launch_file].includes.append(sub_launch_file)
-            if launch_file_pkg != sub_pkg:            
-                file_deps[launch_file].pkgs.append(sub_pkg)
-            
-            # recurse
-            file_deps[sub_launch_file] = RoslaunchDeps()
-            try:
-                dom = parse(sub_launch_file).getElementsByTagName('launch')
-                if not len(dom):
-                    print("ERROR: %s is not a valid roslaunch file"%sub_launch_file, file=sys.stderr)
-                else:
-                    launch_tag = dom[0]
-                    sub_context = _parse_subcontext(tag.childNodes, context)
-                    _parse_launch(launch_tag.childNodes, sub_launch_file, file_deps, verbose, sub_context)
-            except IOError as e:
-                raise RoslaunchDepsException("Cannot load roslaunch include '%s' in '%s'"%(sub_launch_file, launch_file))
+            # Check if an empty file is included, and skip if so.  This will allow a default-empty <include> inside a
+            # conditional to pass
+            if sub_launch_file == '':
+                print("WARNING: empty <include> in %s. Skipping <include> of %s" % (launch_file,
+                                                                                    tag.attributes['file'].value))
+            else:
+                if verbose:
+                    print("processing included launch %s"%sub_launch_file)
+
+                # determine package dependency for included file
+                sub_pkg = rospkg.get_package_name(os.path.dirname(os.path.abspath(sub_launch_file)))
+                if sub_pkg is None:
+                    print("ERROR: cannot determine package for [%s]"%sub_launch_file, file=sys.stderr)
+
+                elif sub_launch_file not in file_deps[launch_file].includes:
+                    file_deps[launch_file].includes.append(sub_launch_file)
+                if launch_file_pkg != sub_pkg:
+                    file_deps[launch_file].pkgs.append(sub_pkg)
+
+                # recurse
+                file_deps[sub_launch_file] = RoslaunchDeps()
+                try:
+                    dom = parse(sub_launch_file).getElementsByTagName('launch')
+                    if not len(dom):
+                        print("ERROR: %s is not a valid roslaunch file"%sub_launch_file, file=sys.stderr)
+                    else:
+                        launch_tag = dom[0]
+                        sub_context = _parse_subcontext(tag.childNodes, context)
+                        _parse_launch(launch_tag.childNodes, sub_launch_file, file_deps, verbose, sub_context)
+                except IOError as e:
+                    raise RoslaunchDepsException("Cannot load roslaunch include '%s' in '%s'"%(sub_launch_file,
+                                                                                               launch_file))
 
         elif tag.tagName in ['node', 'test']:
             try:


### PR DESCRIPTION
Our internal build system runs roslaunch-check against relevant packages, which will fail when it encounters `<include file='' />`. This change allows roslaunch-check to pass, but prints a warning when such an include is encountered.

This allows a file path to be passed in as an arg, and left empty by default, and still have roslaunch-check pass (but with a warning).  For example:

```
<launch>
  <arg name="some_mesh_launch" default=""/>

  <group if="$(eval len(some_mesh_launch) > 0)">
    <include file="$(arg some_mesh_launch)"/>
  </group>

</launch>
```
