### PR TITLE
[rospy] raise error on rospy.init_node with None or empty node name string

### DIFF
--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -257,7 +257,12 @@ def init_node(name, argv=None, anonymous=False, log_level=None, disable_rostime=
         # reload the mapping table. Any previously created rospy data
         # structure does *not* reinitialize based on the new mappings.
         rospy.names.reload_mappings(argv)
-        
+
+    # node name is None or empty string, raise error
+    # NOTE: the empty strings are considered false in a Boolean context (PEP 8)
+    if not name:
+        raise ValueError("name must not be empty")
+
     # this test can be eliminated once we change from warning to error in the next check
     if rosgraph.names.SEP in name:
         raise ValueError("namespaces are not allowed in node names")

--- a/test/test_rospy/test/unit/test_rospy_client.py
+++ b/test/test_rospy/test/unit/test_rospy_client.py
@@ -54,6 +54,20 @@ class TestRospyClient(unittest.TestCase):
             failed = False
         self.failIf(failed, "init_node allowed '/' in name")
 
+        failed = True
+        try:
+            rospy.init_node(name=None)
+        except ValueError:
+            failed = False
+        self.failIf(failed, "init_node allowed None as name")
+
+        failed = True
+        try:
+            rospy.init_node("")
+        except ValueError:
+            failed = False
+        self.failIf(failed, "init_node allowed empty string as name")
+
     def test_spin(self):
         failed = True
         try:


### PR DESCRIPTION
according to the discussion at #891 
current rospy shows warning if node name is empty string, so this pull request ensures the empty string for node name on initialization is invalid with raising error.
