### PR TITLE
Pause service for rosbag player

### DIFF
--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT WIN32)
   set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Wextra")
 endif()
 
-find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp topic_tools xmlrpcpp)
+find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
 find_package(Boost REQUIRED COMPONENTS date_time regex program_options filesystem)
 find_package(BZip2 REQUIRED)
 
@@ -19,7 +19,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 catkin_package(
   LIBRARIES rosbag
   INCLUDE_DIRS include
-  CATKIN_DEPENDS rosbag_storage rosconsole roscpp topic_tools xmlrpcpp)
+  CATKIN_DEPENDS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
 
 add_library(rosbag
   src/player.cpp

--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -47,6 +47,7 @@
 
 #include <ros/ros.h>
 #include <ros/time.h>
+#include <std_srvs/SetBool.h>
 
 #include "rosbag/bag.h"
 
@@ -177,6 +178,7 @@ private:
 
     void printTime();
 
+    bool pauseCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
 
 private:
 
@@ -184,9 +186,15 @@ private:
 
     ros::NodeHandle node_handle_;
 
+    ros::ServiceServer pause_service_;
+
     bool paused_;
 
     bool pause_for_topics_;
+
+    bool pause_change_requested_;
+
+    bool requested_pause_state_;
 
     ros::WallTime paused_time_;
 

--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -180,6 +180,8 @@ private:
 
     bool pauseCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
 
+    void processPause(const bool paused, ros::WallTime &horizon);
+
 private:
 
     PlayerOptions options_;

--- a/tools/rosbag/package.xml
+++ b/tools/rosbag/package.xml
@@ -23,6 +23,7 @@
   <build_depend>rosconsole</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roscpp_serialization</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>topic_tools</build_depend>
   <build_depend>xmlrpcpp</build_depend>
 
@@ -35,6 +36,7 @@
   <run_depend>roscpp</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>topic_tools</run_depend>
   <run_depend>xmlrpcpp</run_depend>
 

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -110,7 +110,8 @@ Player::Player(PlayerOptions const& options) :
     requested_pause_state_(false),
     terminal_modified_(false)
 {
-  pause_service_ = node_handle_.advertiseService("pause", &Player::pauseCallback, this);
+  ros::NodeHandle private_node_handle("~");
+  pause_service_ = private_node_handle.advertiseService("pause", &Player::pauseCallback, this);
 }
 
 Player::~Player() {
@@ -290,7 +291,7 @@ bool Player::pauseCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::R
 
   if (res.success)
   {
-    res.message = (requested_pause_state_ ? "Pause" : "Resume") + std::string(" requested.");
+    res.message = std::string("Playback is now ") + (requested_pause_state_ ? "paused" : "resumed");
   }
   else
   {

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -286,8 +286,16 @@ bool Player::pauseCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::R
   pause_change_requested_ = (req.data != paused_);
   requested_pause_state_ = req.data;
 
-  res.success = true;
-  res.message = (requested_pause_state_ ? "Pause" : "Resume") + std::string(" requested.");
+  res.success = pause_change_requested_;
+
+  if (res.success)
+  {
+    res.message = (requested_pause_state_ ? "Pause" : "Resume") + std::string(" requested.");
+  }
+  else
+  {
+    res.message = std::string("Bag is already ") + (requested_pause_state_ ? "paused." : "running.");
+  }
 
   return true;
 }

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -102,6 +102,7 @@ void PlayerOptions::check() {
 
 Player::Player(PlayerOptions const& options) :
     options_(options),
+    node_handle_("~"),
     paused_(false),
     // If we were given a list of topics to pause on, then go into that mode
     // by default (it can be toggled later via 't' from the keyboard).

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -102,7 +102,6 @@ void PlayerOptions::check() {
 
 Player::Player(PlayerOptions const& options) :
     options_(options),
-    node_handle_("~"),
     paused_(false),
     // If we were given a list of topics to pause on, then go into that mode
     // by default (it can be toggled later via 't' from the keyboard).


### PR DESCRIPTION
We've recently required the ability to pause playback in `rosbag play` via service calls within code. The changes include the addition of a `spinOnce()` call within `doPublish()` so that we can process the service request. I'm not sure if having callbacks in the `Player` class is acceptable, or if this functionality would be useful for anyone else, but I thought it worth a PR.