### PR TITLE
[rospy] made get_published_topics threadsafe

### DIFF
--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -90,8 +90,6 @@ class MasterProxy(object):
         self._lock = Lock()
 
     def __getattr__(self, key): #forward api calls to target
-        with self._lock:
-            f = getattr(self.target, key)
         if key in _master_arg_remap:
             remappings = _master_arg_remap[key]
         else:
@@ -104,6 +102,7 @@ class MasterProxy(object):
                 #print "Remap %s => %s"%(args[i], rospy.names.resolve_name(args[i]))
                 args[i] = rospy.names.resolve_name(args[i])
             with self._lock:
+                f = getattr(self.target, key)
                 return f(*args, **kwds)
         return wrappedF
 

--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -103,7 +103,8 @@ class MasterProxy(object):
                 i = i + 1 #callerId does not count
                 #print "Remap %s => %s"%(args[i], rospy.names.resolve_name(args[i]))
                 args[i] = rospy.names.resolve_name(args[i])
-            return f(*args, **kwds)
+            with self._lock:
+                return f(*args, **kwds)
         return wrappedF
 
     def __getitem__(self, key):


### PR DESCRIPTION
With multiple threads trying to get the currently published topics at least one of them crashes with 

```
Exception in thread Thread-4:
Traceback (most recent call last):
    topics = rospy.get_published_topics()
  File "/ros_comm/clients/rospy/src/rospy/client.py", line 376, in get_published_topics
    code, msg, val = get_master().getPublishedTopics(namespace)
  File "/ros_comm/clients/rospy/src/rospy/msproxy.py", line 106, in wrappedF
    return f(*args, **kwds)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1233, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1587, in __request
    verbose=self.__verbose
  File "/usr/lib/python2.7/xmlrpclib.py", line 1273, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1303, in single_request
    response = h.getresponse(buffering=True)
  File "/usr/lib/python2.7/httplib.py", line 1077, in getresponse
    raise ResponseNotReady()
ResponseNotReady

Exception in thread Thread-5:
Traceback (most recent call last):

    topics = rospy.get_published_topics()
  File "/ros_comm/clients/rospy/src/rospy/client.py", line 376, in get_published_topics
    code, msg, val = get_master().getPublishedTopics(namespace)
  File "/ros_comm/clients/rospy/src/rospy/msproxy.py", line 106, in wrappedF
    return f(*args, **kwds)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1233, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1587, in __request
    verbose=self.__verbose
  File "/usr/lib/python2.7/xmlrpclib.py", line 1273, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1298, in single_request
    self.send_request(h, handler, request_body)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1400, in send_request
    connection.putrequest("POST", handler, skip_accept_encoding=True)
  File "/usr/lib/python2.7/httplib.py", line 906, in putrequest
    raise CannotSendRequest()
CannotSendRequest
```

the acquisition of `f` is thread safe, but the final call to `f` seems not.