### PR TITLE
patch to support non-ascii string for #834

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -56,14 +56,10 @@ try:
 except ImportError:
     import urlparse
 
-try:
-    import xmlrpc.client as xmlrpcclient #Python 3.x
-except ImportError:
-    import xmlrpclib as xmlrpcclient #Python 2.x
-
 import rospkg
 
 import rosgraph.roslogging
+import rosgraph.xmlrpc
 
 import rospy.exceptions
 import rospy.rostime
@@ -534,12 +530,12 @@ def is_topic(param_name):
 def xmlrpcapi(uri):
     """
     @return: instance for calling remote server or None if not a valid URI
-    @rtype: xmlrpclib.ServerProxy
+    @rtype: rosgraph.xmlrpc.ServerProxy
     """
     if uri is None:
         return None
     uriValidate = urlparse.urlparse(uri)
     if not uriValidate[0] or not uriValidate[1]:
         return None
-    return xmlrpcclient.ServerProxy(uri)
+    return rosgraph.xmlrpc.ServerProxy(uri)
 

--- a/clients/rospy/src/rospy/impl/tcpros_pubsub.py
+++ b/clients/rospy/src/rospy/impl/tcpros_pubsub.py
@@ -38,11 +38,7 @@ import socket
 import threading
 import time
 
-try:
-    from xmlrpc.client import ServerProxy  # Python 3.x
-except ImportError:
-    from xmlrpclib import ServerProxy  # Python 2.x
-
+from rosgraph.xmlrpc import ServerProxy
 from rospy.core import logwarn, logerr, logdebug, rospyerr
 import rospy.exceptions
 import rospy.names

--- a/test/test_roslaunch/test/params_basic.py
+++ b/test/test_roslaunch/test/params_basic.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# coding:utf-8
 # Software License Agreement (BSD License)
 #
 # Copyright (c) 2008, Willow Garage, Inc.
@@ -58,7 +59,14 @@ class TestParamsBasic(unittest.TestCase):
         self.assertEquals(get_param('stringbar'), 'bar')
         self.assertEquals(get_param('str10'), '10')
         self.assertEquals(get_param('string10'), '10')        
-        self.assertEquals(get_param('stringentity'), '<stringentity/>')        
+        self.assertEquals(get_param('stringentity'), '<stringentity/>')
+        try:
+            # python 2.X
+            self.assertEquals(get_param('stringnotascii'),
+                              unicode('\xef\xbd\x86\xef\xbd\x8f\xef\xbd\x8f'.decode('unicode-escape')))
+        except:
+            self.assertEquals(get_param('stringnotascii'),
+                              'ｆｏｏ')
         ## Test roslaunch integer params
         self.assertEquals(get_param("integerneg1"), -1)
         self.assertEquals(get_param("integer0"), 0)

--- a/test/test_roslaunch/test/params_basic.test
+++ b/test/test_roslaunch/test/params_basic.test
@@ -1,10 +1,11 @@
 <launch>
   <!-- string parameters -->
-  <param name="stringempty"  value="" />
-  <param name="stringbar"    value="bar" />
-  <param name="str10"        value="10" type="str" />
-  <param name="string10"     value="10" type="string" />  <!-- type alias -->
-  <param name="stringentity" value="&lt;stringentity/&gt;" />  
+  <param name="stringempty"    value="" />
+  <param name="stringbar"      value="bar" />
+  <param name="str10"          value="10" type="str" />
+  <param name="string10"       value="10" type="string" />  <!-- type alias -->
+  <param name="stringentity"   value="&lt;stringentity/&gt;" />
+  <param name="stringnotascii" value="ｆｏｏ" />
   
   <!-- integer parameters -->
   <param name="integer0"     value="0" />

--- a/test/test_rosmaster/test/client_verification/test_slave_api.py
+++ b/test/test_rosmaster/test/client_verification/test_slave_api.py
@@ -47,7 +47,7 @@ except ImportError:
 
 import rosunit
 import rosgraph
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 
 TCPROS = 'TCPROS'
 
@@ -127,7 +127,7 @@ class TestSlaveApi(unittest.TestCase):
             self.fail("master did not return XML-RPC API for [%s, %s]"%(self.caller_id, self.test_node))
         print "[%s] API  = %s"%(self.test_node, self.node_api)
         self.assert_(self.node_api.startswith('http'))
-        self.node = rosgraph.xmlrpc.ServerProxy(self.node_api)
+        self.node = ServerProxy(self.node_api)
 
         # hack: sleep for a couple seconds just in case the node is
         # still registering with the master.

--- a/test/test_rosmaster/test/client_verification/test_slave_api.py
+++ b/test/test_rosmaster/test/client_verification/test_slave_api.py
@@ -41,12 +41,13 @@ import string
 import time
 import unittest
 try:
-    from xmlrpc.client import Fault, ServerProxy
+    from xmlrpc.client import Fault
 except ImportError:
-    from xmlrpclib import Fault, ServerProxy
+    from xmlrpclib import Fault
 
 import rosunit
 import rosgraph
+import rosgraph.xmlrpc
 
 TCPROS = 'TCPROS'
 
@@ -126,7 +127,7 @@ class TestSlaveApi(unittest.TestCase):
             self.fail("master did not return XML-RPC API for [%s, %s]"%(self.caller_id, self.test_node))
         print "[%s] API  = %s"%(self.test_node, self.node_api)
         self.assert_(self.node_api.startswith('http'))
-        self.node = ServerProxy(self.node_api)
+        self.node = rosgraph.xmlrpc.ServerProxy(self.node_api)
 
         # hack: sleep for a couple seconds just in case the node is
         # still registering with the master.

--- a/test/test_rosmaster/test/master.py
+++ b/test/test_rosmaster/test/master.py
@@ -39,7 +39,7 @@ import time
 
 import rospy
 import rosgraph
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 
 from rosclient import *
 
@@ -72,7 +72,7 @@ class _MasterTestCase(TestRosClient):
         super(_MasterTestCase, self).setUp()
         self.master_uri = os.environ.get(rosgraph.ROS_MASTER_URI, None)
         self._checkUri(self.master_uri)
-        self.master = rosgraph.xmlrpc.ServerProxy(self.master_uri)
+        self.master = ServerProxy(self.master_uri)
 
     ## validates a URI as being http(s)
     def _checkUri(self, uri):

--- a/test/test_rosmaster/test/master.py
+++ b/test/test_rosmaster/test/master.py
@@ -36,13 +36,10 @@ import os
 import sys
 import string
 import time
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rospy
 import rosgraph
+import rosgraph.xmlrpc
 
 from rosclient import *
 
@@ -75,7 +72,7 @@ class _MasterTestCase(TestRosClient):
         super(_MasterTestCase, self).setUp()
         self.master_uri = os.environ.get(rosgraph.ROS_MASTER_URI, None)
         self._checkUri(self.master_uri)
-        self.master = ServerProxy(self.master_uri)
+        self.master = rosgraph.xmlrpc.ServerProxy(self.master_uri)
 
     ## validates a URI as being http(s)
     def _checkUri(self, uri):

--- a/test/test_rosmaster/test/node.py
+++ b/test/test_rosmaster/test/node.py
@@ -39,7 +39,7 @@ import time
 
 import rospy
 import rosgraph
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 
 from rosclient import *
 
@@ -111,7 +111,7 @@ class _NodeTestCase(TestRosClient):
             self.fail("master did not return XML-RPC API for [%s, %s]"%(self.caller_id, self.test_node))
         print("[%s] API  = %s" %(self.test_node, self.node_api))
         self.assert_(self.node_api.startswith('http'))
-        self.node = rosgraph.xmlrpc.ServerProxy(self.node_api)
+        self.node = ServerProxy(self.node_api)
 
     ## validates a URI as being http(s)
     def _checkUri(self, uri):

--- a/test/test_rosmaster/test/node.py
+++ b/test/test_rosmaster/test/node.py
@@ -36,13 +36,10 @@ import os
 import sys
 import string
 import time
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rospy
 import rosgraph
+import rosgraph.xmlrpc
 
 from rosclient import *
 
@@ -114,7 +111,7 @@ class _NodeTestCase(TestRosClient):
             self.fail("master did not return XML-RPC API for [%s, %s]"%(self.caller_id, self.test_node))
         print("[%s] API  = %s" %(self.test_node, self.node_api))
         self.assert_(self.node_api.startswith('http'))
-        self.node = ServerProxy(self.node_api)
+        self.node = rosgraph.xmlrpc.ServerProxy(self.node_api)
 
     ## validates a URI as being http(s)
     def _checkUri(self, uri):

--- a/test/test_rosmaster/test/rosclient.py
+++ b/test/test_rosmaster/test/rosclient.py
@@ -34,12 +34,9 @@
 # Revision $Id: test_embed_msg.py 1986 2008-08-26 23:57:56Z sfkwc $
 
 import unittest
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rosgraph
+import rosgraph.xmlrpc
 
 class TestRosClient(unittest.TestCase):
 
@@ -47,7 +44,7 @@ class TestRosClient(unittest.TestCase):
         self.last_code = None
         self.last_msg = None
         self.last_val = None
-        self.master = ServerProxy(rosgraph.get_master_uri())
+        self.master = rosgraph.xmlrpc.ServerProxy(rosgraph.get_master_uri())
     
     def tearDown(self):
         self.master = None

--- a/test/test_rosmaster/test/rosclient.py
+++ b/test/test_rosmaster/test/rosclient.py
@@ -36,7 +36,8 @@
 import unittest
 
 import rosgraph
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
+
 
 class TestRosClient(unittest.TestCase):
 
@@ -44,7 +45,7 @@ class TestRosClient(unittest.TestCase):
         self.last_code = None
         self.last_msg = None
         self.last_val = None
-        self.master = rosgraph.xmlrpc.ServerProxy(rosgraph.get_master_uri())
+        self.master = ServerProxy(rosgraph.get_master_uri())
     
     def tearDown(self):
         self.master = None

--- a/test/test_rosmaster/test/testMaster.py
+++ b/test/test_rosmaster/test/testMaster.py
@@ -45,7 +45,7 @@ except ImportError:
     from xmlrpclib import DateTime
 import unittest
 import rospy
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 from rostest import *
 from testSlave import msMain
 
@@ -76,7 +76,7 @@ def verifyNodeAddress(master, callerId, name, machine, addr, port):
         raddrinfo = socket.getaddrinfo(raddr, 0, 0, 0, socket.SOL_TCP)
         assert raddrinfo == addrinfo, "%s!=%s" % (raddrinfo, addrinfo)
     #ping the node
-    apiSuccess(rosgraph.xmlrpc.ServerProxy("http://%s:%s/"%(raddr, rport)).getPid(''))
+    apiSuccess(ServerProxy("http://%s:%s/"%(raddr, rport)).getPid(''))
 
 def testGraphState(master, graphNodes, graphFlows):
     graph = apiSuccess(master.getGraph(''))
@@ -573,7 +573,7 @@ class MasterTestCase(ROSGraphTestCase):
     def _verifyNodeDead(self, port):
         testUri = "http://localhost:%s/"%port
         try:
-            rosgraph.xmlrpc.ServerProxy(testUri).getPid('node')
+            ServerProxy(testUri).getPid('node')
             self.fail("test node is still running")
         except:
             pass

--- a/test/test_rosmaster/test/testMaster.py
+++ b/test/test_rosmaster/test/testMaster.py
@@ -40,11 +40,12 @@ To run, invoke nodes/testMaster
 import os, sys, getopt, traceback, logging, socket
 import datetime, math, random
 try:
-    from xmlrpc.client import DateTime, ServerProxy
+    from xmlrpc.client import DateTime
 except ImportError:
-    from xmlrpclib import DateTime, ServerProxy
+    from xmlrpclib import DateTime
 import unittest
 import rospy
+import rosgraph.xmlrpc
 from rostest import *
 from testSlave import msMain
 
@@ -75,7 +76,7 @@ def verifyNodeAddress(master, callerId, name, machine, addr, port):
         raddrinfo = socket.getaddrinfo(raddr, 0, 0, 0, socket.SOL_TCP)
         assert raddrinfo == addrinfo, "%s!=%s" % (raddrinfo, addrinfo)
     #ping the node
-    apiSuccess(ServerProxy("http://%s:%s/"%(raddr, rport)).getPid(''))
+    apiSuccess(rosgraph.xmlrpc.ServerProxy("http://%s:%s/"%(raddr, rport)).getPid(''))
 
 def testGraphState(master, graphNodes, graphFlows):
     graph = apiSuccess(master.getGraph(''))
@@ -572,7 +573,7 @@ class MasterTestCase(ROSGraphTestCase):
     def _verifyNodeDead(self, port):
         testUri = "http://localhost:%s/"%port
         try:
-            ServerProxy(testUri).getPid('node')
+            rosgraph.xmlrpc.ServerProxy(testUri).getPid('node')
             self.fail("test node is still running")
         except:
             pass

--- a/test/test_rosmaster/test/testSlave.py
+++ b/test/test_rosmaster/test/testSlave.py
@@ -35,12 +35,9 @@
 import os
 import sys
 import string
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rospy
+import rosgraph.xmlrpc
 from rostest import *
 
 singletest = None
@@ -73,7 +70,7 @@ class SlaveTestCase(TestRosClient):
         self.caller_id = rospy.get_caller_id()
         self.node_api = self.apiSuccess(self.master.lookupNode(self.caller_id, 'test_node'))
         self.assert_(self.node_api.startswith('http'))
-        self.node = ServerProxy(self.node_api)
+        self.node = rosgraph.xmlrpc.ServerProxy(self.node_api)
         
     def testGetPid(self):
         pid = self.apiSuccess(self.node.getPid(self.caller_id))
@@ -107,7 +104,7 @@ class SlaveTestCase(TestRosClient):
             port = apiSuccess(master.addNode('', '', sourceName, pkg, node, TEST_MACHINE, 0))
             apiSuccess(master.addNode('', '', sinkName, pkg, node, TEST_MACHINE, 0))
             sourceUri = 'http://%s:%s/'%(testNodeAddr[0], port)
-            sources[sourceName] = ServerProxy(sourceUri)
+            sources[sourceName] = rosgraph.xmlrpc.ServerProxy(sourceUri)
 
         for test in tests:
             sourceName, sinkName = [val%testName for val in test[0]]
@@ -186,7 +183,7 @@ class SlaveTestCase(TestRosClient):
             port = apiSuccess(master.addNode('', '', sourceName, pkg, node, TEST_MACHINE, 0))
             apiSuccess(master.addNode('', '', sinkName, pkg, node, TEST_MACHINE, 0))
             sourceUri = 'http://%s:%s/'%(testNodeAddr[0], port)
-            sources[sourceName] = ServerProxy(sourceUri)
+            sources[sourceName] = rosgraph.xmlrpc.ServerProxy(sourceUri)
             # - start the flow
             callerId, sourceLocator, sinkLocator = test[1]
             apiSuccess(master.connectFlow(callerId, sourceLocator, sinkLocator, 1))
@@ -257,7 +254,7 @@ class SlaveTestCase(TestRosClient):
             sourceUri = 'http://%s:%s/'%(testNodeAddr[0], sourcePort)
             sinkUri = 'http://%s:%s/'%(testNodeAddr[0], sinkPort)
             sourceUris[sourceName] = sourceUri
-            sinks[sinkName] = ServerProxy(sinkUri)
+            sinks[sinkName] = rosgraph.xmlrpc.ServerProxy(sinkUri)
         return sourceUris, sinks
 
     def _sink_StartFlows(self, tests, sourceUris, sinks):

--- a/test/test_rosmaster/test/testSlave.py
+++ b/test/test_rosmaster/test/testSlave.py
@@ -37,7 +37,7 @@ import sys
 import string
 
 import rospy
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 from rostest import *
 
 singletest = None
@@ -70,7 +70,7 @@ class SlaveTestCase(TestRosClient):
         self.caller_id = rospy.get_caller_id()
         self.node_api = self.apiSuccess(self.master.lookupNode(self.caller_id, 'test_node'))
         self.assert_(self.node_api.startswith('http'))
-        self.node = rosgraph.xmlrpc.ServerProxy(self.node_api)
+        self.node = ServerProxy(self.node_api)
         
     def testGetPid(self):
         pid = self.apiSuccess(self.node.getPid(self.caller_id))
@@ -104,7 +104,7 @@ class SlaveTestCase(TestRosClient):
             port = apiSuccess(master.addNode('', '', sourceName, pkg, node, TEST_MACHINE, 0))
             apiSuccess(master.addNode('', '', sinkName, pkg, node, TEST_MACHINE, 0))
             sourceUri = 'http://%s:%s/'%(testNodeAddr[0], port)
-            sources[sourceName] = rosgraph.xmlrpc.ServerProxy(sourceUri)
+            sources[sourceName] = ServerProxy(sourceUri)
 
         for test in tests:
             sourceName, sinkName = [val%testName for val in test[0]]
@@ -183,7 +183,7 @@ class SlaveTestCase(TestRosClient):
             port = apiSuccess(master.addNode('', '', sourceName, pkg, node, TEST_MACHINE, 0))
             apiSuccess(master.addNode('', '', sinkName, pkg, node, TEST_MACHINE, 0))
             sourceUri = 'http://%s:%s/'%(testNodeAddr[0], port)
-            sources[sourceName] = rosgraph.xmlrpc.ServerProxy(sourceUri)
+            sources[sourceName] = ServerProxy(sourceUri)
             # - start the flow
             callerId, sourceLocator, sinkLocator = test[1]
             apiSuccess(master.connectFlow(callerId, sourceLocator, sinkLocator, 1))
@@ -254,7 +254,7 @@ class SlaveTestCase(TestRosClient):
             sourceUri = 'http://%s:%s/'%(testNodeAddr[0], sourcePort)
             sinkUri = 'http://%s:%s/'%(testNodeAddr[0], sinkPort)
             sourceUris[sourceName] = sourceUri
-            sinks[sinkName] = rosgraph.xmlrpc.ServerProxy(sinkUri)
+            sinks[sinkName] = ServerProxy(sinkUri)
         return sourceUris, sinks
 
     def _sink_StartFlows(self, tests, sourceUris, sinks):

--- a/test/test_rospy/test/rostest/test_deregister.py
+++ b/test/test_rospy/test/rostest/test_deregister.py
@@ -46,6 +46,7 @@ import weakref
 
 import rospy
 import rostest
+import rosgraph.xmlrpc
 from std_msgs.msg import String
 from test_rospy.srv import EmptySrv
 
@@ -61,15 +62,11 @@ def callback(data):
     print("message received", data.data)
     _last_callback = data
 
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 class TestDeregister(unittest.TestCase):
         
     def test_unpublish(self):
-        node_proxy = ServerProxy(rospy.get_node_uri())
+        node_proxy = rosgraph.xmlrpc.ServerProxy(rospy.get_node_uri())
         
         _, _, pubs = node_proxy.getPublications('/foo')
         pubs = [p for p in pubs if p[0] != '/rosout']
@@ -112,7 +109,7 @@ class TestDeregister(unittest.TestCase):
         global _last_callback
 
         uri = rospy.get_node_uri()
-        node_proxy = ServerProxy(uri)
+        node_proxy = rosgraph.xmlrpc.ServerProxy(uri)
         _, _, subscriptions = node_proxy.getSubscriptions('/foo')
         self.assert_(not subscriptions, 'subscriptions present: %s'%str(subscriptions))
         

--- a/test/test_rospy/test/rostest/test_deregister.py
+++ b/test/test_rospy/test/rostest/test_deregister.py
@@ -46,7 +46,7 @@ import weakref
 
 import rospy
 import rostest
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 from std_msgs.msg import String
 from test_rospy.srv import EmptySrv
 
@@ -66,7 +66,7 @@ def callback(data):
 class TestDeregister(unittest.TestCase):
         
     def test_unpublish(self):
-        node_proxy = rosgraph.xmlrpc.ServerProxy(rospy.get_node_uri())
+        node_proxy = ServerProxy(rospy.get_node_uri())
         
         _, _, pubs = node_proxy.getPublications('/foo')
         pubs = [p for p in pubs if p[0] != '/rosout']
@@ -109,7 +109,7 @@ class TestDeregister(unittest.TestCase):
         global _last_callback
 
         uri = rospy.get_node_uri()
-        node_proxy = rosgraph.xmlrpc.ServerProxy(uri)
+        node_proxy = ServerProxy(uri)
         _, _, subscriptions = node_proxy.getSubscriptions('/foo')
         self.assert_(not subscriptions, 'subscriptions present: %s'%str(subscriptions))
         

--- a/test/test_rospy/test/rostest/test_sub_to_multiple_pubs.py
+++ b/test/test_rospy/test/rostest/test_sub_to_multiple_pubs.py
@@ -43,12 +43,9 @@ import socket
 import sys
 import time
 import unittest
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rosgraph
+import rosgraph.xmlrpc
 import rospy
 import rostest
 
@@ -84,7 +81,7 @@ class TestPubSubToMultiplePubs(unittest.TestCase):
             self.assert_(False, 'cannot contact [%s]: unknown node' % LISTENER_NODE)
 
         socket.setdefaulttimeout(5.0)
-        node = ServerProxy(node_api)
+        node = rosgraph.xmlrpc.ServerProxy(node_api)
         code, _, businfo = node.getBusInfo(NAME)
         if code != 1:
             self.assert_(False, 'cannot get node information')

--- a/test/test_rospy/test/rostest/test_sub_to_multiple_pubs.py
+++ b/test/test_rospy/test/rostest/test_sub_to_multiple_pubs.py
@@ -45,7 +45,7 @@ import time
 import unittest
 
 import rosgraph
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 import rospy
 import rostest
 
@@ -81,7 +81,7 @@ class TestPubSubToMultiplePubs(unittest.TestCase):
             self.assert_(False, 'cannot contact [%s]: unknown node' % LISTENER_NODE)
 
         socket.setdefaulttimeout(5.0)
-        node = rosgraph.xmlrpc.ServerProxy(node_api)
+        node = ServerProxy(node_api)
         code, _, businfo = node.getBusInfo(NAME)
         if code != 1:
             self.assert_(False, 'cannot get node information')

--- a/test/test_rospy/test/unit/test_rospy_core.py
+++ b/test/test_rospy/test/unit/test_rospy_core.py
@@ -219,10 +219,7 @@ class TestRospyCore(unittest.TestCase):
         self.assert_(rospy.core.xmlrpcapi('http://') is None)
         api = rospy.core.xmlrpcapi('http://localhost:1234')
         self.assert_(api is not None)
-        try:
-            from xmlrpc.client import ServerProxy
-        except ImportError:
-            from xmlrpclib import ServerProxy
+        from rosgraph.xmlrpc import ServerProxy
         self.assert_(isinstance(api, ServerProxy))
     
 called = None

--- a/tools/rosgraph/package.xml
+++ b/tools/rosgraph/package.xml
@@ -16,6 +16,7 @@
 
   <run_depend>python-netifaces</run_depend>
   <run_depend>python-rospkg</run_depend>
+  <run_depend>python-requests</run_depend>
 
   <test_depend>python-mock</test_depend>
 

--- a/tools/rosgraph/package.xml
+++ b/tools/rosgraph/package.xml
@@ -15,8 +15,8 @@
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 
   <run_depend>python-netifaces</run_depend>
-  <run_depend>python-rospkg</run_depend>
   <run_depend>python-requests</run_depend>
+  <run_depend>python-rospkg</run_depend>
 
   <test_depend>python-mock</test_depend>
 

--- a/tools/rosgraph/src/rosgraph/impl/graph.py
+++ b/tools/rosgraph/src/rosgraph/impl/graph.py
@@ -47,7 +47,7 @@ import traceback
 import socket
 
 import rosgraph.masterapi
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 
 logger = logging.getLogger('rosgraph.graph')
 
@@ -452,7 +452,7 @@ class Graph(object):
         uri = self._node_uri_refresh(node)
         try:
             if uri:
-                api = rosgraph.xmlrpc.ServerProxy(uri)
+                api = ServerProxy(uri)
                 updated = self._node_refresh_businfo(node, api, bad_node)
         except KeyError as e:
             logger.warn('cannot contact node [%s] as it is not in the lookup table'%node)

--- a/tools/rosgraph/src/rosgraph/impl/graph.py
+++ b/tools/rosgraph/src/rosgraph/impl/graph.py
@@ -44,13 +44,10 @@ import itertools
 import random
 import logging
 import traceback
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 import socket
 
 import rosgraph.masterapi
+import rosgraph.xmlrpc
 
 logger = logging.getLogger('rosgraph.graph')
 
@@ -371,7 +368,7 @@ class Graph(object):
         @param node: node name
         @type  node: str
         @param api: XML-RPC proxy
-        @type  api: ServerProxy
+        @type  api: rosgraph.xmlrpc.ServerProxy
         @param bad_node: If True, node has connectivity issues and
         should be treated differently
         @type  bad_node: bool
@@ -455,7 +452,7 @@ class Graph(object):
         uri = self._node_uri_refresh(node)
         try:
             if uri:
-                api = ServerProxy(uri)
+                api = rosgraph.xmlrpc.ServerProxy(uri)
                 updated = self._node_refresh_businfo(node, api, bad_node)
         except KeyError as e:
             logger.warn('cannot contact node [%s] as it is not in the lookup table'%node)

--- a/tools/rosgraph/src/rosgraph/masterapi.py
+++ b/tools/rosgraph/src/rosgraph/masterapi.py
@@ -37,14 +37,10 @@ Master directly using XML-RPC, this API provides a safer abstraction in the even
 the Master API is changed.
 """
 
-try:
-    from xmlrpc.client import ServerProxy  # Python 3.x
-except ImportError:
-    from xmlrpclib import ServerProxy  # Python 2.x
-
 from . names import make_caller_id
 from . rosenv import get_master_uri
 from . network import parse_http_host_and_port
+from . xmlrpc import ServerProxy
 
 class MasterException(Exception):
     """

--- a/tools/rosgraph/src/rosgraph/transport.py
+++ b/tools/rosgraph/src/rosgraph/transport.py
@@ -25,8 +25,10 @@ class RequestsTransport(xmlrpc.Transport):
         url = '{scheme}://{host}{handler}'.format(scheme=self._scheme,
                                                   host=host,
                                                   handler=handler)
+        if isinstance(request_body, unicode):
+            request_body = request_body.encode('utf-8')
         try:
-            resp = requests.post(url, data=request_body.encode('utf-8'),
+            resp = requests.post(url, data=request_body,
                                  headers=headers)
         except requests.exceptions.Timeout:
             raise socket.timeout('timed out')

--- a/tools/rosgraph/src/rosgraph/transport.py
+++ b/tools/rosgraph/src/rosgraph/transport.py
@@ -23,19 +23,16 @@ class RequestsTransport(xmlrpc.Transport):
         """Make a xmlrpc request."""
         headers = {'User-Agent': self.user_agent, 'Content-Type': 'text/xml'}
         url = '{scheme}://{host}{handler}'.format(scheme=self._scheme,
-                                                   host=host,
-                                                   handler=handler)
+                                                  host=host,
+                                                  handler=handler)
         try:
             resp = requests.post(url, data=request_body.encode('utf-8'),
                                  headers=headers)
         except requests.exceptions.Timeout:
             raise socket.timeout('timed out')
         except requests.RequestException as exc:
-            if isinstance(exc.args[0], urllib3.exceptions.HTTPError):
-                # Rethrow urllib3 exception.reason. That are e.g. socket.error
-                # Or other exceptions that the default xmlrpclib implementation
-                # would throw.
-                raise exc.args[0].reason
+            if isinstance(exc.args[0], urllib3.exceptions.MaxRetryError):
+                raise socket.timeout('timed out')
             else:
                 # otherwise, rethrow the exc
                 # We could add more exception mappings here:

--- a/tools/rosgraph/src/rosgraph/transport.py
+++ b/tools/rosgraph/src/rosgraph/transport.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """A replacement transport for Python xmlrpc library."""
 
 try:
@@ -27,7 +26,8 @@ class RequestsTransport(xmlrpc.Transport):
                                                    host=host,
                                                    handler=handler)
         try:
-            resp = requests.post(url, data=request_body, headers=headers)
+            resp = requests.post(url, data=request_body.encode('utf-8'),
+                                 headers=headers)
         except requests.exceptions.Timeout:
             raise socket.timeout('timed out')
         except requests.RequestException as exc:

--- a/tools/rosgraph/src/rosgraph/transport.py
+++ b/tools/rosgraph/src/rosgraph/transport.py
@@ -42,8 +42,6 @@ class RequestsTransport(xmlrpc.Transport):
                 #  - requests.exceptions.InvalidURL    -> socket.gaierror?
                 #  - requests.exceptions.InvalidSchema -> socket.gaierror?
                 raise exc
-        except (ValueError, Exception):
-            raise
         else:
             try:
                 resp.raise_for_status()

--- a/tools/rosgraph/src/rosgraph/transport.py
+++ b/tools/rosgraph/src/rosgraph/transport.py
@@ -26,6 +26,8 @@ class RequestsTransport(xmlrpc.Transport):
                                                    handler=handler)
         try:
             resp = requests.post(url, data=request_body, headers=headers)
+        except requests.RequestException as exc:
+            raise exc.args[0].reason
         except (ValueError, Exception):
             raise
         else:

--- a/tools/rosgraph/src/rosgraph/transport.py
+++ b/tools/rosgraph/src/rosgraph/transport.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""A replacement transport for Python xmlrpc library."""
+
+try:
+    import xmlrpc.client as xmlrpc
+except ImportError:
+    import xmlrpclib as xmlrpc
+
+import requests
+
+
+class RequestsTransport(xmlrpc.Transport):
+    """Drop in Transport for xmlrpclib that uses Requests instead of httplib"""
+
+    user_agent = "Python XMLRPC with Requests (python-requests.org)"
+
+    def __init__(self, scheme, use_datetime=0):
+        xmlrpc.Transport.__init__(self, use_datetime)
+        self._scheme = scheme
+
+    def request(self, host, handler, request_body, verbose=0):
+        """Make a xmlrpc request."""
+        headers = {'User-Agent': self.user_agent, 'Content-Type': 'text/xml'}
+        url = '{scheme}://{host}{handler}'.format(scheme=self._scheme,
+                                                   host=host,
+                                                   handler=handler)
+        try:
+            resp = requests.post(url, data=request_body, headers=headers)
+        except (ValueError, Exception):
+            raise
+        else:
+            try:
+                resp.raise_for_status()
+            except requests.RequestException as exc:
+                raise xmlrpc.ProtocolError(url, resp.status_code,
+                                           str(exc), resp.headers)
+            else:
+                return self.parse_response(resp)
+
+    def parse_response(self, resp):
+        """
+        Parse the xmlrpc response.
+        """
+        p, u = self.getparser()
+        p.feed(resp.text)
+        p.close()
+        return u.close()

--- a/tools/rosgraph/src/rosgraph/transport.py
+++ b/tools/rosgraph/src/rosgraph/transport.py
@@ -55,6 +55,6 @@ class RequestsTransport(xmlrpc.Transport):
         Parse the xmlrpc response.
         """
         p, u = self.getparser()
-        p.feed(resp.text)
+        p.feed(resp.text.encode(resp.apparent_encoding))
         p.close()
         return u.close()

--- a/tools/rosgraph/src/rosgraph/transport.py
+++ b/tools/rosgraph/src/rosgraph/transport.py
@@ -41,7 +41,7 @@ class RequestsTransport(xmlrpc.Transport):
                 # We could add more exception mappings here:
                 #  - requests.exceptions.InvalidURL    -> socket.gaierror?
                 #  - requests.exceptions.InvalidSchema -> socket.gaierror?
-                raise exc
+                raise
         else:
             try:
                 resp.raise_for_status()

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -76,6 +76,8 @@ def isstring(s):
         return isinstance(s, str)
 
 class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
     def log_message(self, format, *args):
         if 0:
             SimpleXMLRPCRequestHandler.log_message(self, format, *args)

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -60,11 +60,21 @@ except ImportError:
     from SimpleXMLRPCServer import SimpleXMLRPCRequestHandler #Python 2.x
 
 try:
+    from xmlrpc.client import ServerProxy as _ServerProxy
+except ImportError:
+    from xmlrpclib import ServerProxy as _ServerProxy
+try:
+    from urllib.parse import splittype
+except ImportError:
+    from urllib import splittype
+
+try:
     import socketserver
 except ImportError:
     import SocketServer as socketserver
 
 import rosgraph.network
+from rosgraph.transport import RequestsTransport
 
 def isstring(s):
     """Small helper version to check an object is a string in a way that works
@@ -81,6 +91,17 @@ class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
     def log_message(self, format, *args):
         if 0:
             SimpleXMLRPCRequestHandler.log_message(self, format, *args)
+    
+class ServerProxy(_ServerProxy):
+    def __init__(self, uri, transport=None, encoding=None, verbose=0,
+                 allow_none=0, use_datetime=0):
+        if transport is None:
+            scheme, _ = splittype(uri)
+            transport = RequestsTransport(scheme)
+
+        _ServerProxy.__init__(self, uri, transport=transport, encoding=encoding,
+                              verbose=verbose, allow_none=allow_none,
+                              use_datetime=use_datetime)
     
 class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     """

--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -24,6 +24,7 @@
   <run_depend version_gte="1.0.37">python-rospkg</run_depend>
   <run_depend>python-yaml</run_depend>
   <run_depend>rosclean</run_depend>
+  <run_depend>rosgraph</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend version_gte="1.11.16">rosmaster</run_depend>

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -51,7 +51,7 @@ import rospkg
 import rosgraph
 import rosgraph.names 
 import rosgraph.network
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 
 from xml.sax.saxutils import escape 
 try:
@@ -291,7 +291,7 @@ class Master(object):
         """
         :returns:: XMLRPC proxy for communicating with master, ``rosgraph.xmlrpc.ServerProxy``
         """
-        return rosgraph.xmlrpc.ServerProxy(self.uri)
+        return ServerProxy(self.uri)
     
     def get_multi(self):
         """

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -42,15 +42,16 @@ import logging
 import socket
 import sys
 try:
-    from xmlrpc.client import MultiCall, ServerProxy
+    from xmlrpc.client import MultiCall
 except ImportError:
-    from xmlrpclib import MultiCall, ServerProxy
+    from xmlrpclib import MultiCall
 
 import rospkg
 
 import rosgraph
 import rosgraph.names 
 import rosgraph.network
+import rosgraph.xmlrpc
 
 from xml.sax.saxutils import escape 
 try:
@@ -288,9 +289,9 @@ class Master(object):
 
     def get(self):
         """
-        :returns:: XMLRPC proxy for communicating with master, ``xmlrpc.client.ServerProxy``
+        :returns:: XMLRPC proxy for communicating with master, ``rosgraph.xmlrpc.ServerProxy``
         """
-        return ServerProxy(self.uri)
+        return rosgraph.xmlrpc.ServerProxy(self.uri)
     
     def get_multi(self):
         """

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -433,7 +433,7 @@ class ROSLaunchRunner(object):
         @param default_run_id: run_id to use if value is not set
         @type  default_run_id: str
         @param param_server: parameter server proxy
-        @type  param_server: xmlrpclib.ServerProxy
+        @type  param_server: rosgraph.xmlrpc.ServerProxy
         """
         code, _, val = param_server.hasParam(_ID, '/run_id')
         if code == 1 and not val:

--- a/tools/roslaunch/src/roslaunch/netapi.py
+++ b/tools/roslaunch/src/roslaunch/netapi.py
@@ -36,13 +36,9 @@
 Convience methods for manipulating XML-RPC APIs
 """
 
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
-
 import rosgraph
 import rosgraph.network
+import rosgraph.xmlrpc
 
 _ID = '/roslaunch_netapi'
 def get_roslaunch_uris():
@@ -83,7 +79,7 @@ def list_processes(roslaunch_uris=None):
     procs = []
     for uri in roslaunch_uris:
         try:
-            r = ServerProxy(uri)
+            r = rosgraph.xmlrpc.ServerProxy(uri)
             code, msg, val = r.list_processes()
             if code == 1:
                 active, dead = val

--- a/tools/roslaunch/src/roslaunch/netapi.py
+++ b/tools/roslaunch/src/roslaunch/netapi.py
@@ -38,7 +38,7 @@ Convience methods for manipulating XML-RPC APIs
 
 import rosgraph
 import rosgraph.network
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 
 _ID = '/roslaunch_netapi'
 def get_roslaunch_uris():
@@ -79,7 +79,7 @@ def list_processes(roslaunch_uris=None):
     procs = []
     for uri in roslaunch_uris:
         try:
-            r = rosgraph.xmlrpc.ServerProxy(uri)
+            r = ServerProxy(uri)
             code, msg, val = r.list_processes()
             if code == 1:
                 active, dead = val

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -39,12 +39,9 @@ Process handler for launching ssh-based roslaunch child processes.
 import os
 import socket
 import traceback
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rosgraph
+import rosgraph.xmlrpc
 from roslaunch.core import printlog, printerrlog
 import roslaunch.pmon
 import roslaunch.server
@@ -240,10 +237,11 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
 
     def getapi(self):
         """
-        :returns: ServerProxy to remote client XMLRPC server, `ServerProxy`
+        :returns: rosgraph.xmlrpc.ServerProxy to remote client XMLRPC server,
+                  `rosgraph.xmlrpc.ServerProxy`
         """
         if self.uri:
-            return ServerProxy(self.uri)
+            return rosgraph.xmlrpc.ServerProxy(self.uri)
         else:
             return None
     

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -41,7 +41,7 @@ import socket
 import traceback
 
 import rosgraph
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 from roslaunch.core import printlog, printerrlog
 import roslaunch.pmon
 import roslaunch.server
@@ -237,11 +237,10 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
 
     def getapi(self):
         """
-        :returns: rosgraph.xmlrpc.ServerProxy to remote client XMLRPC server,
-                  `rosgraph.xmlrpc.ServerProxy`
+        :returns: ServerProxy to remote client XMLRPC server, `rosgraph.xmlrpc.ServerProxy`
         """
         if self.uri:
-            return rosgraph.xmlrpc.ServerProxy(self.uri)
+            return ServerProxy(self.uri)
         else:
             return None
     

--- a/tools/roslaunch/src/roslaunch/server.py
+++ b/tools/roslaunch/src/roslaunch/server.py
@@ -58,10 +58,6 @@ try:
     from urllib.parse import urlparse
 except ImportError:
     from urlparse import urlparse
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rosgraph.network as network
 import rosgraph.xmlrpc as xmlrpc
@@ -263,7 +259,7 @@ class ROSLaunchChildHandler(ROSLaunchBaseHandler):
         self.name = name
         self.pm = pm
         self.server_uri = server_uri
-        self.server = ServerProxy(server_uri)
+        self.server = xmlrpc.ServerProxy(server_uri)
 
     def _shutdown(self, reason):
         """
@@ -373,7 +369,7 @@ class ROSLaunchNode(xmlrpc.XmlRpcNode):
         server_up = False
         while not server_up and time.time() < timeout_t:
             try:
-                code, msg, val = ServerProxy(self.uri).get_pid()
+                code, msg, val = xmlrpc.ServerProxy(self.uri).get_pid()
                 if val != os.getpid():
                     raise RLException("Server at [%s] did not respond with correct PID. There appears to be something wrong with the networking configuration"%self.uri)
                 server_up = True
@@ -502,7 +498,7 @@ class ROSLaunchChildNode(ROSLaunchNode):
         name = self.name
         self.logger.info("attempting to register with roslaunch parent [%s]"%self.server_uri)
         try:
-            server = ServerProxy(self.server_uri)
+            server = xmlrpc.ServerProxy(self.server_uri)
             code, msg, _ = server.register(name, self.uri)
             if code != 1:
                 raise RLException("unable to register with roslaunch server: %s"%msg)

--- a/tools/roslaunch/test/unit/test_core.py
+++ b/tools/roslaunch/test/unit/test_core.py
@@ -151,10 +151,7 @@ class TestCore(unittest.TestCase):
             self.assertEquals(m, m)
             self.assertEquals(m, Master(Master.ROSMASTER, 'http://foo:1234'))
 
-            try:
-                from xmlrpc.client import ServerProxy
-            except ImportError:
-                from xmlrpclib import ServerProxy
+            from rosgraph.xmlrpc import ServerProxy
             self.assert_(isinstance(m.get(), ServerProxy))
             m.uri = 'http://foo:567'
             self.assertEquals(567, m.get_port())

--- a/tools/roslaunch/test/unit/test_roslaunch_core.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_core.py
@@ -34,11 +34,11 @@ import os
 import sys
 import rospkg
 try:
-    from xmlrpc.client import MultiCall, ServerProxy
+    from xmlrpc.client import MultiCall
 except ImportError:
-    from xmlrpclib import MultiCall, ServerProxy
+    from xmlrpclib import MultiCall
 
-
+import rosgraph.xmlrpc
 import roslaunch.core
 
 def test_Executable():
@@ -246,7 +246,7 @@ def test_Master():
     m.get_host() == 'localhost'
     m.get_port() == 11311
     assert m.is_running() in [True, False]
-    assert isinstance(m.get(), ServerProxy)
+    assert isinstance(m.get(), rosgraph.xmlrpc.ServerProxy)
     assert isinstance(m.get_multi(), MultiCall)
     
     m = Master(uri='http://badhostname:11312')

--- a/tools/roslaunch/test/unit/test_roslaunch_core.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_core.py
@@ -38,7 +38,7 @@ try:
 except ImportError:
     from xmlrpclib import MultiCall
 
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 import roslaunch.core
 
 def test_Executable():
@@ -246,7 +246,7 @@ def test_Master():
     m.get_host() == 'localhost'
     m.get_port() == 11311
     assert m.is_running() in [True, False]
-    assert isinstance(m.get(), rosgraph.xmlrpc.ServerProxy)
+    assert isinstance(m.get(), ServerProxy)
     assert isinstance(m.get_multi(), MultiCall)
     
     m = Master(uri='http://badhostname:11312')

--- a/tools/roslaunch/test/unit/test_roslaunch_server.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_server.py
@@ -35,9 +35,9 @@ import sys
 import unittest
 import time
 
+from rosgraph.xmlrpc import ServerProxy
 import roslaunch.pmon
 import roslaunch.server
-import rosgraph.xmlrpc
 from roslaunch.server import ProcessListener
 
 
@@ -347,7 +347,7 @@ class TestRoslaunchServer(unittest.TestCase):
         self.assert_(node.uri)
 
         # - call the ping API that we added
-        s = rosgraph.xmlrpc.ServerProxy(node.uri)
+        s = ServerProxy(node.uri)
         test_val = 'test-%s'%time.time()
         s.ping(test_val)
         self.assertEquals(handler.pinged, test_val)
@@ -404,7 +404,7 @@ class TestRoslaunchServer(unittest.TestCase):
         try:
             server.start()
             self.assert_(server.uri, "server URI did not initialize")
-            s = rosgraph.xmlrpc.ServerProxy(server.uri)
+            s = ServerProxy(server.uri)
             child_uri = 'http://fake-unroutable:1324'
             # - list children should be empty
             val = self._succeed(s.list_children())
@@ -455,7 +455,7 @@ class TestRoslaunchServer(unittest.TestCase):
         try:
             server.start()
             self.assert_(server.uri, "server URI did not initialize")
-            s = rosgraph.xmlrpc.ServerProxy(server.uri)
+            s = ServerProxy(server.uri)
 
             print("SERVER STARTED")
             

--- a/tools/roslaunch/test/unit/test_roslaunch_server.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_server.py
@@ -37,12 +37,9 @@ import time
 
 import roslaunch.pmon
 import roslaunch.server
+import rosgraph.xmlrpc
 from roslaunch.server import ProcessListener
 
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rosgraph
 master = rosgraph.Master('test_roslaunch_server')
@@ -350,7 +347,7 @@ class TestRoslaunchServer(unittest.TestCase):
         self.assert_(node.uri)
 
         # - call the ping API that we added
-        s = ServerProxy(node.uri)
+        s = rosgraph.xmlrpc.ServerProxy(node.uri)
         test_val = 'test-%s'%time.time()
         s.ping(test_val)
         self.assertEquals(handler.pinged, test_val)
@@ -407,7 +404,7 @@ class TestRoslaunchServer(unittest.TestCase):
         try:
             server.start()
             self.assert_(server.uri, "server URI did not initialize")
-            s = ServerProxy(server.uri)
+            s = rosgraph.xmlrpc.ServerProxy(server.uri)
             child_uri = 'http://fake-unroutable:1324'
             # - list children should be empty
             val = self._succeed(s.list_children())
@@ -458,7 +455,7 @@ class TestRoslaunchServer(unittest.TestCase):
         try:
             server.start()
             self.assert_(server.uri, "server URI did not initialize")
-            s = ServerProxy(server.uri)
+            s = rosgraph.xmlrpc.ServerProxy(server.uri)
 
             print("SERVER STARTED")
             

--- a/tools/rosmaster/src/rosmaster/util.py
+++ b/tools/rosmaster/src/rosmaster/util.py
@@ -41,9 +41,11 @@ try:
 except ImportError:
     from urlparse import urlparse
 try:
-    from xmlrpc.client import ServerProxy
+    from urllib.parse import splittype
 except ImportError:
-    from xmlrpclib import ServerProxy
+    from urllib import splittype
+
+import rosgraph.xmlrpc
 
 from defusedxml.xmlrpc import monkey_patch
 monkey_patch()
@@ -53,7 +55,7 @@ _proxies = {} #cache ServerProxys
 def xmlrpcapi(uri):
     """
     @return: instance for calling remote server or None if not a valid URI
-    @rtype: xmlrpc.client.ServerProxy
+    @rtype: rosgraph.xmlrpc.ServerProxy
     """
     if uri is None:
         return None
@@ -61,7 +63,7 @@ def xmlrpcapi(uri):
     if not uriValidate[0] or not uriValidate[1]:
         return None
     if not uri in _proxies:
-        _proxies[uri] = ServerProxy(uri)
+        _proxies[uri] = rosgraph.xmlrpc.ServerProxy(uri)
     return _proxies[uri]
 
 

--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -45,10 +45,6 @@ import errno
 import sys
 import socket
 import time
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 try: #py3k
     import urllib.parse as urlparse
@@ -56,6 +52,7 @@ except ImportError:
     import urlparse
 
 from optparse import OptionParser
+from rosgraph.xmlrpc import ServerProxy
 import rosgraph
 import rosgraph.names
 import rostopic
@@ -402,7 +399,7 @@ def cleanup_master_blacklist(master, blacklist):
     """
     Remove registrations from ROS Master that do not match blacklist.    
     @param master: XMLRPC handle to ROS Master
-    @type  master: xmlrpclib.ServerProxy
+    @type  master: rosgraph.xmlrpc.ServerProxy
     @param blacklist: list of nodes to scrub
     @type  blacklist: [str]
     """
@@ -428,7 +425,7 @@ def cleanup_master_whitelist(master, whitelist):
     """
     Remove registrations from ROS Master that do not match whitelist.
     @param master: XMLRPC handle to ROS Master
-    @type  master: xmlrpclib.ServerProxy
+    @type  master: nosgraph.xmlrpc.ServerProxy
     @param whitelist: list of nodes to keep
     @type  whitelist: list of nodes to keep
    """

--- a/tools/rostest/src/rostest/__init__.py
+++ b/tools/rostest/src/rostest/__init__.py
@@ -58,12 +58,9 @@ def get_master():
     @return: XML-RPC proxy to ROS master
     @rtype: xmlrpclib.ServerProxy
     """
-    try:
-        import xmlrpc.client as xmlrpcclient  #Python 3.x
-    except ImportError:
-        import xmlrpclib as xmlrpcclient #Python 2.x
+    from rosgraph.xmlrpc import ServerProxy
     uri = rosgraph.get_master_uri()
-    return xmlrpcclient.ServerProxy(uri)
+    return ServerProxy(uri)
 
 def is_subscriber(topic, subscriber_id):
     """

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1057,7 +1057,7 @@ _caller_apis = {}
 def get_api(master, caller_id):
     """
     Get XML-RPC API of node
-    :param master: XML-RPC handle to ROS Master, :class:`xmlrpclib.ServerProxy`
+    :param master: XML-RPC handle to ROS Master, :class:`rosgraph.xmlrpc.ServerProxy`
     :param caller_id: node name, ``str``
     :returns: XML-RPC URI of node, ``str``
     :raises: :exc:`ROSTopicIOException` If unable to communicate with master

--- a/utilities/roswtf/src/roswtf/graph.py
+++ b/utilities/roswtf/src/roswtf/graph.py
@@ -40,16 +40,13 @@ import itertools
 import socket
 import sys
 import time
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 import rospkg.environment
 
 import rosgraph
 import rosgraph.rosenv
 import rosgraph.network
+import rosgraph.xmlrpc
 
 import rosnode
 import rosservice
@@ -291,7 +288,7 @@ class NodeInfoThread(threading.Thread):
                     ctx.errors.append(WtfError("Master does not have lookup information for node [%s]"%n))
                 return
                 
-            node = ServerProxy(node_api)
+            node = rosgraph.xmlrpc.ServerProxy(node_api)
             start = time.time()
             socket.setdefaulttimeout(3.0)            
             code, msg, bus_info = node.getBusInfo('/roswtf')

--- a/utilities/roswtf/src/roswtf/graph.py
+++ b/utilities/roswtf/src/roswtf/graph.py
@@ -46,7 +46,7 @@ import rospkg.environment
 import rosgraph
 import rosgraph.rosenv
 import rosgraph.network
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 
 import rosnode
 import rosservice
@@ -288,7 +288,7 @@ class NodeInfoThread(threading.Thread):
                     ctx.errors.append(WtfError("Master does not have lookup information for node [%s]"%n))
                 return
                 
-            node = rosgraph.xmlrpc.ServerProxy(node_api)
+            node = ServerProxy(node_api)
             start = time.time()
             socket.setdefaulttimeout(3.0)            
             code, msg, bus_info = node.getBusInfo('/roswtf')

--- a/utilities/roswtf/src/roswtf/roslaunchwtf.py
+++ b/utilities/roswtf/src/roswtf/roslaunchwtf.py
@@ -40,7 +40,7 @@ import sys
 
 from os.path import isfile, isdir
 
-import rosgraph.xmlrpc
+from rosgraph.xmlrpc import ServerProxy
 import roslib.packages
 import roslaunch
 import roslaunch.netapi
@@ -198,7 +198,7 @@ def roslaunch_respawn_check(ctx):
     respawn = []
     for uri in ctx.roslaunch_uris:
         try:
-            r = rosgraph.xmlrpc.ServerProxy(uri)
+            r = ServerProxy(uri)
             code, msg, val = r.list_processes()
             active, _ = val
             respawn.extend([a for a in active if a[1] > 1])
@@ -214,13 +214,13 @@ def roslaunch_uris_check(ctx):
     # uris only contains the parent launches
     for uri in ctx.roslaunch_uris:
         try:
-            r = rosgraph.xmlrpc.ServerProxy(uri)
+            r = ServerProxy(uri)
             code, msg, val = r.list_children()
             # check the children launches
             if code == 1:
                 for child_uri in val:
                     try:
-                        r = rosgraph.xmlrpc.ServerProxy(uri)
+                        r = ServerProxy(uri)
                         code, msg, val = r.get_pid()
                     except:
                         bad.append(child_uri)
@@ -232,7 +232,7 @@ def roslaunch_dead_check(ctx):
     dead = []
     for uri in ctx.roslaunch_uris:
         try:
-            r = rosgraph.xmlrpc.ServerProxy(uri)
+            r = ServerProxy(uri)
             code, msg, val = r.list_processes()
             _, dead_list = val
             dead.extend([d[0] for d in dead_list])

--- a/utilities/roswtf/src/roswtf/roslaunchwtf.py
+++ b/utilities/roswtf/src/roswtf/roslaunchwtf.py
@@ -37,13 +37,10 @@ import itertools
 import socket
 import stat
 import sys
-try:
-    from xmlrpc.client import ServerProxy
-except ImportError:
-    from xmlrpclib import ServerProxy
 
 from os.path import isfile, isdir
 
+import rosgraph.xmlrpc
 import roslib.packages
 import roslaunch
 import roslaunch.netapi
@@ -201,7 +198,7 @@ def roslaunch_respawn_check(ctx):
     respawn = []
     for uri in ctx.roslaunch_uris:
         try:
-            r = ServerProxy(uri)
+            r = rosgraph.xmlrpc.ServerProxy(uri)
             code, msg, val = r.list_processes()
             active, _ = val
             respawn.extend([a for a in active if a[1] > 1])
@@ -217,13 +214,13 @@ def roslaunch_uris_check(ctx):
     # uris only contains the parent launches
     for uri in ctx.roslaunch_uris:
         try:
-            r = ServerProxy(uri)
+            r = rosgraph.xmlrpc.ServerProxy(uri)
             code, msg, val = r.list_children()
             # check the children launches
             if code == 1:
                 for child_uri in val:
                     try:
-                        r = ServerProxy(uri)
+                        r = rosgraph.xmlrpc.ServerProxy(uri)
                         code, msg, val = r.get_pid()
                     except:
                         bad.append(child_uri)
@@ -235,7 +232,7 @@ def roslaunch_dead_check(ctx):
     dead = []
     for uri in ctx.roslaunch_uris:
         try:
-            r = ServerProxy(uri)
+            r = rosgraph.xmlrpc.ServerProxy(uri)
             code, msg, val = r.list_processes()
             _, dead_list = val
             dead.extend([d[0] for d in dead_list])


### PR DESCRIPTION
I found that the pull request #834 does not support non-ascii rosparams.
Since @mgrrx does not permit pull request (I could not send pull request to his repository), I made another pull request.
This pull request also includes a test code for this issue.

I checked by:

```yaml
# test.yaml
param: "ｎｏｔａｓｃｉｉ"  # this is not ascii
```

```xml
<!-- test.launch -->
<launch>
  <rosparam command="load" file="/tmp/test.yaml" />
</launch>
```

- `roslaunch /tmp/test.launch`

  - `ros:kinetic-devel`:

```bash
$ roslaunch test.launch 
... logging to /root/.ros/log/0701c404-16c1-11e7-b3ce-0242ac110002/roslaunch-db478db0f966-22337.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://db478db0f966:37491/

SUMMARY
========

PARAMETERS
 * /param: <...>
 * /rosdistro: kinetic
 * /rosversion: 1.12.6

NODES

auto-starting new master
process[master]: started with pid [22348]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 0701c404-16c1-11e7-b3ce-0242ac110002
process[rosout-1]: started with pid [22361]
started core service [/rosout]
```

  - `mgrrx:fix/610`:

```bash
# roslaunch test.launch 
... logging to /root/.ros/log/4446ff00-16c1-11e7-bf75-0242ac110002/roslaunch-db478db0f966-22439.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://db478db0f966:38999/

SUMMARY
========

PARAMETERS
 * /param: <...>
 * /rosdistro: kinetic
 * /rosversion: 1.12.6

NODES

auto-starting new master
process[master]: started with pid [22450]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 4446ff00-16c1-11e7-bf75-0242ac110002
process[rosout-1]: started with pid [22465]
started core service [/rosout]
load_parameters: unable to set parameters (last param was [/rosdistro=kinetic
]): 'ascii' codec can't decode byte 0xef in position 607: ordinal not in range(128)
'ascii' codec can't decode byte 0xef in position 607: ordinal not in range(128)
The traceback for the exception was written to the log file
[rosout-1] killing on exit
[master] killing on exit
```

@mgrrx Could you please port my update (the latest 3 commits) to yours if it's ok?
