### PR TITLE
expose rate-control-topic and rate-control-max-delay args to command …

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -222,6 +222,8 @@ def play_cmd(argv):
     parser.add_option("--pause-topics", dest="pause_topics", default=[],  callback=handle_pause_topics, action="callback", help="topics to pause on during playback")
     parser.add_option("--bags",  help="bags files to play back from")
     parser.add_option("--wait-for-subscribers",  dest="wait_for_subscribers", default=False, action="store_true", help="wait for at least one subscriber on each topic before publishing")
+    parser.add_option("--rate-control-topic", dest="rate_control_topic", default='', type='str', help="watch the given topic, and if the last publish was more than <rate-control-max-delay> ago, wait until the topic publishes again to continue playback")
+    parser.add_option("--rate-control-max-delay", dest="rate_control_max_delay", default=1.0, type='float', help="maximum time difference from <rate-control-topic> before pausing")
 
     (options, args) = parser.parse_args(argv)
 
@@ -268,6 +270,12 @@ def play_cmd(argv):
     # prevent bag files to be passed as --topics or --pause-topics
     if options.topics or options.pause_topics:
         cmd.extend(['--bags'])
+
+    if options.rate_control_topic:
+        cmd.extend(['--rate-control-topic', str(options.rate_control_topic)])
+
+    if options.rate_control_max_delay:
+        cmd.extend(['--rate-control-max-delay', str(options.rate_control_max_delay)])
 
     cmd.extend(args)
 


### PR DESCRIPTION
…line tool

To use #947 with command line tool.

```
jihoonl@whoola:~$ rosbag play --help
Usage: rosbag play BAGFILE1 [BAGFILE2 BAGFILE3 ...]

Play back the contents of one or more bag files in a time-synchronized
fashion.

Options:
  -h, --help            show this help message and exit
  -p PREFIX, --prefix=PREFIX
                        prefix all output topics
  -q, --quiet           suppress console output
  -i, --immediate       play back all messages without waiting
  --pause               start in paused mode
  --queue=SIZE          use an outgoing queue of size SIZE (defaults to 100)
  --clock               publish the clock time
  --hz=HZ               use a frequency of HZ when publishing clock time
                        (default: 100)
  -d SEC, --delay=SEC   sleep SEC seconds after every advertise call (to allow
                        subscribers to connect)
  -r FACTOR, --rate=FACTOR
                        multiply the publish rate by FACTOR
  -s SEC, --start=SEC   start SEC seconds into the bag files
  -u SEC, --duration=SEC
                        play only SEC seconds from the bag files
  --skip-empty=SEC      skip regions in the bag with no messages for more than
                        SEC seconds
  -l, --loop            loop playback
  -k, --keep-alive      keep alive past end of bag (useful for publishing
                        latched topics)
  --try-future-version  still try to open a bag file, even if the version
                        number is not known to the player
  --topics              topics to play back
  --pause-topics        topics to pause on during playback
  --bags=BAGS           bags files to play back from
  --wait-for-subscribers
                        wait for at least one subscriber on each topic before
                        publishing
  --rate-control-topic=RATE_CONTROL_TOPIC
                        watch the given topic, and if the last publish was
                        more than <rate-control-max-delay> ago, wait until the
                        topic publishes again to continue playback
  --rate-control-max-delay=RATE_CONTROL_MAX_DELAY
                        maximum time difference from <rate-control-topic>
                        before pausing
jihoonl@whoola:~$ 
```