### PR TITLE
Close CLOSE_WAIT sockets (#610)

### DIFF
--- a/tools/roslaunch/scripts/roscore
+++ b/tools/roslaunch/scripts/roscore
@@ -56,6 +56,10 @@ def _get_optparse():
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
+    parser.add_option("--close-sockets",
+                      dest="close_sockets",
+                      action="store_true", default=False,
+                      help="enable checking and closing CLOSE_WAIT sockets.")
     return parser
 
 

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -180,6 +180,10 @@ def _get_optparse():
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds). Only valid for core services.", metavar="TIMEOUT")
+    parser.add_option("--close-sockets",
+                      dest="close_sockets",
+                      action="store_true", default=False,
+                      help="enable checking and closing CLOSE_WAIT sockets.")
 
     return parser
     
@@ -302,7 +306,7 @@ def main(argv=sys.argv):
             p = roslaunch_parent.ROSLaunchParent(uuid, args, roslaunch_strs=roslaunch_strs,
                     is_core=options.core, port=options.port, local_only=options.local_only,
                     verbose=options.verbose, force_screen=options.force_screen,
-                    num_workers=options.num_workers, timeout=options.timeout)
+                    num_workers=options.num_workers, timeout=options.timeout, close_sockets=options.close_sockets)
             p.start()
             p.spin()
 

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -234,8 +234,8 @@ class ROSLaunchRunner(object):
     allows the main thread to continue to do work while processes are
     monitored.
     """
-    
-    def __init__(self, run_id, config, server_uri=None, pmon=None, is_core=False, remote_runner=None, is_child=False, is_rostest=False, num_workers=NUM_WORKERS, timeout=None):
+
+    def __init__(self, run_id, config, server_uri=None, pmon=None, is_core=False, remote_runner=None, is_child=False, is_rostest=False, num_workers=NUM_WORKERS, timeout=None, close_sockets=False):
         """
         @param run_id: /run_id for this launch. If the core is not
             running, this value will be used to initialize /run_id. If
@@ -264,6 +264,8 @@ class ROSLaunchRunner(object):
         @type num_workers: int
         @param timeout: If this is the core, the socket-timeout to use.
         @type timeout: Float or None
+        @param close_sockets: If this is the core, enable close CLOSE_WAIT sockets.
+        @type close_sockets: bool
         """
         if run_id is None:
             raise RLException("run_id is None")
@@ -281,6 +283,7 @@ class ROSLaunchRunner(object):
         self.is_rostest = is_rostest
         self.num_workers = num_workers
         self.timeout = timeout
+        self.close_sockets = close_sockets
         self.logger = logging.getLogger('roslaunch')
         self.pm = pmon or start_process_monitor()
 
@@ -394,7 +397,7 @@ class ROSLaunchRunner(object):
             validate_master_launch(m, self.is_core, self.is_rostest)
 
             printlog("auto-starting new master")
-            p = create_master_process(self.run_id, m.type, get_ros_root(), m.get_port(), self.num_workers, self.timeout)
+            p = create_master_process(self.run_id, m.type, get_ros_root(), m.get_port(), self.num_workers, self.timeout, self.close_sockets)
             self.pm.register_core_proc(p)
             success = p.start()
             if not success:

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -63,7 +63,7 @@ def _next_counter():
     _counter += 1
     return _counter
 
-def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None):
+def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None, close_sockets=False):
     """
     Launch a master
     @param type_: name of master executable (currently just Master.ZENMASTER)
@@ -76,12 +76,14 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
     @type  num_workers: int
     @param timeout: socket timeout for connections.
     @type  timeout: float
+    @param close_sockets: enable close CLOSE_WAIT sockets.
+    @type close_sockets: bool
     @raise RLException: if type_ or port is invalid
     """    
     if port < 1 or port > 65535:
         raise RLException("invalid port assignment: %s"%port)
 
-    _logger.info("create_master_process: %s, %s, %s, %s, %s", type_, ros_root, port, num_workers, timeout)
+    _logger.info("create_master_process: %s, %s, %s, %s, %s, %s", type_, ros_root, port, num_workers, timeout, close_sockets)
     # catkin/fuerte: no longer use ROS_ROOT-relative executables, search path instead
     master = type_
     # zenmaster is deprecated and aliased to rosmaster
@@ -90,6 +92,8 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
         args = [master, '--core', '-p', str(port), '-w', str(num_workers)]
         if timeout is not None:
             args += ['-t', str(timeout)]
+        if close_sockets:
+            args += ['--close-sockets']
     else:
         raise RLException("unknown master typ_: %s"%type_)
 

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -73,7 +73,8 @@ class ROSLaunchParent(object):
     """
 
     def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,
-            verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None):
+                 verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS,
+                 timeout=None, close_sockets=False):
         """
         @param run_id: UUID of roslaunch session
         @type  run_id: str
@@ -100,6 +101,8 @@ class ROSLaunchParent(object):
         @type num_workers: int
         @param timeout: If this is the core, the socket-timeout to use.
         @type timeout: Float or None
+        @param close_sockets: If this is the core, enable close CLOSE_WAIT sockets.
+        @type close_sockets: bool
         @throws RLException
         """
         
@@ -116,6 +119,7 @@ class ROSLaunchParent(object):
         self.verbose = verbose
         self.num_workers = num_workers
         self.timeout = timeout
+        self.close_sockets = close_sockets
 
         # I don't think we should have to pass in so many options from
         # the outside into the roslaunch parent. One possibility is to
@@ -152,7 +156,7 @@ class ROSLaunchParent(object):
             raise RLException("pm is not initialized")
         if self.server is None:
             raise RLException("server is not initialized")
-        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout)
+        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout, close_sockets=self.close_sockets)
 
         # print runner info to user, put errors last to make the more visible
         if self.is_core:

--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -42,6 +42,7 @@ import optparse
 
 import rosmaster.master
 from rosmaster.master_api import NUM_WORKERS
+from rosmaster.util import enable_close_sockets
 
 def configure_logging():
     """
@@ -71,6 +72,10 @@ def rosmaster_main(argv=sys.argv, stdout=sys.stdout, env=os.environ):
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
+    parser.add_option("--close-sockets",
+                      dest="close_sockets",
+                      action="store_true", default=False,
+                      help="enable checking and closing CLOSE_WAIT sockets.")
     options, args = parser.parse_args(argv[1:])
 
     # only arg that zenmaster supports is __log remapping of logfilename
@@ -78,7 +83,7 @@ def rosmaster_main(argv=sys.argv, stdout=sys.stdout, env=os.environ):
         if not arg.startswith('__log:='):
             parser.error("unrecognized arg: %s"%arg)
     configure_logging()   
-    
+
     port = rosmaster.master.DEFAULT_MASTER_PORT
     if options.port:
         port = int(options.port)
@@ -107,6 +112,9 @@ WARNING ACHTUNG WARNING ACHTUNG WARNING
         logger.info("Setting socket timeout to %s" % options.timeout)
         import socket
         socket.setdefaulttimeout(float(options.timeout))
+
+    if options.close_sockets:
+        enable_close_sockets()
 
     try:
         logger.info("Starting ROS Master Node")

--- a/tools/rosmaster/src/rosmaster/util.py
+++ b/tools/rosmaster/src/rosmaster/util.py
@@ -52,6 +52,8 @@ del monkey_patch
 import socket
 
 _proxies = {} #cache ServerProxys
+_enable_close_sockets = False  # call close_half_closed_sockets in xmlrpcapi
+
 def xmlrpcapi(uri):
     """
     @return: instance for calling remote server or None if not a valid URI
@@ -64,7 +66,14 @@ def xmlrpcapi(uri):
         return None
     if not uri in _proxies:
         _proxies[uri] = ServerProxy(uri)
+    if _enable_close_sockets:
+        close_half_closed_sockets()
     return _proxies[uri]
+
+
+def enable_close_sockets():
+    global _enable_close_sockets
+    _enable_close_sockets = True
 
 
 def close_half_closed_sockets():


### PR DESCRIPTION
Hi,

I'm having the same issue as in #610 and I found that some of the sockets in caches of ServerProxy([``_proxies``](https://github.com/ros/ros_comm/blob/lunar-devel/tools/rosmaster/src/rosmaster/util.py#L52)) are remained CLOSE_WAIT when a slave(xmlrpc server) close its port suddenly.
I added a function to close all the CLOSE_WAIT sockets in caches(f06bdf1), made it an option to call the function in ``xmlrpcapi`` (d3e7921) and added ``--close-sockets`` option to roscore(00d8f73).

I think calling the ``close_half_closed_sockets`` periodically is enough, but I couldn't find the right way so I call it in ``xmlrpcapi``.
I'm happy if closing CLOSE_WAIT sockets is enabled by default, could you review this and sugget a better way?

Thanks in advance.