### PR TITLE
Add more logging to publisher update calls.

### DIFF
--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -202,22 +202,18 @@ def publisher_update_task(api, topic, pub_uris):
     @param pub_uris: list of publisher APIs to send to node
     @type  pub_uris: [str]
     """
-    is_rosout_topic = 'rosout' in topic
     start_sec = time.time()
     msg = "publisherUpdate[%s] -> %s %s" % (topic, api, str(pub_uris))
-    if not is_rosout_topic:
-        mloginfo(msg)
+    mloginfo(msg)
     #TODO: check return value for errors so we can unsubscribe if stale
     try:
         ret = xmlrpcapi(api).publisherUpdate('/master', topic, pub_uris)
     except Exception as ex:
-        if not is_rosout_topic:
-            delta_sec = (time.time() - start_sec)
-            mloginfo("%s: sec=%0.2f, exception=%s", msg, delta_sec, str(ex))
-        raise
-    if not is_rosout_topic:
         delta_sec = (time.time() - start_sec)
-        mloginfo("%s: sec=%0.2f, result=%s", msg, delta_sec, ret)
+        mloginfo("%s: sec=%0.2f, exception=%s", msg, delta_sec, str(ex))
+        raise
+    delta_sec = (time.time() - start_sec)
+    mloginfo("%s: sec=%0.2f, result=%s", msg, delta_sec, ret)
 
 
 def service_update_task(api, service, uri):

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -202,10 +202,23 @@ def publisher_update_task(api, topic, pub_uris):
     @param pub_uris: list of publisher APIs to send to node
     @type  pub_uris: [str]
     """
-    
-    mloginfo("publisherUpdate[%s] -> %s", topic, api)
+    is_rosout_topic = 'rosout' in topic
+    start_sec = time.time()
+    msg = "publisherUpdate[%s] -> %s %s" % (topic, api, str(pub_uris))
+    if not is_rosout_topic:
+        mloginfo(msg)
     #TODO: check return value for errors so we can unsubscribe if stale
-    xmlrpcapi(api).publisherUpdate('/master', topic, pub_uris)
+    try:
+        ret = xmlrpcapi(api).publisherUpdate('/master', topic, pub_uris)
+    except Exception as ex:
+        if not is_rosout_topic:
+            delta_sec = (time.time() - start_sec)
+            mloginfo("%s: sec=%0.2f, exception=%s", msg, delta_sec, str(ex))
+        raise
+    if not is_rosout_topic:
+        delta_sec = (time.time() - start_sec)
+        mloginfo("%s: sec=%0.2f, result=%s", msg, delta_sec, ret)
+
 
 def service_update_task(api, service, uri):
     """

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -202,18 +202,19 @@ def publisher_update_task(api, topic, pub_uris):
     @param pub_uris: list of publisher APIs to send to node
     @type  pub_uris: [str]
     """
-    start_sec = time.time()
-    msg = "publisherUpdate[%s] -> %s %s" % (topic, api, str(pub_uris))
+    msg = "publisherUpdate[%s] -> %s %s" % (topic, api, pub_uris)
     mloginfo(msg)
-    #TODO: check return value for errors so we can unsubscribe if stale
+    start_sec = time.time()
     try:
+        #TODO: check return value for errors so we can unsubscribe if stale
         ret = xmlrpcapi(api).publisherUpdate('/master', topic, pub_uris)
+        msg_suffix = "result=%s" % ret
     except Exception as ex:
-        delta_sec = (time.time() - start_sec)
-        mloginfo("%s: sec=%0.2f, exception=%s", msg, delta_sec, str(ex))
+        msg_suffix = "exception=%s" % ex
         raise
-    delta_sec = (time.time() - start_sec)
-    mloginfo("%s: sec=%0.2f, result=%s", msg, delta_sec, ret)
+    finally:
+        delta_sec = time.time() - start_sec
+        mloginfo("%s: sec=%0.2f, %s", msg, delta_sec, msg_suffix)
 
 
 def service_update_task(api, service, uri):


### PR DESCRIPTION
Because the publisher update calls are critical for setting
up topic connections between subscribers and publishers,
have added more detailed logging messages.  The publishers
are included so you know what the subscriber was told, as
well as when the call succeeded or failed and if so why.
The rosout topic is filtered out to reduce noise.