### PR TITLE
Fix ROS message migration rule tool

### DIFF
--- a/tools/rosbag/src/rosbag/migration.py
+++ b/tools/rosbag/src/rosbag/migration.py
@@ -968,7 +968,7 @@ class MessageMigrator(object):
                 found_stop = True
                 break
 
-        # Next see if we can create a valid rule
+        # Next see if we can create a valid rule, including the sub rules
         if not found_stop:
             for (ind, tmp_sn) in reversed(list(zip(range(len(sn_range)), sn_range))):
                 if (tmp_sn.new_class._type != new_class._type):
@@ -977,12 +977,13 @@ class MessageMigrator(object):
                 R = new_rule(self, 'GENERATED.' + new_rule.__name__)
                 if R.valid:
                     R.find_sub_paths()
-                    sn = ScaffoldNode(tmp_sn.new_class, new_class, R)
-                    self.extra_nodes.append(sn)
-                    sn_range = sn_range[:ind+1]
-                    sn_range.append(sn)
-                    found_stop = True
-                    break
+                    if R.sub_rules_valid:
+                        sn = ScaffoldNode(tmp_sn.new_class, new_class, R)
+                        self.extra_nodes.append(sn)
+                        sn_range = sn_range[:ind+1]
+                        sn_range.append(sn)
+                        found_stop = True
+                        break
 
         # If there were no valid implicit rules, we suggest a new one from to the end
         if not found_stop:
@@ -1018,7 +1019,7 @@ class MessageMigrator(object):
                     self.found_paths[key] = [sn]
                     return [sn]
 
-        # Next see if we can create a valid rule
+        # Next see if we can create a valid rule, including the sub rules
         if not found_start:
             for (ind, tmp_sn) in reversed(list(zip(range(len(sn_range)), sn_range))):
                 if (tmp_sn.old_class._type != old_class._type):
@@ -1027,12 +1028,13 @@ class MessageMigrator(object):
                 R = new_rule(self, 'GENERATED.' + new_rule.__name__)
                 if R.valid:
                     R.find_sub_paths()
-                    sn = ScaffoldNode(old_class, tmp_sn.old_class, R)
-                    self.extra_nodes.append(sn)
-                    sn_range = sn_range[ind:]
-                    sn_range.insert(0,sn)
-                    found_start = True
-                    break
+                    if R.sub_rules_valid:
+                        sn = ScaffoldNode(old_class, tmp_sn.old_class, R)
+                        self.extra_nodes.append(sn)
+                        sn_range = sn_range[ind:]
+                        sn_range.insert(0,sn)
+                        found_start = True
+                        break
 
         # If there were no valid implicit rules, we suggest a new one from the beginning
         if not found_start:

--- a/tools/rosbag/src/rosbag/migration.py
+++ b/tools/rosbag/src/rosbag/migration.py
@@ -1006,6 +1006,18 @@ class MessageMigrator(object):
                 found_start = True
                 break
 
+        # Next see if we can create a valid rule directly to the end, including the sub rules
+        if not found_start:
+            new_rule = self.make_update_rule(old_class, new_class)
+            R = new_rule(self, 'GENERATED.' + new_rule.__name__)
+            if R.valid:
+                R.find_sub_paths()
+                if R.sub_rules_valid:
+                    sn = ScaffoldNode(old_class, new_class, R)
+                    self.extra_nodes.append(sn)
+                    self.found_paths[key] = [sn]
+                    return [sn]
+
         # Next see if we can create a valid rule
         if not found_start:
             for (ind, tmp_sn) in reversed(list(zip(range(len(sn_range)), sn_range))):


### PR DESCRIPTION
# Description of the buggy corner case not handled on the rosbag migration tool

Consider the following scenario for a message G with the following versions:

> G0 -- rule.bmr --> G1 -- auto-generated rule --> G3

where `G3` is the **current** msg, and `G2` is the **bag** message that needs migration.

We need to check for a migration rule like this first:

> G2 --> G3

instead of the backwards ones that were generated before this bug fix:

> G2 --> G1

Note that the **lazy** check to mark the rules as valid in the `make_update_rule` (see https://github.com/clearpathrobotics/ros_comm/blob/kinetic-devel-cpr/tools/rosbag/src/rosbag/migration.py#L1123) method makes that rule pass initially, but later it fails because there's no rule for the sub fields.

This has been adapted from the commit https://github.com/clearpathrobotics/ros_comm/commit/ec8ec371fb06ea92b0a92f6fdd56d40940aab5d4 description.

# Improvement to the validation check for the rules

The other commit https://github.com/clearpathrobotics/ros_comm/commit/97fdf48274788a0a1265d515b8cc34d55014dd64 simply allows to improve the **lazy** check in `make_update_rule` and therefore allows to find a better placement/position for the message to be migrated inside of the chain rules. This helps to avoid marking rules as valid, that later would fail because there's no rule for the sub fields. The more precise check that fails later happens at the sub fields level, and there's already a comment on the code that suggest that the way this is handled should be improved (see https://github.com/clearpathrobotics/ros_comm/blob/kinetic-devel-cpr/tools/rosbag/src/rosbag/migration.py#L307).

This replaces https://github.com/clearpathrobotics/ros_comm/pull/10

I recommend installing this chrome add-on to have a better diff: https://chrome.google.com/webstore/detail/github-diff-whitespace/lhbcdehjihmbiafeodkfnbndleijnnhp

FYI @mikepurvis @dirk-thomas @afakihcpr