### PR TITLE
fixed UDP block number when EAGAIN or EWOULDBLOCK

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -590,7 +590,7 @@ int32_t TransportUDP::write(uint8_t* buffer, uint32_t size)
       else
       {
         num_bytes = 0;
-	--this_block;
+        --this_block;
       }
     }
     else if (num_bytes < (unsigned) sizeof(header))

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -245,7 +245,7 @@ bool TransportUDP::createIncoming(int port, bool is_server)
 
   server_address_.sin_family = AF_INET;
   server_address_.sin_port = htons(port);
-  server_address_.sin_addr.s_addr = isOnlyLocalhostAllowed() ? 
+  server_address_.sin_addr.s_addr = isOnlyLocalhostAllowed() ?
                                     htonl(INADDR_LOOPBACK) :
                                     INADDR_ANY;
   if (bind(sock_, (sockaddr *)&server_address_, sizeof(server_address_)) < 0)
@@ -590,6 +590,7 @@ int32_t TransportUDP::write(uint8_t* buffer, uint32_t size)
       else
       {
         num_bytes = 0;
+        --this_block;
       }
     }
     else if (num_bytes < (unsigned) sizeof(header))
@@ -612,7 +613,7 @@ void TransportUDP::enableRead()
 {
   {
     boost::mutex::scoped_lock lock(close_mutex_);
-  
+
     if (closed_)
     {
       return;
@@ -685,7 +686,7 @@ void TransportUDP::disableWrite()
 TransportUDPPtr TransportUDP::createOutgoing(std::string host, int port, int connection_id, int max_datagram_size)
 {
   ROS_ASSERT(is_server_);
-  
+
   TransportUDPPtr transport(boost::make_shared<TransportUDP>(poll_set_, flags_, max_datagram_size));
   if (!transport->connect(host, port, connection_id))
   {

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -245,7 +245,7 @@ bool TransportUDP::createIncoming(int port, bool is_server)
 
   server_address_.sin_family = AF_INET;
   server_address_.sin_port = htons(port);
-  server_address_.sin_addr.s_addr = isOnlyLocalhostAllowed() ?
+  server_address_.sin_addr.s_addr = isOnlyLocalhostAllowed() ? 
                                     htonl(INADDR_LOOPBACK) :
                                     INADDR_ANY;
   if (bind(sock_, (sockaddr *)&server_address_, sizeof(server_address_)) < 0)
@@ -590,7 +590,7 @@ int32_t TransportUDP::write(uint8_t* buffer, uint32_t size)
       else
       {
         num_bytes = 0;
-        --this_block;
+	--this_block;
       }
     }
     else if (num_bytes < (unsigned) sizeof(header))
@@ -613,7 +613,7 @@ void TransportUDP::enableRead()
 {
   {
     boost::mutex::scoped_lock lock(close_mutex_);
-
+  
     if (closed_)
     {
       return;
@@ -686,7 +686,7 @@ void TransportUDP::disableWrite()
 TransportUDPPtr TransportUDP::createOutgoing(std::string host, int port, int connection_id, int max_datagram_size)
 {
   ROS_ASSERT(is_server_);
-
+  
   TransportUDPPtr transport(boost::make_shared<TransportUDP>(poll_set_, flags_, max_datagram_size));
   if (!transport->connect(host, port, connection_id))
   {


### PR DESCRIPTION
I found a bug in `TransportUDP::write`. When this branch is taken, `num_bytes` is initialized to retry the write operation. However, `this_block` stays increased. This causes block number in the datagram head to increase to an arbitrary amount, and the subscriber cannot receive the expected block. This commit just decreases `this_block` and retry the write properly.