### PR TITLE
support use_test_depends option for roslaunch-check

### DIFF
--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -41,9 +41,9 @@ import rospkg
 import roslaunch.rlutil
 import rosunit
 
-def check_roslaunch_file(roslaunch_file):
+def check_roslaunch_file(roslaunch_file, use_test_depends = False):
     print("checking", roslaunch_file)
-    error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file)
+    error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file, use_test_depends)
     # error message has to be XML attr safe
     if error_msg:
         return "[%s]:\n\t%s"%(roslaunch_file,error_msg)
@@ -66,6 +66,9 @@ if __name__ == '__main__':
     parser.add_option("-o", "--output-file",
                       dest="output_file", default=None,
                       help="file to store test results in", metavar="FILE")
+    parser.add_option("-t", "--use-test-depends",
+                      action="store_true", dest="test_depends", default=False,
+                      help="Assuming packages listed in test_depends are also installed")
 
     options, args = parser.parse_args()
     if not args:
@@ -83,11 +86,11 @@ if __name__ == '__main__':
     pkg_dir = r.get_path(pkg)
 
     if os.path.isfile(roslaunch_path):
-        error_msg = check_roslaunch_file(roslaunch_path)
+        error_msg = check_roslaunch_file(roslaunch_path, options.test_depends)
         outname = os.path.basename(roslaunch_path).replace('.', '_')
     else:
         print("checking *.launch in directory", roslaunch_path)
-        error_msg = check_roslaunch_dir(roslaunch_path)
+        error_msg = check_roslaunch_dir(roslaunch_path, options.test_depends)
         abspath = os.path.abspath
         relpath = abspath(roslaunch_path)[len(abspath(pkg_dir))+1:]
         outname = relpath.replace(os.sep, '_')

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -245,7 +245,7 @@ def print_deps(base_pkg, file_deps, verbose):
     # print space-separated to be friendly to rosmake
     print(' '.join([p for p in set(pkgs)]))
 
-def calculate_missing(base_pkg, missing, file_deps):
+def calculate_missing(base_pkg, missing, file_deps, use_test_depends=False):
     """
     Calculate missing package dependencies in the manifest. This is
     mainly used as a subroutine of roslaunch_deps().
@@ -256,6 +256,8 @@ def calculate_missing(base_pkg, missing, file_deps):
     @type  missing: { str: set(str) }
     @param file_deps: dictionary mapping launch file names to RoslaunchDeps of each file
     @type  file_deps: { str: RoslaunchDeps}
+    @param use_test_depends [bool]: use test_depends as installed package
+    @type  use_test_depends: [bool]
     @return: missing (see parameter)
     @rtype: { str: set(str) }
     """
@@ -275,6 +277,9 @@ def calculate_missing(base_pkg, missing, file_deps):
             from catkin_pkg.package import parse_package
             p = parse_package(os.path.dirname(m.filename))
             d_pkgs = set([d.name for d in p.run_depends])
+            if use_test_depends:
+                for d in p.test_depends:
+                    d_pkgs.add(d.name)
         # make sure we don't count ourselves as a dep
         d_pkgs.add(pkg)
 
@@ -285,13 +290,15 @@ def calculate_missing(base_pkg, missing, file_deps):
     return missing
         
     
-def roslaunch_deps(files, verbose=False):
+def roslaunch_deps(files, verbose=False, use_test_depends=False):
     """
     @param packages: list of packages to check
     @type  packages: [str]
     @param files [str]: list of roslaunch files to check. Must be in
       same package.
     @type  files: [str]
+    @param use_test_depends [bool]: use test_depends as installed package
+    @type  use_test_depends: [bool]
     @return: base_pkg, file_deps, missing.
       base_pkg is the package of all files
       file_deps is a { filename : RoslaunchDeps } dictionary of
@@ -315,7 +322,7 @@ def roslaunch_deps(files, verbose=False):
         base_pkg = pkg
         rl_file_deps(file_deps, launch_file, verbose)
 
-    calculate_missing(base_pkg, missing, file_deps)
+    calculate_missing(base_pkg, missing, file_deps, use_test_depends)
     return base_pkg, file_deps, missing            
     
 def roslaunch_deps_main(argv=sys.argv):

--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -180,12 +180,13 @@ def get_or_generate_uuid(options_runid, options_wait_for_master):
                 val = roslaunch.core.generate_run_id()
     return val
     
-def check_roslaunch(f):
+def check_roslaunch(f, option_use_test_depends=False):
     """
     Check roslaunch file for errors, returning error message if check fails. This routine
     is mainly to support rostest's roslaunch_check.
 
     :param f: roslaunch file name, ``str``
+    :param option_use_test_depends: Consider test_depends, ``Bool``
     :returns: error message or ``None``
     """
     try:
@@ -197,7 +198,7 @@ def check_roslaunch(f):
     errors = []
     # check for missing deps
     try:
-        base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f])
+        base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f], use_test_depends=option_use_test_depends)
     except rospkg.common.ResourceNotFound as r:
         errors.append("Could not find package [%s] included from [%s]"%(str(r), f))
         missing = {}


### PR DESCRIPTION
following https://github.com/ros/ros_comm/pull/885, when we check roslaunch, sometimes we have test launch code which depends on `test_depend`
