### PR TITLE
A fix to a critical stack buffer overflow vulnerability which leads to direct control flow hijacking

### DIFF
--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -225,29 +225,18 @@ void Bag::readVersion() {
 
     file_header_pos_ = file_.getOffset();
 
-    size_t version_line_len = version_line.length();
-
-    if(version_line_len == 0)
-        throw BagIOException("Error reading version line");
-
-    char * logtypename = (char *) malloc(version_line_len + 1);
-
-    if(logtypename == NULL)
-        throw BagIOException("Error reading version line");
-
+    char logtypename[100];
     int version_major, version_minor;
 #if defined(_MSC_VER)
     if (sscanf_s(version_line.c_str(), "#ROS%s V%d.%d", logtypename, sizeof(logtypename), &version_major, &version_minor) != 3)
 #else
-    if (sscanf(version_line.c_str(), "#ROS%s V%d.%d", logtypename, &version_major, &version_minor) != 3)
+    if (sscanf(version_line.c_str(), "#ROS%99s V%d.%d", logtypename, &version_major, &version_minor) != 3)
 #endif
         throw BagIOException("Error reading version line");
 
     version_ = version_major * 100 + version_minor;
 
     logDebug("Read VERSION: version=%d", version_);
-
-    free(logtypename);
 }
 
 uint32_t Bag::getMajorVersion() const { return version_ / 100; }

--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -225,7 +225,16 @@ void Bag::readVersion() {
 
     file_header_pos_ = file_.getOffset();
 
-    char logtypename[100];
+    size_t version_line_len = version_line.length();
+
+    if(version_line_len == 0)
+        throw BagIOException("Error reading version line");
+
+    char * logtypename = (char *) malloc(version_line_len + 1);
+
+    if(logtypename == NULL)
+        throw BagIOException("Error reading version line");
+
     int version_major, version_minor;
 #if defined(_MSC_VER)
     if (sscanf_s(version_line.c_str(), "#ROS%s V%d.%d", logtypename, sizeof(logtypename), &version_major, &version_minor) != 3)
@@ -237,6 +246,8 @@ void Bag::readVersion() {
     version_ = version_major * 100 + version_minor;
 
     logDebug("Read VERSION: version=%d", version_);
+
+    free(logtypename);
 }
 
 uint32_t Bag::getMajorVersion() const { return version_ / 100; }


### PR DESCRIPTION
Hi there, I find a stack buffer overflow in `Bag::readVersion`. When reading from malicious inputs, which contains an over-length log type name in the version line, the stack may be smashed and return address would be tampered. Attacker could hi-jack the system using a malicious input file.