### PR TITLE
[roslaunch] Add yaml type for <param> tag

### DIFF
--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -32,6 +32,7 @@
   <run_depend version_gte="1.13.3">rosunit</run_depend>
 
   <test_depend>rosbuild</test_depend>
+  <test_depend>rospy</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -32,7 +32,6 @@
   <run_depend version_gte="1.13.3">rosunit</run_depend>
 
   <test_depend>rosbuild</test_depend>
-  <test_depend>rospy</test_depend>
 
   <export>
     <rosdoc config="rosdoc.yaml"/>

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -504,7 +504,7 @@ class Loader(object):
                 raise
             if c_value is None:
                 raise ValueError("parameter: unable to get output of command [%s]"%command)
-            return c_value
+            return convert_value(c_value.strip(), ptype)
         else: #_param_tag prevalidates, so this should not be reachable
             raise ValueError("unable to determine parameter value")
 

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -89,7 +89,7 @@ def convert_value(value, type_):
     elif type_ == 'double':
         return float(value)
     elif type_ == 'bool' or type_ == 'boolean':
-        value = value.lower()
+        value = value.lower().strip()
         if value == 'true' or value == '1':
             return True
         elif value == 'false' or value == '0':

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -94,6 +94,12 @@ def convert_value(value, type_):
         elif value == 'false' or value == '0':
             return False
         raise ValueError("%s is not a '%s' type"%(value, type_))
+    elif type_ == 'yaml':
+        # - lazy import
+        global yaml
+        if yaml is None:
+            import yaml
+        return yaml.load(value)
     else:
         raise ValueError("Unknown type '%s'"%type_)        
 

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -70,13 +70,13 @@ def convert_value(value, type_):
         #attempt numeric conversion
         try:
             if '.' in value:
-                return float(value)
+                return float(value.strip())
             else:
-                return int(value)
+                return int(value.strip())
         except ValueError as e:
             pass
         #bool
-        lval = value.lower()
+        lval = value.strip().lower()
         if lval == 'true' or lval == 'false':
             return convert_value(value, 'bool')
         #string
@@ -84,11 +84,11 @@ def convert_value(value, type_):
     elif type_ == 'str' or type_ == 'string':
         return value
     elif type_ == 'int':
-        return int(value)
+        return int(value.strip())
     elif type_ == 'double':
-        return float(value)
+        return float(value.strip())
     elif type_ == 'bool' or type_ == 'boolean':
-        value = value.lower()
+        value = value.strip().lower()
         if value == 'true' or value == '1':
             return True
         elif value == 'false' or value == '0':
@@ -471,10 +471,10 @@ class Loader(object):
         @raise ValueError: if parameters are invalid
         """
         if value is not None:
-            return convert_value(value.strip(), ptype)
+            return convert_value(value, ptype)
         elif textfile is not None:
             with open(textfile, 'r') as f:
-                return convert_value(f.read().strip(), ptype)
+                return convert_value(f.read(), ptype)
         elif binfile is not None:
             try:
                 from xmlrpc.client import Binary
@@ -504,7 +504,7 @@ class Loader(object):
                 raise
             if c_value is None:
                 raise ValueError("parameter: unable to get output of command [%s]"%command)
-            return convert_value(c_value.strip(), ptype)
+            return convert_value(c_value, ptype)
         else: #_param_tag prevalidates, so this should not be reachable
             raise ValueError("unable to determine parameter value")
 

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -474,7 +474,7 @@ class Loader(object):
             return convert_value(value.strip(), ptype)
         elif textfile is not None:
             with open(textfile, 'r') as f:
-                return f.read()
+                return convert_value(f.read().strip(), ptype)
         elif binfile is not None:
             try:
                 from xmlrpc.client import Binary

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -96,7 +96,10 @@ def convert_value(value, type_):
             return False
         raise ValueError("%s is not a '%s' type"%(value, type_))
     elif type_ == 'yaml':
-        return yaml.load(value)
+        try:
+            return yaml.load(value)
+        except yaml.parser.ParserError as e:
+            raise ValueError(e)
     else:
         raise ValueError("Unknown type '%s'"%type_)        
 

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -70,13 +70,13 @@ def convert_value(value, type_):
         #attempt numeric conversion
         try:
             if '.' in value:
-                return float(value.strip())
+                return float(value)
             else:
-                return int(value.strip())
+                return int(value)
         except ValueError as e:
             pass
         #bool
-        lval = value.strip().lower()
+        lval = value.lower()
         if lval == 'true' or lval == 'false':
             return convert_value(value, 'bool')
         #string
@@ -84,11 +84,11 @@ def convert_value(value, type_):
     elif type_ == 'str' or type_ == 'string':
         return value
     elif type_ == 'int':
-        return int(value.strip())
+        return int(value)
     elif type_ == 'double':
-        return float(value.strip())
+        return float(value)
     elif type_ == 'bool' or type_ == 'boolean':
-        value = value.strip().lower()
+        value = value.lower()
         if value == 'true' or value == '1':
             return True
         elif value == 'false' or value == '0':
@@ -471,7 +471,7 @@ class Loader(object):
         @raise ValueError: if parameters are invalid
         """
         if value is not None:
-            return convert_value(value, ptype)
+            return convert_value(value.strip(), ptype)
         elif textfile is not None:
             with open(textfile, 'r') as f:
                 return convert_value(f.read(), ptype)

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -39,12 +39,13 @@ General routines and representations for loading roslaunch model.
 import os
 from copy import deepcopy
 
+import yaml
+
 from roslaunch.core import Param, RosbinExecutable, RLException, PHASE_SETUP
 
 from rosgraph.names import make_global_ns, ns_join, PRIV_NAME, load_mappings, is_legal_name, canonicalize_name
 
 #lazy-import global for yaml and rosparam
-yaml = None
 rosparam = None
 
 class LoadException(RLException):
@@ -95,10 +96,6 @@ def convert_value(value, type_):
             return False
         raise ValueError("%s is not a '%s' type"%(value, type_))
     elif type_ == 'yaml':
-        # - lazy import
-        global yaml
-        if yaml is None:
-            import yaml
         return yaml.load(value)
     else:
         raise ValueError("Unknown type '%s'"%type_)        
@@ -401,10 +398,6 @@ class Loader(object):
                     text = f.read()
                     
             # parse YAML text
-            # - lazy import
-            global yaml
-            if yaml is None:
-                import yaml
             # - lazy import: we have to import rosparam in oder to to configure the YAML constructors
             global rosparam
             if rosparam is None:

--- a/tools/roslaunch/test/xml/test-params-valid.xml
+++ b/tools/roslaunch/test/xml/test-params-valid.xml
@@ -35,6 +35,12 @@
   <!-- upload the output of a command as a param. -->
   <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" />
 
+  <!-- upload the output of a command as a param as types. -->
+  <param name="commandoutputinteger" type="int" command="echo 0" />
+  <param name="commandoutputdouble" type="double" command="echo 10" />
+  <param name="commandoutputbool" type="bool" command="echo true" />
+  <param name="commandoutputyaml" type="yaml" command="cat &quot;$(find roslaunch)/test/params.yaml&quot;" />
+
 
   <!-- test that we can override params -->
   <param name="override" value="fail" />

--- a/tools/roslaunch/test/xml/test-params-valid.xml
+++ b/tools/roslaunch/test/xml/test-params-valid.xml
@@ -17,6 +17,9 @@
   
   <param name="somefloat1" value="3.14159" type="double" />  
   <param name="somefloat2" value="5.0" />
+
+  <param name="someyaml1" value="[0, 1, 2]" type="yaml" />
+  <param name="someyaml2" value="{string1: bar2, string2: '10', integer1: 1, float1: 3.14, list1: [0, 1, 2], list2: ['a', 'b', 'c']}" type="yaml" />
   
   <!-- you can set parameters in child namespaces -->
   <param name="wg/wgchildparam" value="a child namespace parameter 1" />  


### PR DESCRIPTION
## Why?

To set dict, list string as a parameter.
This is ok if we use `<rosparam>` tag, but it does not have the feature of running arbitrary commands which `<param>` tag has.

## Example

My motivation is ways to use like below:

```bash
% cat apc2015_00.json
{
  "bin_contents":
  {
    "bin_I":
    [
      "sharpie_accent_tank_style_highlighters",
      "dr_browns_bottle_brush"
    ]
  },

  "work_order":
  [
    {
      "bin": "bin_I",
      "item": "sharpie_accent_tank_style_highlighters"
    }
  ]
}

% cat spam.launch
<launch>

  <param name="/test" type="yaml"
         command="/usr/local/bin/json2yaml $(find roslaunch)/apc2015_00.json" />

</launch>

% roslaunch ./spam.launch

% rosparam get /test
bin_contents:
  bin_I: [sharpie_accent_tank_style_highlighters, dr_browns_bottle_brush]
work_order:
- {bin: bin_I, item: sharpie_accent_tank_style_highlighters}
```