### PR TITLE
Add XXH_NAMESPACE, for namespace emulation in C

### DIFF
--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -31,6 +31,9 @@ add_library(roslz4 src/lz4s.c src/xxhash.c)
 set_source_files_properties(
   src/lz4s.c
 PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
+set_source_files_properties(
+  src/lz4s.c src/xxhash.c
+PROPERTIES COMPILE_DEFINITIONS "XXH_NAMESPACE=ROSLZ4_")
 target_link_libraries(roslz4 ${lz4_LIBRARIES} ${catkin_LIBRARIES})
 
 if(NOT ANDROID)

--- a/utilities/roslz4/src/xxhash.h
+++ b/utilities/roslz4/src/xxhash.h
@@ -69,6 +69,28 @@ extern "C" {
 //****************************
 typedef enum { XXH_OK=0, XXH_ERROR } XXH_errorcode;
 
+/*!XXH_NAMESPACE, aka Namespace Emulation :
+
+If you want to include _and expose_ xxHash functions from within your own library,
+but also want to avoid symbol collisions with other libraries which may also include xxHash,
+
+you can use XXH_NAMESPACE, to automatically prefix any public symbol from xxhash library
+with the value of XXH_NAMESPACE (therefore, avoid NULL and numeric values).
+
+Note that no change is required within the calling program as long as it includes `xxhash.h` :
+regular symbol name will be automatically translated by this header.
+*/
+#ifdef XXH_NAMESPACE
+#  define XXH_CAT(A,B) A##B
+#  define XXH_NAME2(A,B) XXH_CAT(A,B)
+#  define XXH32 XXH_NAME2(XXH_NAMESPACE, XXH32)
+#  define XXH32_sizeofState XXH_NAME2(XXH_NAMESPACE, XXH32_sizeofState)
+#  define XXH32_resetState XXH_NAME2(XXH_NAMESPACE, XXH32_resetState)
+#  define XXH32_init XXH_NAME2(XXH_NAMESPACE, XXH32_init)
+#  define XXH32_update XXH_NAME2(XXH_NAMESPACE, XXH32_update)
+#  define XXH32_intermediateDigest XXH_NAME2(XXH_NAMESPACE, XXH32_intermediateDigest)
+#  define XXH32_digest XXH_NAME2(XXH_NAMESPACE, XXH32_digest)
+#endif
 
 
 //****************************


### PR DESCRIPTION
I've been trying to use `rosbag` in a PostgreSQL extension based on [Multicorn](https://github.com/Kozea/Multicorn). But that doesn't work in PostgreSQL 9.6. I get SIGSEGV crashes. See https://github.com/elemoine/FdwRosTest for a complete test case with instructions on how to reproduce the bug.

The issue is that the `postgresql` 9.6 binary uses liblz4, which, as the `roslz4` code, includes xxhash.h and xxhash.c. So when run in PostgreSQL the roslz4 code uses the XXH32_ symbols from liblz4 instead of its own symbols. This results in SIGSEGV crashes.

This PR introduces the `XXH_NAMESPACE` pre-processor variable for namespacing XXH32_ symbols. I did not invent anything – the latest xxHash code already [uses](https://github.com/Cyan4973/xxHash/blob/dev/xxhash.h#L122-L144) that.

Alternatively, the roslz4 code could be updated to include the latest xxHash code. But that would require changes to the lz4s.c code, as the xxHash API has changed.