### PR TITLE
[kinetic] fix check of test type

### DIFF
--- a/tools/rostest/src/rostest/__init__.py
+++ b/tools/rostest/src/rostest/__init__.py
@@ -134,7 +134,7 @@ def rosrun(package, test_name, test, sysargs=None):
     import rospy
     
     suite = None
-    if issubclass(test, unittest.TestCase):
+    if isinstance(test, unittest.TestCase):
         suite = unittest.TestLoader().loadTestsFromTestCase(test)
     else:
         suite = unittest.TestLoader().loadTestsFromName(test)


### PR DESCRIPTION
Similar to the update discussed in [ros/pulls/121](https://github.com/ros/ros/pull/121) and merged in [ros/pulls/123](https://github.com/ros/ros/pull/123).
