### PR TITLE
[roslaunch-check] Typo in named arg in call to check_roslaunch()

### DIFF
--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -43,7 +43,7 @@ import rosunit
 
 def check_roslaunch_file(roslaunch_file, use_test_depends=False):
     print("checking", roslaunch_file)
-    error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file, use_test_depends=use_test_depends)
+    error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file, option_use_test_depends=use_test_depends)
     # error message has to be XML attr safe
     if error_msg:
         return "[%s]:\n\t%s"%(roslaunch_file,error_msg)


### PR DESCRIPTION
Corrected named arg option_use_test_depends in call to check_roslaunch()
