### PR TITLE
Add subscriber to connection log messages.

### DIFF
--- a/clients/roscpp/src/libros/connection_manager.cpp
+++ b/clients/roscpp/src/libros/connection_manager.cpp
@@ -209,7 +209,7 @@ bool ConnectionManager::onConnectionHeaderReceived(const ConnectionPtr& conn, co
   std::string val;
   if (header.getValue("topic", val))
   {
-    ROSCPP_LOG_DEBUG("Connection: Creating TransportSubscriberLink for topic [%s] connected to [%s]", 
+    ROSCPP_CONN_LOG_DEBUG("Connection: Creating TransportSubscriberLink for topic [%s] connected to [%s]", 
 		     val.c_str(), conn->getRemoteString().c_str());
 
     TransportSubscriberLinkPtr sub_link(boost::make_shared<TransportSubscriberLink>());


### PR DESCRIPTION
When roscpp_internal.connection is set to DEBUG for a node, we get  a log message when connection to a Publisher is made, bu tnot when a Subscriber connects.  This change fixes that.