### PR TITLE
rosconsole: remove extra semicolon in definition of macro ROSCONSOLE_PRINTF_ATTRIBUTE(a, b)

### DIFF
--- a/tools/rosconsole/include/ros/console.h
+++ b/tools/rosconsole/include/ros/console.h
@@ -60,7 +60,7 @@
 
 #ifdef __GNUC__
 #if __GNUC__ >= 3
-#define ROSCONSOLE_PRINTF_ATTRIBUTE(a, b) __attribute__ ((__format__ (__printf__, a, b)));
+#define ROSCONSOLE_PRINTF_ATTRIBUTE(a, b) __attribute__ ((__format__ (__printf__, a, b)))
 #endif
 #endif
 


### PR DESCRIPTION
Another extra semicolon that triggers compiler warnings with `-Wpedantic`, like in https://github.com/ros/ros_comm/pull/817.