### PR TITLE
Close socket when connection was not accepted

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcServer.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServer.cpp
@@ -141,6 +141,8 @@ unsigned
 XmlRpcServer::handleEvent(unsigned)
 {
   acceptConnection();
+  if (getfd() == -1)
+     return XmlRpcDispatch::Exception;
   return XmlRpcDispatch::ReadableEvent;		// Continue to monitor this fd
 }
 
@@ -154,7 +156,7 @@ XmlRpcServer::acceptConnection()
   XmlRpcUtil::log(2, "XmlRpcServer::acceptConnection: socket %d", s);
   if (s < 0)
   {
-    //this->close();
+    this->close();
     XmlRpcUtil::error("XmlRpcServer::acceptConnection: Could not accept connection (%s).", XmlRpcSocket::getErrorMsg().c_str());
   }
   else if ( ! XmlRpcSocket::setNonBlocking(s))


### PR DESCRIPTION
Retry #960, from @mgrrx.

We haven't been able to get a MWE for the problems we saw with this merged, but it came up in our crash reporter originating from unit test runs, workstations, and also robots. An example stack trace:

```
  File "../nptl/sysdeps/unix/sysv/linux/raise.c", line 56, in __GI_raise
  File "abort.c", line 89, in __GI_abort
  File "../sysdeps/posix/libc_fatal.c", line 175, in __libc_message
  File "fortify_fail.c", line 38, in __GI___fortify_fail
  File "chk_fail.c", line 28, in __GI___chk_fail
  File "fdelt_chk.c", line 25, in __fdelt_chk
  File "../../../../../ros-comm-f6da1ec87d6ed4653e65ac2dbae1325f7bc1238d/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp", line 100, in XmlRpc::XmlRpcDispatch::work
  File "../../../../../ros-comm-f6da1ec87d6ed4653e65ac2dbae1325f7bc1238d/utilities/xmlrpcpp/src/XmlRpcServer.cpp", line 133, in XmlRpc::XmlRpcServer::work
  File "../../../../../ros-comm-f6da1ec87d6ed4653e65ac2dbae1325f7bc1238d/clients/roscpp/src/libros/xmlrpc_manager.cpp", line 272, in ros::XMLRPCManager::serverThreadFunc
  File "/usr/lib/x86_64-linux-gnu/libboost_thread.so.1.54.0", in ?? ()
  File "pthread_create.c", line 312, in start_thread
  File "../sysdeps/unix/sysv/linux/x86_64/clone.S", line 111, in clone
```

It's possible that the crashes were coming up during node shutdown, but that still fails affected tests _and_ is a regression from previously.