### PR TITLE
Avoid deleting XmlRpcClient's while they are being still in use on another thread

### DIFF
--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -155,20 +155,24 @@ void XMLRPCManager::shutdown()
   server_.close();
 
   // kill the last few clients that were started in the shutdown process
-  for (V_CachedXmlRpcClient::iterator i = clients_.begin();
-       i != clients_.end(); ++i)
   {
-    for (int wait_count = 0; i->in_use_ && wait_count < 10; wait_count++)
+    boost::mutex::scoped_lock lock(clients_mutex_);
+
+    for (V_CachedXmlRpcClient::iterator i = clients_.begin();
+         i != clients_.end();)
     {
-      ROSCPP_LOG_DEBUG("waiting for xmlrpc connection to finish...");
-      ros::WallDuration(0.01).sleep();
+      if (!i->in_use_)
+      {
+        i->client_->close();
+        delete i->client_;
+        i = clients_.erase(i);
+      }
+      else
+      {
+        ++i;
+      }
     }
-
-    i->client_->close();
-    delete i->client_;
   }
-
-  clients_.clear();
 
   boost::mutex::scoped_lock lock(functions_mutex_);
   functions_.clear();
@@ -369,7 +373,17 @@ void XMLRPCManager::releaseXMLRPCClient(XmlRpcClient *c)
   {
     if (c == i->client_)
     {
-      i->in_use_ = false;
+      if (shutting_down_)
+      {
+        // if we are shutting down we won't be re-using the client
+        i->client_->close();
+        delete i->client_;
+        clients_.erase(i);
+      }
+      else
+      {
+        i->in_use_ = false;
+      }
       break;
     }
   }

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -174,6 +174,13 @@ void XMLRPCManager::shutdown()
     }
   }
 
+  // Wait for the clients that are in use to finish and remove themselves from clients_
+  for (int wait_count = 0; !clients_.empty() && wait_count < 10; wait_count++)
+  {
+    ROSCPP_LOG_DEBUG("waiting for xmlrpc connection to finish...");
+    ros::WallDuration(0.01).sleep();
+  }
+
   boost::mutex::scoped_lock lock(functions_mutex_);
   functions_.clear();
 


### PR DESCRIPTION
@dirk-thomas @mikepurvis @efernandez @jasonimercer 

# Bug description:

Deleting XmlRpcClient's in [XMLRPCManager::shutdown()](https://github.com/ros/ros_comm/blob/lunar-devel/clients/roscpp/src/libros/xmlrpc_manager.cpp#L145) could lead to crashes or to the process getting blocked if a thread tries to communicate with the master while the clients are being deleted. The issue is in the following code at [line 158](https://github.com/ros/ros_comm/blob/lunar-devel/clients/roscpp/src/libros/xmlrpc_manager.cpp#L158) of xmlrpc_manager.cpp:

```
// kill the last few clients that were started in the shutdown process
  for (V_CachedXmlRpcClient::iterator i = clients_.begin();
       i != clients_.end(); ++i)
  {
    for (int wait_count = 0; i->in_use_ && wait_count < 10; wait_count++)
    {
      ROSCPP_LOG_DEBUG("waiting for xmlrpc connection to finish...");
      ros::WallDuration(0.01).sleep();
    }

    i->client_->close();
    delete i->client_;
  }
```
 There are three potential crashes that could result from this:

1. The `clients_` vector  is not protected while deleting. A thread can attempt to get a client while the loop is running and it could get a client that has been deleted. This would cause a crash somewhere in 
[XmlRpcClient::execute](https://github.com/ros/ros_comm/blob/lunar-devel/utilities/xmlrpcpp/src/XmlRpcClient.cpp#L80) or could cause the node to be blocked at [select](https://github.com/ros/ros_comm/blob/lunar-devel/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp#L107).
2. Also, if many clients are being requested repeatedly during the time when `shutdown()` is sleeping and waiting for a client to become out of use, and being served with that same client,  the wait could timeout with the client still in use, and it would get deleted while being in use.
3. Finally, there's a chance, that getXMLRpcClient would push_back a new client into clients triggering a re-allocation and invalidating `clients` which would cause a crash in the delete loop itself.

# Code to reproduce:

```
#include "ros/ros.h"
#include <boost/thread.hpp>
#include <boost/date_time/posix_time/posix_time.hpp>
#include <boost/thread/thread.hpp>

void run()
{
  ros::NodeHandle nh("~");
  std::string s = "something";
  const int iterations = 100;
  while (true)
  {
    for (int i = 0; i < iterations; ++i)
    {
      nh.param("param", s, s);
    } 
    boost::this_thread::interruption_point();
  }
}

int main(int argc, char **argv)
{
  ros::init(argc, argv, "test_node");

  boost::thread t(run);
  boost::this_thread::sleep(boost::posix_time::milliseconds(1000));
    
  ros::shutdown();

  t.interrupt();
  t.join();

  return 0;
}
```

# Resolution

   * Acquire clients_mutex_ before deleting the clients
   * Remove the timed wait for the clients to become not in use
   * Only delete and erase clients that are not in use
   * Clients that would still be in use would delete themselves on release