### PR TITLE
Fix BagMigrationException in migrate_raw

### DIFF
--- a/tools/rosbag/src/rosbag/migration.py
+++ b/tools/rosbag/src/rosbag/migration.py
@@ -1039,7 +1039,7 @@ class MessageMigrator(object):
         path = self.find_path(msg_from[4], msg_to[4])
 
         if False in [sn.rule.valid for sn in path]:
-            raise BagMigrationException("Migrate called, but no valid migration path from [%s] to [%s]"%(msg_from._type, msg_to._type))
+            raise BagMigrationException("Migrate called, but no valid migration path from [%s] to [%s]"%(msg_from[0], msg_to[0]))
 
         # Short cut to speed up case of matching md5sum:
         if path == [] or msg_from[2] == msg_to[2]:


### PR DESCRIPTION
Take the `._type` using `[0]`, because the arguments passed to `migrate_raw` are tuples.

This was throwing another exception because of that bug: `AttributeError`, saying that tuple has no attribute `_type`:

``` bash
new_msg_raw = migrator.migrate_raw(msg_raw, new_msg_raw)

File "/opt/ros/indigo/lib/python2.7/dist-packages/rosbag/migration.py", line 1042, in migrate_raw

raise BagMigrationException("Migrate called, but no valid migration path from [%s] to [%s]"%(msg_from._type, msg_to._type))'

"AttributeError: 'tuple' object has no attribute '_type'\n"
```
