### PR TITLE
Better naming for roslaunch check test XMLs.

### DIFF
--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -29,7 +29,7 @@
   <run_depend version_gte="1.11.16">rosmaster</run_depend>
   <run_depend>rosout</run_depend>
   <run_depend>rosparam</run_depend>
-  <run_depend>rosunit</run_depend>
+  <run_depend version_gte="1.13.3">rosunit</run_depend>
 
   <test_depend>rosbuild</test_depend>
 

--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -87,15 +87,13 @@ if __name__ == '__main__':
 
     if os.path.isfile(roslaunch_path):
         error_msg = check_roslaunch_file(roslaunch_path, use_test_depends=options.test_depends)
-        outname = os.path.basename(roslaunch_path).replace('.', '_')
     else:
         print("checking *.launch in directory", roslaunch_path)
         error_msg = check_roslaunch_dir(roslaunch_path, use_test_depends=options.test_depends)
-        abspath = os.path.abspath
-        relpath = abspath(roslaunch_path)[len(abspath(pkg_dir))+1:]
-        outname = relpath.replace(os.sep, '_')
-        if outname == '.':
-            outname = '_pkg'
+    relpath = os.path.abspath(roslaunch_path)[len(os.path.abspath(pkg_dir))+1:]
+    outname = relpath.replace('.', '_').replace(os.sep, '_')
+    if outname == '_':
+        outname = '_pkg'
 
     if options.output_file:
         test_file = options.output_file
@@ -116,10 +114,12 @@ if __name__ == '__main__':
         print("FAILURE:\n%s"%error_msg, file=sys.stderr)
         with open(test_file, 'w') as f:
             message = "roslaunch check [%s] failed"%(roslaunch_path)
-            f.write(rosunit.junitxml.test_failure_junit_xml(test_name, message, stdout=error_msg))
+            f.write(rosunit.junitxml.test_failure_junit_xml(test_name, message, stdout=error_msg,
+                    class_name="roslaunch.RoslaunchCheck", testcase_name="%s_%s" % (pkg, outname)))
         print("wrote test file to [%s]"%test_file)
         sys.exit(1)
     else:
         print("passed")
         with open(test_file, 'w') as f:
-            f.write(rosunit.junitxml.test_success_junit_xml(test_name))
+            f.write(rosunit.junitxml.test_success_junit_xml(test_name, stdout="",
+                    class_name="roslaunch.RoslaunchCheck", testcase_name="%s_%s" % (pkg, outname)))

--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -121,5 +121,5 @@ if __name__ == '__main__':
     else:
         print("passed")
         with open(test_file, 'w') as f:
-            f.write(rosunit.junitxml.test_success_junit_xml(test_name, stdout="",
+            f.write(rosunit.junitxml.test_success_junit_xml(test_name,
                     class_name="roslaunch.RoslaunchCheck", testcase_name="%s_%s" % (pkg, outname)))


### PR DESCRIPTION
Companion to https://github.com/ros/ros/pull/119

Ran: `rosrun roslaunch roslaunch-check src/ridgeback/ridgeback_description/launch/description.launch`

Which the following to: `test_results/ridgeback_description/rosunit-roslaunch_check_launch_description_launch.xml`

```
<testsuite errors="0" failures="1" name="src/ridgeback/ridgeback_description/launch/description.launch" tests="1" time="1"><testcase classname="roslaunch.RoslaunchCheck" name="ridgeback_description_launch_description_launch" status="run" time="1"><failure message="roslaunch check [src/ridgeback/ridgeback_description/launch/description.launch] failed" type="" /><system-out>&lt;![CDATA[
[src/ridgeback/ridgeback_description/launch/description.launch]:
  Invalid &lt;param&gt; tag: Cannot load command parameter [robot_description]: command [/Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/scripts/env_run                     /Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/urdf/configs/empty                     /opt/ros/indigo/lib/xacro/xacro /Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/urdf/ridgeback.urdf.xacro] returned with code [1].

Param xml is &lt;param command="$(find ridgeback_description)/scripts/env_run                     $(find ridgeback_description)/urdf/configs/$(arg config)                     $(find xacro)/xacro $(find ridgeback_description)/urdf/ridgeback.urdf.xacro" name="robot_description"/&gt;
]]&gt;</system-out></testcase></testsuite>
```

Ran: `rosrun roslaunch roslaunch-check src/ridgeback/ridgeback_description/launch`

Wrote the following to: `test_results/ridgeback_description/rosunit-roslaunch_check_launch.xml`

```
<testsuite errors="0" failures="1" name="src/ridgeback/ridgeback_description/launch" tests="1" time="1"><testcase classname="roslaunch.RoslaunchCheck" name="ridgeback_description_launch" status="run" time="1"><failure message="roslaunch check [src/ridgeback/ridgeback_description/launch] failed" type="" /><system-out>&lt;![CDATA[
[src/ridgeback/ridgeback_description/launch/description.launch]:
  Invalid &lt;param&gt; tag: Cannot load command parameter [robot_description]: command [/Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/scripts/env_run                     /Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/urdf/configs/empty                     /opt/ros/indigo/lib/xacro/xacro /Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/urdf/ridgeback.urdf.xacro] returned with code [1].

Param xml is &lt;param command="$(find ridgeback_description)/scripts/env_run                     $(find ridgeback_description)/urdf/configs/$(arg config)                     $(find xacro)/xacro $(find ridgeback_description)/urdf/ridgeback.urdf.xacro" name="robot_description"/&gt;
]]&gt;</system-out></testcase></testsuite>
```

Ran `catkin_make run_tests_ridgeback_navigation_roslaunch-check`

Which wrote the following to `test_results/ridgeback_description/roslaunch-check_launch_description.launch.xml`

```
<testsuite errors="0" failures="1" name="roslaunch-check_launch_description.launch.xml" tests="1" time="1"><testcase classname="roslaunch.RoslaunchCheck" name="ridgeback_description_launch_description_launch" status="run" time="1"><failure message="roslaunch check [/Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/launch/description.launch] failed" type="" /><system-out>&lt;![CDATA[
[/Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/launch/description.launch]:
  Invalid &lt;param&gt; tag: Cannot load command parameter [robot_description]: command [/Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/scripts/env_run                     /Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/urdf/configs/empty                     /opt/ros/indigo/lib/xacro/xacro /Users/mikepurvis/testing_ws/src/ridgeback/ridgeback_description/urdf/ridgeback.urdf.xacro] returned with code [1].

Param xml is &lt;param command="$(find ridgeback_description)/scripts/env_run                     $(find ridgeback_description)/urdf/configs/$(arg config)                     $(find xacro)/xacro $(find ridgeback_description)/urdf/ridgeback.urdf.xacro" name="robot_description"/&gt;
]]&gt;</system-out></testcase></testsuite>
```
