### PR TITLE
Drop epydoc from rosbag_storage

### DIFF
--- a/tools/rosbag_storage/rosdoc.yaml
+++ b/tools/rosbag_storage/rosdoc.yaml
@@ -1,5 +1,3 @@
- - builder: epydoc
-   output_dir: python
  - builder: doxygen
    name: C++ API
    output_dir: c++


### PR DESCRIPTION
It doesn't generate anyway: http://docs.ros.org/jade/api/rosbag_storage/html/python/