### PR TITLE
Use boost::bind to bind the callback function

### DIFF
--- a/utilities/message_filters/include/message_filters/simple_filter.h
+++ b/utilities/message_filters/include/message_filters/simple_filter.h
@@ -93,7 +93,8 @@ public:
   template<typename P>
   Connection registerCallback(void(*callback)(P))
   {
-    return Connection(boost::bind(&Signal::removeCallback, &signal_, signal_.addCallback(callback)));
+    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(boost::bind(callback, _1));
+    return Connection(boost::bind(&Signal::removeCallback, &signal_, helper));
   }
 
   /**


### PR DESCRIPTION
Example usage:
void callback(const boost::shared_ptr<M const>&)

message_filters::Subscriber<std_msgs::UInt32> sub(nh, "my_topic", 1);
sub.registerCallback(myCallback);

cf. http://wiki.ros.org/message_filters#Example_.28C.2B-.2B-.29
