### PR TITLE
Add a missing #include <vector> statement

### DIFF
--- a/tools/rosconsole/include/ros/console.h
+++ b/tools/rosconsole/include/ros/console.h
@@ -40,6 +40,7 @@
 #include <cstdarg>
 #include <ros/macros.h>
 #include <map>
+#include <vector>
 
 #ifdef ROSCONSOLE_BACKEND_LOG4CXX
 #include "log4cxx/level.h"


### PR DESCRIPTION
It was not possibe to build with GCC 6.2.1 without it.