### PR TITLE
Fix a bug that causes an XmlRpc::XmlRpcException

### DIFF
--- a/clients/roscpp/src/libros/master.cpp
+++ b/clients/roscpp/src/libros/master.cpp
@@ -245,6 +245,11 @@ bool execute(const std::string& method, const XmlRpc::XmlRpcValue& request, XmlR
 
   XMLRPCManager::instance()->releaseXMLRPCClient(c);
 
+  if (payload.getType() == XmlRpc::XmlRpcValue::TypeInvalid)
+  {
+    return false;
+  }
+
   return true;
 }
 


### PR DESCRIPTION
The exception is raised  if the node is trying to subscribe to a topic after rosmaster dies. In this case,  the node will be stuck in the while loop in `ros::master::execute()`:

https://github.com/ros/ros_comm/blob/kinetic-devel/clients/roscpp/src/libros/master.cpp#L189

if the condition ```(!ros::isShuttingDown() && !XMLRPCManager::instance()->isShuttingDown())``` becomes false, the loop would be exited and the function returns True although ```payload``` is invalid.

A simple example to reproduce:

```
#include "ros/ros.h"
#include "std_msgs/String.h"
#include <ros/topic.h>

void callback(const std_msgs::String::ConstPtr& msg)
{
  ROS_ERROR(msg->data.c_str());
}

int main(int argc, char **argv)
{
  ros::init(argc, argv, "test_node");
  ros::NodeHandle n;

  boost::shared_ptr<std_msgs::String const> msg;
  while (!(msg = ros::topic::waitForMessage<std_msgs::String>("some_topic", n, ros::Duration(2))) && ros::ok())
  {
    ROS_ERROR("Waiting for messages");
  }
  
  ros::spin();
  return 0;
}
```

If we run roscore, then run the above node, then kill roscore then try to stop the node with Ctrl-C we will get:
` terminate called after throwing an instance of ' XmlRpc::XmlRpcException'`

@dirk-thomas 
FYI @mikepurvis  @efernandez 