### PR TITLE
Backport: fix test type handling (#722)

### DIFF
--- a/tools/rostest/src/rostest/__init__.py
+++ b/tools/rostest/src/rostest/__init__.py
@@ -134,10 +134,11 @@ def rosrun(package, test_name, test, sysargs=None):
     import rospy
     
     suite = None
-    if issubclass(test, unittest.TestCase):
-        suite = unittest.TestLoader().loadTestsFromTestCase(test)
-    else:
+    if isinstance(test, str):
         suite = unittest.TestLoader().loadTestsFromName(test)
+    else:
+        # some callers pass a TestCase type (instead of an instance)
+        suite = unittest.TestLoader().loadTestsFromTestCase(test)
 
     if text_mode:
         result = unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Hi, I would appreciate this change will be backported to Indigo.

Actually, ``issubclass`` requires that arg 1 must be a class. So when I pass a string to ``test``, it always fails with the following message:
```
  File "/opt/ros/indigo/lib/python2.7/dist-packages/rostest/__init__.py", line 137, in rosrun
    if issubclass(test, unittest.TestCase):
TypeError: issubclass() arg 1 must be a class
testtest ... FAILURE!
````

Thanks in advance.