### PR TITLE
Fix race condition that lead to miss first message

### DIFF
--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -102,17 +102,6 @@ void CallbackQueue::addCallback(const CallbackInterfacePtr& callback, uint64_t r
   info.removal_id = removal_id;
 
   {
-    boost::mutex::scoped_lock lock(mutex_);
-
-    if (!enabled_)
-    {
-      return;
-    }
-
-    callbacks_.push_back(info);
-  }
-
-  {
     boost::mutex::scoped_lock lock(id_info_mutex_);
 
     M_IDInfo::iterator it = id_info_.find(removal_id);
@@ -122,6 +111,17 @@ void CallbackQueue::addCallback(const CallbackInterfacePtr& callback, uint64_t r
       id_info->id = removal_id;
       id_info_.insert(std::make_pair(removal_id, id_info));
     }
+  }
+
+  {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    if (!enabled_)
+    {
+      return;
+    }
+
+    callbacks_.push_back(info);
   }
 
   condition_.notify_one();


### PR DESCRIPTION
Callback queue waits for callback from "callOne" method.
When internal queue is not empty this last method succeeded even if id
info mapping does not contains related callback's id.
In this case, first callback (for one id) is never called since
"addCallback" method first push callback into internal queue and *then*
set info mapping.

So id info mapping has to be set before push callback into interal
queue. Otherwise first message could be ignored.

Attached file highlights this issue.
[ros_callback_queue_bug.cpp.zip](https://github.com/ros/ros_comm/files/993526/ros_callback_queue_bug.cpp.zip)

