### PR TITLE
Fix WallTimerEvent class -> struct

### DIFF
--- a/clients/roscpp/include/ros/transport_publisher_link.h
+++ b/clients/roscpp/include/ros/transport_publisher_link.h
@@ -42,7 +42,7 @@ typedef boost::weak_ptr<Subscription> SubscriptionWPtr;
 class Connection;
 typedef boost::shared_ptr<Connection> ConnectionPtr;
 
-class WallTimerEvent;
+struct WallTimerEvent;
 
 /**
  * \brief Handles a connection to a single publisher on a given topic.  Receives messages from a publisher


### PR DESCRIPTION
Aligns the forward decl with its definition, silencing a clang warning:

https://github.com/ros/ros_comm/blob/kinetic-devel/clients/roscpp/include/ros/forwards.h#L149