### PR TITLE
Update console.h

### DIFF
--- a/tools/rosconsole/include/ros/console.h
+++ b/tools/rosconsole/include/ros/console.h
@@ -40,6 +40,7 @@
 #include <cstdarg>
 #include <ros/macros.h>
 #include <map>
+#include <vector>
 
 #ifdef ROSCONSOLE_BACKEND_LOG4CXX
 #include "log4cxx/level.h"


### PR DESCRIPTION
Fix for errors using std::vector when not included, this matches the fix of the kinetic branch