### PR TITLE
Add named loggers to rospy 

### DIFF
--- a/test/test_rospy/test/rostest/test_rospy_client_online.py
+++ b/test/test_rospy/test/rostest/test_rospy_client_online.py
@@ -182,6 +182,24 @@ class TestRospyClientOnline(unittest.TestCase):
                     rospy.sleep(rospy.Duration(2))
                 else:
                     self.assert_("test 4" in sys.stderr.getvalue())
+            
+            rospy.loginfo("test child logger 1", logger_name="log1")
+            self.assert_("test child logger 1" in sys.stdout.getvalue())
+            
+            rospy.logwarn("test child logger 2", logger_name="log2")            
+            self.assert_("[WARN]" in sys.stderr.getvalue())
+            self.assert_("test child logger 2" in sys.stderr.getvalue())
+
+            sys.stderr = StringIO()
+            rospy.logerr("test child logger 3", logger_name="log3")            
+            self.assert_("[ERROR]" in sys.stderr.getvalue())
+            self.assert_("test child logger 3" in sys.stderr.getvalue())
+            
+            sys.stderr = StringIO()
+            rospy.logfatal("test child logger 4", logger_name="log4")            
+            self.assert_("[FATAL]" in sys.stderr.getvalue())            
+            self.assert_("test child logger 4" in sys.stderr.getvalue()) 
+
         finally:
             sys.stdout = real_stdout
             sys.stderr = real_stderr

--- a/test/test_rospy/test/unit/test_rospy_core.py
+++ b/test/test_rospy/test/unit/test_rospy_core.py
@@ -79,7 +79,13 @@ class TestRospyCore(unittest.TestCase):
         rospy.logout('out')
         rospy.logerr('err')
         rospy.logfatal('fatal')
-        
+        #basic named logger test
+        rospy.logdebug('debug', logger_name="child1")
+        rospy.logwarn('warn', logger_name="child1")
+        rospy.logout('out', logger_name="child1")
+        rospy.logerr('err', logger_name="child1")
+        rospy.logfatal('fatal', logger_name="child1")
+
     def test_add_shutdown_hook(self):
         def handle(reason):
             pass


### PR DESCRIPTION
This change will create (named) child loggers under rospy.rosout. This allows for each named logger to have seperate verbosity setting, this will allow for two different verboisty settings for logging in a single node.  Two named loggers can log to rosout at two different verbosity setings, which can help noisy debug logs.