### PR TITLE
backport transport_tcp bugfix to Kinetic

### DIFF
--- a/clients/roscpp/CHANGELOG.rst
+++ b/clients/roscpp/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package roscpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* fix bug in transport_tcp (`#1050 <https://github.com/ros/ros_comm/pull/1050>`_)
+
 1.12.7 (2017-02-17)
 -------------------
 * move connection specific log message to new name roscpp_internal.connections (`#980 <https://github.com/ros/ros_comm/pull/980>`_)

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -311,9 +311,10 @@ bool TransportTCP::connect(const std::string& host, int port)
 
   int ret = ::connect(sock_, (sockaddr*) &sas, sas_len);
   // windows might need some time to sleep (input from service robotics hack) add this if testing proves it is necessary.
-  ROS_ASSERT((flags_ & SYNCHRONOUS) || ret != 0);
+  // ROS_ASSERT((flags_ & SYNCHRONOUS) || ret != 0);
   if (((flags_ & SYNCHRONOUS) && ret != 0) || // synchronous, connect() should return 0
-      (!(flags_ & SYNCHRONOUS) && last_socket_error() != ROS_SOCKETS_ASYNCHRONOUS_CONNECT_RETURN)) // asynchronous, connect() should return -1 and WSAGetLastError()=WSAEWOULDBLOCK/errno=EINPROGRESS
+      (!(flags_ & SYNCHRONOUS) && ret != 0 && last_socket_error() != ROS_SOCKETS_ASYNCHRONOUS_CONNECT_RETURN)) 
+      // asynchronous, connect() may return 0 or -1. When return -1, WSAGetLastError()=WSAEWOULDBLOCK/errno=EINPROGRESS
   {
     ROSCPP_CONN_LOG_DEBUG("Connect to tcpros publisher [%s:%d] failed with error [%d, %s]", host.c_str(), port, ret, last_socket_error_string());
     close();


### PR DESCRIPTION
Here I cherrypicked the fix in #1050 and applied it to the kinetic-devel branch.
Tested on my machine in WSL:
```
rosrun turtlesim turtle_teleop_key
rostopic echo /turtle1/cmd_vel
```
Everything works as expected.

---

For people who want to get this now:

```bash
git clone -b transport_tcp_kinetic https://github.com/andyli/ros_comm.git
ln -s /abs/path/to/ros_comm ~/catkin_ws
cd ~/catkin_ws
catkin_make
catkin_make install

# you may add this line to ~/.bashrc
source ~/catkin_ws/devel/setup.bash
```