### PR TITLE
[rospy] Improve rospy.logXXX_throttle performance

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -181,38 +181,37 @@ class LoggingThrottle(object):
 _logging_throttle = LoggingThrottle()
 
 
-def _frame_record_to_caller_id(frame_record):
-    frame, _, lineno, _, code, _ = frame_record
+def _frame_to_caller_id(frame):
     caller_id = (
         inspect.getabsfile(frame),
-        lineno,
+        frame.f_lineno,
         frame.f_lasti,
     )
     return pickle.dumps(caller_id)
 
 
 def logdebug_throttle(period, msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_throttle(caller_id, logdebug, period, msg)
 
 
 def loginfo_throttle(period, msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_throttle(caller_id, loginfo, period, msg)
 
 
 def logwarn_throttle(period, msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_throttle(caller_id, logwarn, period, msg)
 
 
 def logerr_throttle(period, msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_throttle(caller_id, logerr, period, msg)
 
 
 def logfatal_throttle(period, msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_throttle(caller_id, logfatal, period, msg)
 
 
@@ -230,27 +229,27 @@ _logging_once = LoggingOnce()
 
 
 def logdebug_once(msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_once(caller_id, logdebug, msg)
 
 
 def loginfo_once(msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_once(caller_id, loginfo, msg)
 
 
 def logwarn_once(msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_once(caller_id, logwarn, msg)
 
 
 def logerr_once(msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_once(caller_id, logerr, msg)
 
 
 def logfatal_once(msg):
-    caller_id = _frame_record_to_caller_id(inspect.stack()[1])
+    caller_id = _frame_to_caller_id(inspect.currentframe().f_back)
     _logging_once(caller_id, logfatal, msg)
 
 


### PR DESCRIPTION
Hello,

I found that the performance of ``rospy.logXXX_throttle`` gets even worse than normal ``rospy.logXXX`` when the stack is rather deep such as in a subscriber callback.
I've tested the following example

```python
#!/usr/bin/env python
from __future__ import print_function

import time
import rospy
import std_msgs.msg

total = 0.0
count = 0
def callback(data):
    global total, count
    start = time.time()
    # rospy.loginfo("test")               # normal rospy.logXXXX
    rospy.loginfo_throttle(1.0, "test")   # rospy.logXXXX_throttle
    total += time.time() - start
    count += 1

rospy.init_node("test", anonymous=True)
pub = rospy.Publisher("test", std_msgs.msg.String, queue_size=10)
sub = rospy.Subscriber("test", std_msgs.msg.String, callback)

while not rospy.is_shutdown():
    pub.publish("hello")
    rospy.sleep(0.01)

print("average={0}ms".format(total/count*1000.0))
```

and got the following result.

* rospy.logXXX: 0.60ms per call

```bash
[INFO] [WallTime: 1499434598.555137] test
[INFO] [WallTime: 1499434598.565363] test
[INFO] [WallTime: 1499434598.575602] test
[INFO] [WallTime: 1499434598.585872] test
^Caverage=0.599916740383ms
```

* rospy.logXXX_throttle: 0.99ms per call (even it is throttled)

```bash
[INFO] [WallTime: 1499434540.990035] test
[INFO] [WallTime: 1499434541.995128] test
[INFO] [WallTime: 1499434543.000947] test
^Caverage=0.985359591107ms
```

According to the [stakcoverflow](https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow), ``inspect.stack`` is an expensive function because it gathers all the frames and their contexts.
This PR changes the way to get the parent frame and improve its performance.

The final result is
* rospy.logXXX_throttle: 0.15ms per call

```bash
[INFO] [WallTime: 1499435067.096333] test
[INFO] [WallTime: 1499435068.101505] test
[INFO] [WallTime: 1499435069.107257] test
^Caverage=0.148712320531ms
```
