### PR TITLE
[roscpp] throw exception on ros::init with empty node name

### DIFF
--- a/clients/roscpp/src/libros/this_node.cpp
+++ b/clients/roscpp/src/libros/this_node.cpp
@@ -89,6 +89,10 @@ void init(const std::string& name, const M_string& remappings, uint32_t options)
 #endif
   }
 
+  if (name.empty()) {
+    throw InvalidNameException("The node name must not be empty");
+  }
+
   g_name = name;
 
   bool disable_anon = false;

--- a/test/test_roscpp/test/test_names.cpp
+++ b/test/test_roscpp/test/test_names.cpp
@@ -35,6 +35,7 @@
 
 #include <gtest/gtest.h>
 #include "ros/names.h"
+#include "ros/init.h"
 
 using namespace ros;
 
@@ -75,6 +76,13 @@ TEST(Names, parentNamespace)
   EXPECT_STREQ(std::string("/z/a").c_str(), names::parentNamespace("/z/a/b").c_str());
   EXPECT_STREQ(std::string("/z/a").c_str(), names::parentNamespace("/z/a/b/").c_str()); //trailing slash
   EXPECT_STREQ(std::string("/z/asdf").c_str(), names::parentNamespace("/z/asdf/b").c_str());
+}
+
+TEST(Names, init)
+{
+  int argc = 0;
+  char** argv = NULL;
+  EXPECT_THROW(ros::init(argc, argv, ""), ros::InvalidNameException);
 }
 
 int


### PR DESCRIPTION
according to discussion at #891 
