### PR TITLE
Clean the namespace to get rid of double or trailing forward slashes …

### DIFF
--- a/clients/roscpp/src/libros/this_node.cpp
+++ b/clients/roscpp/src/libros/this_node.cpp
@@ -150,6 +150,7 @@ void ThisNode::init(const std::string& name, const M_string& remappings, uint32_
     : ("/" + namespace_)
     ;
 
+  namespace_ = names::clean(namespace_);
 
   std::string error;
   if (!names::validate(namespace_, error))

--- a/clients/roscpp/src/libros/this_node.cpp
+++ b/clients/roscpp/src/libros/this_node.cpp
@@ -145,12 +145,9 @@ void ThisNode::init(const std::string& name, const M_string& remappings, uint32_
     namespace_ = "/";
   }
 
-  namespace_ = (namespace_ == "/")
-    ? std::string("/") 
-    : ("/" + namespace_)
-    ;
-
   namespace_ = names::clean(namespace_);
+  if (namespace_ == "")
+    namespace_ = "/";
 
   std::string error;
   if (!names::validate(namespace_, error))

--- a/clients/roscpp/src/libros/this_node.cpp
+++ b/clients/roscpp/src/libros/this_node.cpp
@@ -140,14 +140,11 @@ void ThisNode::init(const std::string& name, const M_string& remappings, uint32_
     namespace_ = it->second;
   }
 
-  if (namespace_.empty())
-  {
-    namespace_ = "/";
-  }
-
   namespace_ = names::clean(namespace_);
-  if (namespace_ == "")
-    namespace_ = "/";
+  if (namespace_.empty() || (namespace_[0] != '/'))
+  {
+    namespace_ = "/" + namespace_;
+  }
 
   std::string error;
   if (!names::validate(namespace_, error))

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -39,6 +39,7 @@ Core roslaunch model and lower-level utility routines.
 import os
 import logging
 
+import re
 import socket
 import sys
 try:
@@ -456,6 +457,7 @@ class Node(object):
         self.type = node_type
         self.name = name or None
         self.namespace = rosgraph.names.make_global_ns(namespace or '/')
+        self.namespace = re.sub("//+", "/", self.namespace)
         self.machine_name = machine_name or None
         self.respawn = respawn
         self.respawn_delay = respawn_delay


### PR DESCRIPTION
…#1094

This cleans the namespace provided to this_node, getting rid of excess slashes ('//' becomes '/').