### PR TITLE
Removed "ROS time moved backwards" log message

### DIFF
--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -151,7 +151,6 @@ def sleep(duration):
 
         if rospy.rostime.get_rostime() < initial_rostime:
             time_jump = (initial_rostime - rospy.rostime.get_rostime()).to_sec()
-            rospy.core.logerr("ROS time moved backwards: %ss", time_jump)
             raise rospy.exceptions.ROSTimeMovedBackwardsException(time_jump)
         if rospy.core.is_shutdown():
             raise rospy.exceptions.ROSInterruptException("ROS shutdown request")


### PR DESCRIPTION
The log message doesn't make sense IMO, because there is still the exception being thrown.

So the user can either catch it (and then he knows best whether it is an error or not), or he'll not catch it, and then he'll see the message printed in the stack trace.

This is a followup of comment https://github.com/ros/ros_comm/pull/492#discussion_r109936788 .

My use-case: I have a ROS node running alongside Gazebo, and resetting Gazebo always prints this error to the log, even if it is no error for me, since I expect the time to be restarted.