### PR TITLE
Nim 2795 module logging

### DIFF
--- a/clients/roscpp/src/libros/master.cpp
+++ b/clients/roscpp/src/libros/master.cpp
@@ -186,9 +186,9 @@ bool execute(const std::string& method, const XmlRpc::XmlRpcValue& request, XmlR
   bool printed = false;
   bool slept = false;
   bool ok = true;
+  bool b = false;
   do
   {
-    bool b = false;
     {
 #if defined(__APPLE__)
       boost::mutex::scoped_lock lock(g_xmlrpc_call_mutex);
@@ -245,7 +245,7 @@ bool execute(const std::string& method, const XmlRpc::XmlRpcValue& request, XmlR
 
   XMLRPCManager::instance()->releaseXMLRPCClient(c);
 
-  return true;
+  return b;
 }
 
 } // namespace master

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -1004,11 +1004,34 @@ extern std::string console::g_last_error_message;
 
 void TopicManager::pubUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result)
 {
+  std::stringstream ss;
+  const std::string& topic = params[1];
+  int is_rosout_topic = (strcmp(topic.c_str(), "rosout") == 0);
+  if (!is_rosout_topic)
+  {
+    ss << "publisherUpdate callback: topic=" << topic.c_str();
+    ss << ", pubs=[";
+  }
+
   std::vector<std::string> pubs;
   for (int idx = 0; idx < params[2].size(); idx++)
   {
+    const std::string& puburi = params[2][idx];
+    if (!is_rosout_topic)
+    {
+      ss << puburi.c_str() << ",";
+    }
+
     pubs.push_back(params[2][idx]);
   }
+
+  if (!is_rosout_topic) 
+  {
+    ss << "]";
+    auto p = ss.str();
+    ROS_INFO("%s", p.c_str());
+  }
+
   if (pubUpdate(params[1], pubs))
   {
     result = xmlrpc::responseInt(1, "", 0);

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -348,8 +348,8 @@ class TCPROSServer(object):
         except Exception as e:
             # collect stack trace separately in local log file
             if not rospy.core.is_shutdown_requested():
-                logwarn("Inbound TCP/IP connection failed: %s", e)
-                rospyerr("Inbound TCP/IP connection failed:\n%s", traceback.format_exc())
+                logwarn("Inbound TCP/IP connection failed from '%s': %s", str(client_addr), e)
+                rospyerr("Inbound TCP/IP connection failed from '%s':\n%s", str(client_addr), traceback.format_exc())
             if sock is not None:
                 sock.close()
 

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -202,10 +202,23 @@ def publisher_update_task(api, topic, pub_uris):
     @param pub_uris: list of publisher APIs to send to node
     @type  pub_uris: [str]
     """
-    
-    mloginfo("publisherUpdate[%s] -> %s", topic, api)
+    is_rosout_topic = 'rosout' in topic
+    start_ms = time.time()
+    msg = "publisherUpdate[%s] -> %s %s" % (topic, api, str(pub_uris))
+    if not is_rosout_topic:
+        mloginfo(msg)
     #TODO: check return value for errors so we can unsubscribe if stale
-    xmlrpcapi(api).publisherUpdate('/master', topic, pub_uris)
+    try:
+        ret = xmlrpcapi(api).publisherUpdate('/master', topic, pub_uris)
+    except Exception as ex:
+        if not is_rosout_topic:
+            delta_sec = (time.time() - start_ms) * 1000.0
+            mloginfo("%s: secs=%0.2f, exception=%s", msg, delta_sec, str(ex))
+        raise
+    if not is_rosout_topic:
+        delta_sec = (time.time() - start_ms) * 1000.0
+        mloginfo("%s: secs=%0.2f, result=%s", msg, delta_sec, ret)
+
 
 def service_update_task(api, service, uri):
     """


### PR DESCRIPTION
Add child loggers to rosout so we can control how python modules log to rosout and control the verbosity on a child logger scope instead of at a node scope.