### PR TITLE
Delay automatic ros::shutdown() until static cleanup.

### DIFF
--- a/test/test_roscpp/test/src/handles.cpp
+++ b/test/test_roscpp/test/src/handles.cpp
@@ -54,38 +54,21 @@ using namespace test_roscpp;
 
 TEST(RoscppHandles, nodeHandleConstructionDestruction)
 {
+  // Cleanup is done during static deinitialization.
+  // Manual start/shutdown should still work though.
+  //
+  ASSERT_FALSE(ros::isStarted());
   {
-    ASSERT_FALSE(ros::isStarted());
-
     ros::NodeHandle n1;
     ASSERT_TRUE(ros::isStarted());
-
-    {
-      ros::NodeHandle n2;
-      ASSERT_TRUE(ros::isStarted());
-
-      {
-        ros::NodeHandle n3(n2);
-        ASSERT_TRUE(ros::isStarted());
-
-        {
-          ros::NodeHandle n4 = n3;
-          ASSERT_TRUE(ros::isStarted());
-        }
-      }
-    }
-
-    ASSERT_TRUE(ros::isStarted());
   }
+  ASSERT_TRUE(ros::isStarted());
 
+  ros::shutdown();
   ASSERT_FALSE(ros::isStarted());
 
-  {
-    ros::NodeHandle n;
-    ASSERT_TRUE(ros::isStarted());
-  }
-
-  ASSERT_FALSE(ros::isStarted());
+  ros::start();
+  ASSERT_TRUE(ros::isStarted());
 }
 
 TEST(RoscppHandles, nodeHandleParentWithRemappings)


### PR DESCRIPTION
This PR is supposed to address some problems described in #688 .

In particular, the destruction of the last node handle calls `ros::shutdown()` if the creation of a node handle was the trigger for calling `ros::start()`. This PR makes sure that this cleanup is delayed until static de-initialization by starting the relevant refcount at 1 and adding a static object that decrements the refcount in its destructor. Node handles created in the mean time should be fully functional.

The refcount is still used, so if a static object has a node handle, it will keep the refcount non-zero and delay the cleanup even longer so that the node handle will remain usable.