### PR TITLE
Add $(dirname) to get directory of current launch file.

### DIFF
--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -119,20 +119,20 @@ def _anon(resolved, a, args, context):
     anon_context = context['anon']
     return resolved.replace("$(%s)" % a, _eval_anon(id=args[0], anons=anon_context))
 
-def _eval_dir(filename):
+def _eval_dirname(filename):
     if not filename:
-        raise SubstitutionException("Cannot substitute $(dir), no file/directory information available.")
+        raise SubstitutionException("Cannot substitute $(dirname), no file/directory information available.")
     return os.path.abspath(os.path.dirname(filename))
 
-def _dir(resolved, a, args, context):
+def _dirname(resolved, a, args, context):
     """
-    process $(dir)
+    process $(dirname)
     @return: updated resolved argument
     @rtype: str
     @raise SubstitutionException: if no information about the current launch file is available, for example
            if XML was passed via stdin, or this is a remote launch.
     """
-    return resolved.replace("$(%s)" % a, _eval_dir(context.get('filename', None)))
+    return resolved.replace("$(%s)" % a, _eval_dirname(context.get('filename', None)))
 
 def _eval_find(pkg):
     rp = _get_rospack()
@@ -331,12 +331,12 @@ def _eval(s, context):
     def _eval_anon_context(id): return _eval_anon(id, anons=context['anon'])
     # inject arg context
     def _eval_arg_context(name): return convert_value(_eval_arg(name, args=context['arg']), 'auto')
-    # inject dir
-    def _eval_dir_context(): return _eval_dir(context['filename'])
+    # inject dirname context
+    def _eval_dirname_context(): return _eval_dirname(context['filename'])
     functions = {
         'anon': _eval_anon_context,
         'arg': _eval_arg_context,
-        'dir': _eval_dir_context
+        'dirname': _eval_dirname_context
     }
     functions.update(_eval_dict)
 
@@ -380,7 +380,7 @@ def resolve_args(arg_str, context=None, resolve_anon=True, filename=None):
     commands = {
         'env': _env,
         'optenv': _optenv,
-        'dir': _dir,
+        'dirname': _dirname,
         'anon': _anon,
         'arg': _arg,
     }
@@ -393,7 +393,7 @@ def resolve_args(arg_str, context=None, resolve_anon=True, filename=None):
     return resolved
 
 def _resolve_args(arg_str, context, resolve_anon, commands):
-    valid = ['find', 'env', 'optenv', 'dir', 'anon', 'arg']
+    valid = ['find', 'env', 'optenv', 'dirname', 'anon', 'arg']
     resolved = arg_str
     for a in _collect_args(arg_str):
         splits = [s for s in a.split(' ') if s]

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -180,6 +180,8 @@ class XmlLoader(loader.Loader):
         """
         # resolve_args gets called a lot, so we optimize by testing for dollar sign before resolving
         if args and '$' in args:
+            # Populate resolve_dict with name of the current file being processed.
+            context.resolve_dict['filename'] = context.filename
             return substitution_args.resolve_args(args, context=context.resolve_dict, resolve_anon=self.resolve_anon)
         else:
             return args

--- a/tools/roslaunch/test/unit/test_substitution_args.py
+++ b/tools/roslaunch/test/unit/test_substitution_args.py
@@ -96,7 +96,7 @@ def test_resolve_args():
 
     anon_context = {'foo': 'bar'}
     arg_context = {'fuga': 'hoge', 'car': 'cdr', 'arg': 'foo', 'True': 'False'}
-    context = {'anon': anon_context, 'arg': arg_context }
+    context = {'anon': anon_context, 'arg': arg_context, 'filename': '/path/to/file.launch'}
         
     tests = [
         ('$(find roslaunch)', roslaunch_dir),
@@ -119,6 +119,7 @@ def test_resolve_args():
         ('$(optenv NOT_ROS_ROOT)more stuff', 'more stuff'),
         ('$(optenv NOT_ROS_ROOT alternate)', 'alternate'),
         ('$(optenv NOT_ROS_ROOT alternate text)', 'alternate text'),
+        ('$(dirname)/foo', '/path/to/foo'),
 
         # #1776
         ('$(anon foo)', 'bar'),
@@ -177,6 +178,8 @@ def test_resolve_args():
         '$(optenv)',
         '$(anon)',
         '$(anon foo bar)',            
+        # Should fail without the supplied context.
+        '$(dirname)'
         ]
     for f in failures:
         try:

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -1064,3 +1064,18 @@ class TestXmlLoader(unittest.TestCase):
         #    self.fail('should have thrown an exception')
         #except roslaunch.xmlloader.XmlParseException:
         #    pass
+
+    # Test for $(dirname) behaviour across included files.
+    def test_dirname(self):
+        loader = roslaunch.xmlloader.XmlLoader()
+        filename = os.path.join(self.xml_dir, 'test-dirname.xml')
+
+        mock = RosLaunchMock()
+        loader.load(filename, mock)
+
+        param_d = {}
+        for p in mock.params:
+            param_d[p.key] = p.value
+
+        self.assertEquals(param_d['/foo'], self.xml_dir + '/bar')
+        self.assertEquals(param_d['/bar'], self.xml_dir + '/test-dirname/baz')

--- a/tools/roslaunch/test/xml/test-dirname.xml
+++ b/tools/roslaunch/test/xml/test-dirname.xml
@@ -1,0 +1,4 @@
+<launch>
+  <param name="foo" value="$(dirname)/bar" />
+  <include file="$(dirname)/test-dirname/included.xml" />
+</launch>

--- a/tools/roslaunch/test/xml/test-dirname/included.xml
+++ b/tools/roslaunch/test/xml/test-dirname/included.xml
@@ -1,0 +1,3 @@
+<launch>
+  <param name="bar" value="$(dirname)/baz" />
+</launch>


### PR DESCRIPTION
I'm working on adding some test coverage for this, but the basic idea for usage is allowing stuff like:

```
# test1.launch
<launch>
  <include file="$(dir)/baz/test2.launch" />
</launch>
```

```
# baz/test2.launch
<launch>
  <param name="foo" value="$(dir)/foo/bar" />
  <param name="bar" value="$(eval dir() + '/foo/bar')" />
</launch>
```

Where the output is:

```
$ cd /tmp
$ roslaunch ~/roslaunch_ws/test1.launch  --dump-params
{/bar: /Users/mikepurvis/roslaunch_ws/baz/foo/bar, /foo: /Users/mikepurvis/roslaunch_ws/baz/foo/bar}
```

Some possible use-cases for this:

- When including another launch file from within the same directory, stay DRY and don't repeat the package name everywhere as with `$(find)`— instead just `$(dir)/other.launch`.
- Using `eval` to make the a launch file do different things depending on where it's installed. For example `<node .... if="$(eval dir().startswith('/opt'))" />`
- For launch files which aren't part of packages. We use free-floating launch files as part of a configuration scheme on our robots, and we'd like them to be able to include yamls from their own directory.

FYI @guillaumeautran @Jin-Myung