### PR TITLE
Sleep in rospy wait_for_service even if exceptions raised

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_service.py
+++ b/clients/rospy/src/rospy/impl/tcpros_service.py
@@ -128,7 +128,6 @@ def wait_for_service(service, timeout=None):
             try:
                 if contact_service(resolved_name, timeout_t-time.time()):
                     return
-                time.sleep(0.3)
             except KeyboardInterrupt:
                 # re-raise
                 rospy.core.logdebug("wait_for_service: received keyboard interrupt, assuming signals disabled and re-raising")
@@ -137,6 +136,7 @@ def wait_for_service(service, timeout=None):
                 if first:
                     first = False
                     rospy.core.logerr("wait_for_service(%s): failed to contact [%s], will keep trying"%(resolved_name, uri))
+            time.sleep(0.3)
         if rospy.core.is_shutdown():
             raise ROSInterruptException("rospy shutdown")
         else:
@@ -146,7 +146,6 @@ def wait_for_service(service, timeout=None):
             try:
                 if contact_service(resolved_name):
                     return
-                time.sleep(0.3)
             except KeyboardInterrupt:
                 # re-raise
                 rospy.core.logdebug("wait_for_service: received keyboard interrupt, assuming signals disabled and re-raising")
@@ -155,6 +154,7 @@ def wait_for_service(service, timeout=None):
                 if first:
                     first = False
                     rospy.core.logerr("wait_for_service(%s): failed to contact [%s], will keep trying"%(resolved_name, uri))
+            time.sleep(0.3)
         if rospy.core.is_shutdown():
             raise ROSInterruptException("rospy shutdown")
     


### PR DESCRIPTION
If a service is not actually up, wait_for_service will throw an exception at the [contact_service call](https://github.com/ros/ros_comm/blob/247459207e20c1da109fc306e58b84d15c4107bd/clients/rospy/src/rospy/impl/tcpros_service.py#L129) and skip the sleeping.

This leads to the loop being executed without sleep, burning a lot of CPU.

This makes sure we always sleep. Sleep is good for your health.