### PR TITLE
[roslaunch] Indicating <node> tag when it is actually a <test> tag is confusing.

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -409,7 +409,7 @@ class XmlLoader(loader.Loader):
                 elif tag_name == 'env':
                     self._env_tag(t, env_context, ros_config)
                 else:
-                    ros_config.add_config_error("WARN: unrecognized '%s' tag in <node> tag. Node xml is %s"%(t.tagName, tag.toxml()))
+                    ros_config.add_config_error("WARN: unrecognized child '%s' tag in the parent tag element: %s"%(t.tagName, tag.toxml()))
 
             # #1036 evaluate all ~params in context
             # TODO: can we get rid of force_local (above), remove this for loop, and just rely on param_tag logic instead?


### PR DESCRIPTION
For example, [this warning msg](https://travis-ci.org/wg-perception/people/jobs/202019288#L3737) (in this [PR](https://github.com/wg-perception/people/pull/49)):

 ```
 * WARN: unrecognized 'group' tag in <node> tag. Node xml is <test name="$(arg testnode_name)" pkg="rostest" test-name="hztest_test" type="hztest">
    <group unless="$(arg expected_success)">
      <node args="-r 0.5 $(find face_detector)/test/face_detector_noface_test_diamondback.bag" name="play" pkg="rosbag" type="play"/>
      <param name="hz" value="0.0"/>
    </group>
```

This is confusing because the tag in question is actually `<test>`, not `<node>`. Although the warning message refers to the exact <test> tag, I didn't try to read it because I was told the issue is with `<node>`, not `<test>`.

With this PR the message becomes a bit verbose but hope the readers get better idea.