### PR TITLE
Make roslaunch-check respect if/unless attribute on <include>

### DIFF
--- a/tools/roslaunch/resources/example.launch
+++ b/tools/roslaunch/resources/example.launch
@@ -59,4 +59,15 @@
   <!-- more compact import syntax -->
   <include ns="included2" file="$(find roslaunch)/resources/example-include.launch" />
   
+  <!-- Pass over an include and node with if-attributes that evaluate to false. -->
+  <arg name="false_arg" value="false" />
+  <include if="$(arg false_arg)" file="does/not/exist.launch" />
+  <node if="$(arg false_arg)" pkg="doesnt_exist" type="nope" name="nope" />
+
+  <!-- Pass over a group with an unless-attribute that evaluate to true. -->
+  <arg name="true_arg" value="true" />
+  <group unless="$(arg true_arg)">
+    <include file="does/not/exist.launch" />
+    <node pkg="doesnt_exist" type="nope" name="nope" />
+  </group>
 </launch>


### PR DESCRIPTION
As discussed in #993. With the fix removed, the updated test XML fails with:

```
======================================================================
ERROR: unit.test_roslaunch_depends.test_roslaunch_deps
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/administrator/rocksteady_robot_ws/src/roslaunch/test/unit/test_roslaunch_depends.py", line 157, in test_roslaunch_deps
    base_pkg, file_deps, missing = roslaunch_deps(files, verbose=v)
  File "/home/administrator/rocksteady_robot_ws/src/roslaunch/src/roslaunch/depends.py", line 331, in roslaunch_deps
    rl_file_deps(file_deps, launch_file, verbose)
  File "/home/administrator/rocksteady_robot_ws/src/roslaunch/src/roslaunch/depends.py", line 225, in rl_file_deps
    parse_launch(launch_file, file_deps, verbose)
  File "/home/administrator/rocksteady_robot_ws/src/roslaunch/src/roslaunch/depends.py", line 210, in parse_launch
    _parse_launch(launch_tag.childNodes, launch_file, file_deps, verbose, context)
  File "/home/administrator/rocksteady_robot_ws/src/roslaunch/src/roslaunch/depends.py", line 182, in _parse_launch
    raise RoslaunchDepsException("Cannot load roslaunch include '%s' in '%s'"%(sub_launch_file, launch_file))
RoslaunchDepsException: Cannot load roslaunch include 'does/not/exist.launch' in '/home/administrator/rocksteady_robot_ws/src/roslaunch/resources/example.launch
```