### PR TITLE
fix rosbag::View::iterator copy assignment operator

### DIFF
--- a/test/test_rosbag_storage/src/create_and_iterate_bag.cpp
+++ b/test/test_rosbag_storage/src/create_and_iterate_bag.cpp
@@ -10,71 +10,71 @@
 #include "boost/foreach.hpp"
 #include <gtest/gtest.h>
 
-
-TEST(rosbag_storage, create_and_iterate_bag)
+void create_test_bag(const std::string &filename)
 {
-  const char* bag_filename = "/tmp/rosbag_storage_create_and_iterate_bag.bag";
+  rosbag::Bag bag;
+  bag.open(filename, rosbag::bagmode::Write);
+
+  std_msgs::String str;
+  str.data = std::string("foo");
+
+  std_msgs::Int32 i;
+  i.data = 42;
+
+  bag.write("chatter", ros::Time::now(), str);
+  bag.write("numbers", ros::Time::now(), i);
+
+  bag.close();
+}
+
+const char* bag_filename = "/tmp/rosbag_storage_create_and_iterate_bag.bag";
+
+TEST(rosbag_storage, iterate_bag)
+{
+  rosbag::Bag bag;
+  bag.open(bag_filename, rosbag::bagmode::Read);
+
+  std::vector<std::string> topics;
+  topics.push_back(std::string("chatter"));
+  topics.push_back(std::string("numbers"));
+
+  rosbag::View view(bag, rosbag::TopicQuery(topics));
+
+  BOOST_FOREACH(rosbag::MessageInstance const m, view)
   {
-    rosbag::Bag bag;
-    bag.open(bag_filename, rosbag::bagmode::Write);
-
-    std_msgs::String str;
-    str.data = std::string("foo");
-  
-    std_msgs::Int32 i;
-    i.data = 42;
-  
-    bag.write("chatter", ros::Time::now(), str);
-    bag.write("numbers", ros::Time::now(), i);
-
-    bag.close();
-  }
-
-  {
-    rosbag::Bag bag;
-    bag.open(bag_filename, rosbag::bagmode::Read);
-
-    std::vector<std::string> topics;
-    topics.push_back(std::string("chatter"));
-    topics.push_back(std::string("numbers"));
-
-    rosbag::View view(bag, rosbag::TopicQuery(topics));
-
-    BOOST_FOREACH(rosbag::MessageInstance const m, view)
+    std_msgs::String::ConstPtr s = m.instantiate<std_msgs::String>();
+    if (s != NULL)
     {
-      std_msgs::String::ConstPtr s = m.instantiate<std_msgs::String>();
-      if (s != NULL)
-      {
-        if(s->data == std::string("foo")) { 
-          printf("Successfully checked string foo\n");
-        }
-        else
-        {
-          printf("Failed checked string foo\n");
-          FAIL();
-        }
+      if(s->data == std::string("foo")) {
+        printf("Successfully checked string foo\n");
       }
-
-      std_msgs::Int32::ConstPtr i = m.instantiate<std_msgs::Int32>();
-      if (i != NULL)
+      else
       {
-        if (i->data == 42) { 
-          printf("Successfully checked value 42\n");
-        }
-        else
-        {
-          printf("Failed checked value 42.\n"); 
-          FAIL();
-        }
+        printf("Failed checked string foo\n");
+        FAIL();
       }
     }
 
-    bag.close();
+    std_msgs::Int32::ConstPtr i = m.instantiate<std_msgs::Int32>();
+    if (i != NULL)
+    {
+      if (i->data == 42) {
+        printf("Successfully checked value 42\n");
+      }
+      else
+      {
+        printf("Failed checked value 42.\n");
+        FAIL();
+      }
+    }
   }
+
+  bag.close();
 }
 
 int main(int argc, char **argv) {
     ros::Time::init();
+    create_test_bag(bag_filename);
 
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/test_rosbag_storage/src/create_and_iterate_bag.cpp
+++ b/test/test_rosbag_storage/src/create_and_iterate_bag.cpp
@@ -29,6 +29,39 @@ void create_test_bag(const std::string &filename)
 
 const char* bag_filename = "/tmp/rosbag_storage_create_and_iterate_bag.bag";
 
+TEST(rosbag_storage, iterator_copy_constructor)
+{
+  // copy ctor
+  rosbag::Bag bag;
+  bag.open(bag_filename, rosbag::bagmode::Read);
+  rosbag::View view(bag, rosbag::TopicQuery("numbers"));
+  rosbag::View::const_iterator it0 = view.begin();
+  EXPECT_EQ(42, it0->instantiate<std_msgs::Int32>()->data);
+  rosbag::View::const_iterator it1(it0);
+  EXPECT_EQ(it0, it1);
+  EXPECT_EQ(42, it1->instantiate<std_msgs::Int32>()->data);
+  ++it1;
+  EXPECT_NE(it0, it1);
+  EXPECT_EQ(42, it0->instantiate<std_msgs::Int32>()->data);
+}
+
+TEST(rosbag_storage, iterator_copy_assignment)
+{
+  // copy assignment
+  rosbag::Bag bag;
+  bag.open(bag_filename, rosbag::bagmode::Read);
+  rosbag::View view(bag, rosbag::TopicQuery("numbers"));
+  rosbag::View::const_iterator it0 = view.begin();
+  EXPECT_EQ(42, it0->instantiate<std_msgs::Int32>()->data);
+  rosbag::View::const_iterator it1;
+  it1 = it0;
+  EXPECT_EQ(it0, it1);
+  EXPECT_EQ(42, it1->instantiate<std_msgs::Int32>()->data);
+  ++it1;
+  EXPECT_NE(it0, it1);
+  EXPECT_EQ(42, it0->instantiate<std_msgs::Int32>()->data);
+}
+
 TEST(rosbag_storage, iterate_bag)
 {
   rosbag::Bag bag;

--- a/tools/rosbag_storage/include/rosbag/view.h
+++ b/tools/rosbag_storage/include/rosbag/view.h
@@ -63,6 +63,7 @@ public:
     {
     public:
         iterator(iterator const& i);
+        iterator &operator=(iterator const& i);
         iterator();
         ~iterator();
 

--- a/tools/rosbag_storage/src/view.cpp
+++ b/tools/rosbag_storage/src/view.cpp
@@ -59,6 +59,19 @@ View::iterator::iterator(View* view, bool end) : view_(view), view_revision_(0),
 
 View::iterator::iterator(const iterator& i) : view_(i.view_), iters_(i.iters_), view_revision_(i.view_revision_), message_instance_(NULL) { }
 
+View::iterator &View::iterator::operator=(iterator const& i) {
+    if (this != &i) {
+        view_ = i.view_;
+        iters_ = i.iters_;
+        view_revision_ = i.view_revision_;
+        if (message_instance_ != NULL) {
+            delete message_instance_;
+            message_instance_ = NULL;
+        }
+    }
+    return *this;
+}
+
 void View::iterator::populate() {
     assert(view_ != NULL);
 


### PR DESCRIPTION
the compiler-generated copy assignment operator did lead to segfault and
memory leaks.


Side notes:
* could this fix be backported to indigo?
* a boost::scoped_ptr would have avoided this bug.