### PR TITLE
[xmlrpcpp] close socket when connection can't be accepted. Fixes #914

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcServer.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServer.cpp
@@ -141,6 +141,8 @@ unsigned
 XmlRpcServer::handleEvent(unsigned)
 {
   acceptConnection();
+  if (getfd() == -1)
+     return XmlRpcDispatch::Exception;
   return XmlRpcDispatch::ReadableEvent;		// Continue to monitor this fd
 }
 
@@ -154,7 +156,7 @@ XmlRpcServer::acceptConnection()
   XmlRpcUtil::log(2, "XmlRpcServer::acceptConnection: socket %d", s);
   if (s < 0)
   {
-    //this->close();
+    this->close();
     XmlRpcUtil::error("XmlRpcServer::acceptConnection: Could not accept connection (%s).", XmlRpcSocket::getErrorMsg().c_str());
   }
   else if ( ! XmlRpcSocket::setNonBlocking(s))


### PR DESCRIPTION
This PR fixes #914. As suggested by @trainman419 and confirmed by @ruffsl, uncommenting line https://github.com/ros/ros_comm/blob/ea132076ae6741caeda5b933b78f9e64efe2426c/utilities/xmlrpcpp/src/XmlRpcServer.cpp#L157 did the trick.
I also changed the return value of handleEvent in that case.