### PR TITLE
Avoids buffer overflow in xmlrpcpp if fd > 1024

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -6,6 +6,7 @@
 #include <math.h>
 #include <errno.h>
 #include <sys/timeb.h>
+#include <stdexcept>
 #if defined (__ANDROID__)
 #include <sys/select.h>
 #endif
@@ -95,6 +96,10 @@ XmlRpcDispatch::work(double timeout)
     SourceList::iterator it;
     for (it=_sources.begin(); it!=_sources.end(); ++it) {
       int fd = it->getSource()->getfd();
+      if (fd >= FD_SETSIZE) {
+        _inWork = false;
+        throw std::runtime_error("XmlRpcDispatch::work: fd >= FD_SETSIZE limit, too many open files.");
+      }
       if (it->getMask() & ReadableEvent) FD_SET(fd, &inFd);
       if (it->getMask() & WritableEvent) FD_SET(fd, &outFd);
       if (it->getMask() & Exception)     FD_SET(fd, &excFd);


### PR DESCRIPTION
A temporary fix to avoid buffer overflow in XmlRpcDispatch, since select() only works for file descriptors < `FD_SETSIZE` (1024). If `fd >= FD_SETSIZE`, there is buffer overflow, memory corruption, and all-round undefined behaviour. The real solution is to switch to poll as in #833, but since that PR was reverted in #981, this avoids catastrophic failure until that can be worked out.

It throws an exception since:
- this behaviour is no less intrusive than a buffer overflow
- returning an XmlRpcError was handled silently, and just looked like ros comm not being connected 
- this is a temporary solution to fail in a more predictable way.