### PR TITLE
Force a write of all user-space buffered data for stdout in Formatter::print

### DIFF
--- a/tools/rosconsole/src/rosconsole/rosconsole.cpp
+++ b/tools/rosconsole/src/rosconsole/rosconsole.cpp
@@ -397,9 +397,11 @@ void Formatter::print(void* logger_handle, ::ros::console::Level level, const ch
 
   fprintf(f, "%s\n", ss.str().c_str());
   
-  if (g_force_stdout_line_buffered && f == stdout) {
+  if (g_force_stdout_line_buffered && f == stdout)
+  {
     int flush_result = fflush(f);
-    if (flush_result != 0 && !g_stdout_flush_failure_reported) {
+    if (flush_result != 0 && !g_stdout_flush_failure_reported)
+    {
       g_stdout_flush_failure_reported = true;
       fprintf(stderr, "Error: failed to perform fflush on stdout, fflush return code is %d\n", flush_result);
     }
@@ -439,13 +441,14 @@ void initialize()
     std::string line_buffered;
     if (get_environment_variable(line_buffered, "ROSCONSOLE_STDOUT_LINE_BUFFERED"))
     {
-      if (line_buffered == "1") {
+      if (line_buffered == "1")
+      {
         g_force_stdout_line_buffered = true;
-      } else {
-        if (line_buffered != "0") {
-          fprintf(stderr, "Warning: unexpected value %s specified for ROSCONSOLE_STDOUT_LINE_BUFFERED. Default value 0 "
-            "will be used. Valid values are 1 or 0.\n", line_buffered.c_str());
-        }
+      }
+      else if (line_buffered != "0")
+      {
+        fprintf(stderr, "Warning: unexpected value %s specified for ROSCONSOLE_STDOUT_LINE_BUFFERED. Default value 0 "
+          "will be used. Valid values are 1 or 0.\n", line_buffered.c_str());
       }
     }
 

--- a/tools/rosconsole/src/rosconsole/rosconsole.cpp
+++ b/tools/rosconsole/src/rosconsole/rosconsole.cpp
@@ -107,6 +107,9 @@ std::string g_last_error_message = "Unknown Error";
 #endif
 const char* g_format_string = "[${severity}] [${time}]: ${message}";
 
+bool g_force_stdout_line_buffered = false;
+bool g_stdout_flush_failure_reported = false;
+
 typedef std::map<std::string, std::string> M_string;
 M_string g_extra_fixed_tokens;
 
@@ -393,6 +396,14 @@ void Formatter::print(void* logger_handle, ::ros::console::Level level, const ch
   ss << COLOR_NORMAL;
 
   fprintf(f, "%s\n", ss.str().c_str());
+  
+  if (g_force_stdout_line_buffered && f == stdout) {
+    int flush_result = fflush(f);
+    if (flush_result != 0 && !g_stdout_flush_failure_reported) {
+      g_stdout_flush_failure_reported = true;
+      fprintf(stderr, "Error: failed to perform fflush on stdout, fflush return code is %d\n", flush_result);
+    }
+  }
 }
 
 Formatter g_formatter;
@@ -424,6 +435,19 @@ void initialize()
     g_formatter.init(g_format_string);
     backend::function_notifyLoggerLevelsChanged = notifyLoggerLevelsChanged;
     backend::function_print = _print;
+
+    std::string line_buffered;
+    if (get_environment_variable(line_buffered, "ROSCONSOLE_STDOUT_LINE_BUFFERED"))
+    {
+      if (line_buffered == "1") {
+        g_force_stdout_line_buffered = true;
+      } else {
+        if (line_buffered != "0") {
+          fprintf(stderr, "Warning: unexpected value %s specified for ROSCONSOLE_STDOUT_LINE_BUFFERED. Default value 0 "
+            "will be used. Valid values are 1 or 0.\n", line_buffered.c_str());
+        }
+      }
+    }
 
     ::ros::console::impl::initialize();
     g_initialized = true;


### PR DESCRIPTION
On Android under certain conditions, when user runs binary applications using
ros_comm from within APK, he/she cannot see stdout messages if they are few
lines.

The proposal is to forcibly flush stdout with fflush in this case, as \n in the
end implicitly flushes it on most platforms.

I personally faced this problem on Android when running binaries from within APK. It was impossible to see logs and trace your programs if the logs were a few lines. Though stderr was visible, stdout was not visible. Once I applied this patch it became visible.

If you know how to do it better, please tell me, I'm ready to redo something if it's wrong.