### PR TITLE
Remove preprended '|' from pretty-printed strings

### DIFF
--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -266,11 +266,7 @@ def _rosparam_cmd_get_param(param, pretty=False, verbose=False):
         if type(val) == dict:
             _pretty_print(val)
         else:
-            if '\n' in val:
-                for l in val.split('\n'):
-                    print('  '+l)
-            else:
-                print(val)
+            print(val)
     else:
         dump = yaml.dump(val)
         # #1617

--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -267,7 +267,6 @@ def _rosparam_cmd_get_param(param, pretty=False, verbose=False):
             _pretty_print(val)
         else:
             if '\n' in val:
-                print('|')
                 for l in val.split('\n'):
                     print('  '+l)
             else:


### PR DESCRIPTION
Calling:
`rosparam get -p /robot_description > robot.urdf`
results in a malformed URDF file because it contains a prepended `|` in the first line.
E.g.:
```
$ cat robot.urdf | head -n2
|
  <?xml version="1.0" ?>
```
What is the `|` used for?