### PR TITLE
[roslaunch] Fix pid file removing condition

### DIFF
--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -324,7 +324,7 @@ def main(argv=sys.argv):
         sys.exit(1)
     finally:
         # remove the pid file
-        if options.pid_fn:
+        if options is not None and options.pid_fn:
             try: os.unlink(options.pid_fn)
             except os.error: pass
 


### PR DESCRIPTION
This patch will fix an error when ``roslaunch`` is executed with ``-h`` option. The variable ``options`` seems remained ``None`` when ``-h`` option is parsed.

```bash
$ roslaunch -h
Usage: roslaunch [options] [package] <filename> [arg_name:=value...]
       roslaunch [options] <filename> [<filename>...] [arg_name:=value...]

If <filename> is a single dash ('-'), launch XML is read from standard input.

Options:
  -h, --help            show this help message and exit
  --files               Print list files loaded by launch file, including
                        launch file itself
  --args=NODE_NAME      Print command-line arguments for node
  --nodes               Print list of node names in launch file
  --find-node=NODE_NAME
                        Find launch file that node is defined in
  -c NAME, --child=NAME
                        Run as child service 'NAME'. Required with -u
  --local               Do not launch remote nodes
  --screen              Force output of all local nodes to screen
  -u URI, --server_uri=URI
                        URI of server. Required with -c
  --run_id=RUN_ID       run_id of session. Required with -c
  --wait                wait for master to start before launching
  -p PORT, --port=PORT  master port. Only valid if master is launched
  --core                Launch core services only
  --pid=PID_FN          write the roslaunch pid to filename
  -v                    verbose printing
  --dump-params         Dump parameters of all roslaunch files to stdout
  --skip-log-check      skip check size of log folder
  --ros-args            Display command-line arguments for this launch file
  --disable-title       Disable setting of terminal title
  -w NUM_WORKERS, --numworkers=NUM_WORKERS
                        override number of worker threads. Only valid for core
                        services.
  -t TIMEOUT, --timeout=TIMEOUT
                        override the socket connection timeout (in seconds).
                        Only valid for core services.
Traceback (most recent call last):
  File "/home/tamaki/work/ros_comm/install/bin/roslaunch", line 35, in <module>
    roslaunch.main()
  File "/home/tamaki/work/ros_comm/install/lib/python2.7/dist-packages/roslaunch/__init__.py", line 327, in main
    if options.pid_fn:
AttributeError: 'NoneType' object has no attribute 'pid_fn'
```