### PR TITLE
[rostopic] Rostopic pub option -1 delay reduced

### DIFF
--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1488,7 +1488,6 @@ def publish_message(pub, msg_class, pub_args, rate=None, once=False, verbose=Fal
     try:
         
         if rate is None:
-            s = "publishing and latching [%s]"%(msg) if verbose else "publishing and latching message"
             if once:
                 s = "[%s] published"%(msg) if verbose else "message published."
             else:

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1451,7 +1451,7 @@ def _publish_at_rate(pub, msg, rate, verbose=False, substitute_keywords=False, p
         pub.publish(msg)
         r.sleep()
 
-_ONCE_DELAY = 3.
+_ONCE_DELAY = 0.1
 def _publish_latched(pub, msg, once=False, verbose=False):
     """
     Publish and latch message. Subroutine of L{publish_message()}.
@@ -1490,9 +1490,9 @@ def publish_message(pub, msg_class, pub_args, rate=None, once=False, verbose=Fal
         if rate is None:
             s = "publishing and latching [%s]"%(msg) if verbose else "publishing and latching message"
             if once:
-                s = s + " for %s seconds"%_ONCE_DELAY
+                s = "[%s] published"%(msg) if verbose else "message published."
             else:
-                s = s + ". Press ctrl-C to terminate"
+                s = "Publishing and latching " + ("[%s]"%(msg) if verbose else "message") + ". Press ctrl-C to terminate."
             print(s)
 
             _publish_latched(pub, msg, once, verbose)


### PR DESCRIPTION
The expected behaviour of "rostopic pub -1 ..." is to send a message without a delay after sending the message, but there is a delay of 3 seconds. If the user wanted the delay, the default option should be used (without -1).

This PR reduces the delay to an imperceptible amount of time.