### PR TITLE
Add '#Include <vector>' to fix building on GCC-6 (cherry-pick #911)

### DIFF
--- a/tools/rosconsole/include/ros/console.h
+++ b/tools/rosconsole/include/ros/console.h
@@ -40,6 +40,7 @@
 #include <cstdarg>
 #include <ros/macros.h>
 #include <map>
+#include <vector>
 
 #ifdef ROSCONSOLE_BACKEND_LOG4CXX
 #include "log4cxx/level.h"


### PR DESCRIPTION
Don't rely on transitive header inclusion to declare std::vector as building with GCC-6 fails due to no '#Include <vector>' statement.