### PR TITLE
[roscpp] add missing header for writev().

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -48,6 +48,9 @@
 #elif defined(__ANDROID__)
   // For readv() and writev() on ANDROID
   #include <sys/uio.h>
+#elif defined(_POSIX_VERSION)
+  // For readv() and writev()
+  #include <sys/uio.h>
 #endif
 
 namespace ros


### PR DESCRIPTION
After an update of gcc and glibc roscpp started to fail builds with the error:
```
    /home/rojkov/work/ros/build/tmp-glibc/work/i586-oe-linux/roscpp/1.11.21-r0/ros_comm-1.11.21/clients/roscpp/src/libros/transport/transport_udp.cpp:579:25: error: 'writev' was not declared in this scope
         ssize_t num_bytes = writev(sock_, iov, 2);
                             ^~~~~~
```
According to POSIX.1-2001 the function writev() is declared in sys/uio.h.

The patch includes the missing header for POSIX compliant systems.