### PR TITLE
Added missing arg to check_roslaunch_dir() definition

### DIFF
--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -48,7 +48,7 @@ def check_roslaunch_file(roslaunch_file, use_test_depends=False):
     if error_msg:
         return "[%s]:\n\t%s"%(roslaunch_file,error_msg)
 
-def check_roslaunch_dir(roslaunch_dir):
+def check_roslaunch_dir(roslaunch_dir, use_test_depends=False):
     error_msgs = []
     for f in os.listdir(roslaunch_dir):
         if f.endswith('.launch'):

--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -54,7 +54,7 @@ def check_roslaunch_dir(roslaunch_dir, use_test_depends=False):
         if f.endswith('.launch'):
             roslaunch_file = os.path.join(roslaunch_dir, f)
             if os.path.isfile(roslaunch_file):
-                error_msgs.append(check_roslaunch_file(roslaunch_file))
+                error_msgs.append(check_roslaunch_file(roslaunch_file, use_test_depends=use_test_depends))
     # error message has to be XML attr safe
     return '\n'.join([e for e in error_msgs if e])
 


### PR DESCRIPTION
`rosrun roslaunch roslaunch-check /path/to/file` fails on kinetic-devel with the following output:

```
Traceback (most recent call last):
  File "/home/jliviero/ws/src/ros_comm/tools/roslaunch/scripts/roslaunch-check", line 93, in <module>
    error_msg = check_roslaunch_dir(roslaunch_path, use_test_depends=options.test_depends)
TypeError: check_roslaunch_dir() got an unexpected keyword argument 'use_test_depends'
```

It seems the new arg was added to the call, but not the method definition, in [this diff](https://github.com/ros/ros_comm/commit/c224dcd258e8a732ecf098f253856e8d67f2898f).
