### PR TITLE
rosbag play: added option wait-for-subscriber

### DIFF
--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -182,6 +182,7 @@ private:
 
 
 private:
+    typedef std::map<std::string, ros::Publisher> PublisherMap;
 
     PlayerOptions options_;
 
@@ -194,7 +195,7 @@ private:
     ros::WallTime paused_time_;
 
     std::vector<boost::shared_ptr<Bag> >  bags_;
-    std::map<std::string, ros::Publisher> publishers_;
+    PublisherMap publishers_;
 
     // Terminal
     bool    terminal_modified_;

--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -88,6 +88,7 @@ struct ROSBAG_DECL PlayerOptions
     bool     has_duration;
     float    duration;
     bool     keep_alive;
+    bool     wait_for_subscribers;
     ros::Duration skip_empty;
 
     std::vector<std::string> bags;
@@ -176,6 +177,8 @@ private:
     void doKeepAlive();
 
     void printTime();
+
+    void waitForSubscribers() const;
 
 
 private:

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -62,7 +62,7 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       ("topics", po::value< std::vector<std::string> >()->multitoken(), "topics to play back")
       ("pause-topics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
       ("bags", po::value< std::vector<std::string> >(), "bag files to play back from")
-      ("wait-for-subscribers", "wait for subscribers before publishing");
+      ("wait-for-subscribers", "wait for at least one subscriber on each topic before publishing");
     
     po::positional_options_description p;
     p.add("bags", -1);

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -61,7 +61,8 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       ("try-future-version", "still try to open a bag file, even if the version is not known to the player")
       ("topics", po::value< std::vector<std::string> >()->multitoken(), "topics to play back")
       ("pause-topics", po::value< std::vector<std::string> >()->multitoken(), "topics to pause playback on")
-      ("bags", po::value< std::vector<std::string> >(), "bag files to play back from");
+      ("bags", po::value< std::vector<std::string> >(), "bag files to play back from")
+      ("wait-for-subscribers", "wait for subscribers before publishing");
     
     po::positional_options_description p;
     p.add("bags", -1);
@@ -118,6 +119,8 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
       opts.loop = true;
     if (vm.count("keep-alive"))
       opts.keep_alive = true;
+    if (vm.count("wait-for-subscribers"))
+      opts.wait_for_subscribers = true;
 
     if (vm.count("topics"))
     {

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -290,8 +290,7 @@ void Player::waitForSubscribers() const
     std::cout << "Waiting for subscribers." << std::endl;
     while (!all_topics_subscribed) {
         all_topics_subscribed = true;
-        typedef std::pair<std::string, ros::Publisher> value_type;
-        foreach(const value_type& pub, publishers_) {
+        foreach(const PublisherMap::value_type& pub, publishers_) {
             all_topics_subscribed &= pub.second.getNumSubscribers() > 0;
         }
     }

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -293,6 +293,7 @@ void Player::waitForSubscribers() const
         foreach(const PublisherMap::value_type& pub, publishers_) {
             all_topics_subscribed &= pub.second.getNumSubscribers() > 0;
         }
+        ros::Duration(0.1).sleep();
     }
     std::cout << "Finished waiting for subscribers." << std::endl;
 }

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -87,6 +87,7 @@ PlayerOptions::PlayerOptions() :
     has_duration(false),
     duration(0.0f),
     keep_alive(false),
+    wait_for_subscribers(false),
     skip_empty(ros::DURATION_MAX)
 {
 }
@@ -211,6 +212,11 @@ void Player::publish() {
 
     paused_ = options_.start_paused;
 
+    if (options_.wait_for_subscribers)
+    {
+        waitForSubscribers();
+    }
+
     while (true) {
         // Set up our time_translator and publishers
 
@@ -276,6 +282,20 @@ void Player::printTime()
         }
         fflush(stdout);
     }
+}
+
+void Player::waitForSubscribers() const
+{
+    bool all_topics_subscribed = false;
+    std::cout << "Waiting for subscribers." << std::endl;
+    while (!all_topics_subscribed) {
+        all_topics_subscribed = true;
+        typedef std::pair<std::string, ros::Publisher> value_type;
+        foreach(const value_type& pub, publishers_) {
+            all_topics_subscribed &= pub.second.getNumSubscribers() > 0;
+        }
+    }
+    std::cout << "Finished waiting for subscribers." << std::endl;
 }
 
 void Player::doPublish(MessageInstance const& m) {

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -208,7 +208,7 @@ def play_cmd(argv):
     parser.add_option("--topics", dest="topics", default=[],  callback=handle_topics, action="callback", help="topics to play back")
     parser.add_option("--pause-topics", dest="pause_topics", default=[],  callback=handle_pause_topics, action="callback", help="topics to pause on during playback")
     parser.add_option("--bags",  help="bags files to play back from")
-    parser.add_option("--wait-for-subscribers",  dest="wait_for_subscribers", default=False, action="store_true", help="wait for subscribers before publishing")
+    parser.add_option("--wait-for-subscribers",  dest="wait_for_subscribers", default=False, action="store_true", help="wait for at least one subscriber on each topic before publishing")
 
     (options, args) = parser.parse_args(argv)
 

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -208,6 +208,7 @@ def play_cmd(argv):
     parser.add_option("--topics", dest="topics", default=[],  callback=handle_topics, action="callback", help="topics to play back")
     parser.add_option("--pause-topics", dest="pause_topics", default=[],  callback=handle_pause_topics, action="callback", help="topics to pause on during playback")
     parser.add_option("--bags",  help="bags files to play back from")
+    parser.add_option("--wait-for-subscribers",  dest="wait_for_subscribers", default=False, action="store_true", help="wait for subscribers before publishing")
 
     (options, args) = parser.parse_args(argv)
 
@@ -231,6 +232,7 @@ def play_cmd(argv):
     if options.loop:       cmd.extend(["--loop"])
     if options.keep_alive: cmd.extend(["--keep-alive"])
     if options.try_future: cmd.extend(["--try-future-version"])
+    if options.wait_for_subscribers: cmd.extend(["--wait-for-subscribers"])
 
     if options.clock:
         cmd.extend(["--clock", "--hz", str(options.freq)])


### PR DESCRIPTION
Added an option `--wait-for-subscriber`. If this option is chosen, `rosbag play` will wait before publishing until every topic has at least one subscriber. This is pretty useful in tests using `rostest` if one wants to make sure that no message is dropped because of missing subscribers.