### PR TITLE
[rostest] Check /clock publication neatly in publishtest

### DIFF
--- a/tools/rostest/nodes/publishtest
+++ b/tools/rostest/nodes/publishtest
@@ -111,12 +111,12 @@ class PublishTest(unittest.TestCase):
         t_start = time.time()
         while not rospy.is_shutdown() and \
                 use_sim_time and (rospy.Time.now() == rospy.Time(0)):
-            rospy.logwarn('/use_sim_time is specified and rostime is 0, '
-                          '/clock is published?')
+            rospy.logwarn_throttle(
+                1, '/use_sim_time is specified and rostime is 0, /clock is published?')
             if time.time() - t_start > 10:
                 self.fail('Timed out (10s) of /clock publication.')
             # must use time.sleep because /clock isn't yet published, so rospy.sleep hangs.
-            time.sleep(1)
+            time.sleep(0.1)
         # subscribe topics
         checkers = []
         for topic in self.topics:

--- a/tools/rostest/nodes/publishtest
+++ b/tools/rostest/nodes/publishtest
@@ -54,6 +54,7 @@ Author: Kentaro Wada <www.kentaro.wada@gmail.com>
 """
 
 import sys
+import time
 import unittest
 
 from nose.tools import assert_true
@@ -107,10 +108,14 @@ class PublishTest(unittest.TestCase):
     def test_publish(self):
         """Test topics are published and messages come"""
         use_sim_time = rospy.get_param('/use_sim_time', False)
-        while use_sim_time and (rospy.Time.now() == rospy.Time(0)):
+        t_start = time.time()
+        while not rospy.is_shutdown() and \
+                use_sim_time and (rospy.Time.now() == rospy.Time(0)):
             rospy.logwarn('/use_sim_time is specified and rostime is 0, '
                           '/clock is published?')
-            rospy.sleep(0.1)
+            if time.time() - t_start > 10:
+                self.fail('Timed out (10s) of /clock publication.')
+            time.sleep(1)
         # subscribe topics
         checkers = []
         for topic in self.topics:

--- a/tools/rostest/nodes/publishtest
+++ b/tools/rostest/nodes/publishtest
@@ -115,6 +115,7 @@ class PublishTest(unittest.TestCase):
                           '/clock is published?')
             if time.time() - t_start > 10:
                 self.fail('Timed out (10s) of /clock publication.')
+            # must use time.sleep because /clock isn't yet published, so rospy.sleep hangs.
             time.sleep(1)
         # subscribe topics
         checkers = []


### PR DESCRIPTION
- Use time.sleep because rospy.sleep(0.1) hangs if /clock is not published
- Add timeout for clock publication