### PR TITLE
fix rostopic hz to print no message when there are no message on any topic

### DIFF
--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -202,8 +202,6 @@ class ROSTopicHz(object):
         # monitoring multiple topics' hz
         header = ['topic', 'rate', 'min_delta', 'max_delta', 'std_dev', 'window']
         stats = {h: [] for h in header}
-        if not any(self.times.values()):
-            return  # wait for initial message
         for topic in topics:
             hz_stat = self.get_hz(topic)
             if hz_stat is None:


### PR DESCRIPTION
When passing more then one topic but none of them has any messages it should print "no messages" every second.

Follow up of #886.
