### PR TITLE
roslaunch - pass through command-line args to the xmlloader when using the API

### DIFF
--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -413,8 +413,8 @@ def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None,
     roslaunch_files and or launch XML strings and initializing it. This
     config will have a core definition and also set the master to run
     on port.
-    @param roslaunch_files: list of launch files to load
-    @type  roslaunch_files: [str]
+    @param roslaunch_files: list of launch files to load. Launch files may optionally be tupled with list of args.
+    @type  roslaunch_files: [str|(str,[str])]
     @param port: roscore/master port override. Set to 0 or None to use default.
     @type  port: int
     @param roslaunch_strs: (optional) roslaunch XML strings to load

--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -413,7 +413,9 @@ def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None,
     roslaunch_files and or launch XML strings and initializing it. This
     config will have a core definition and also set the master to run
     on port.
-    @param roslaunch_files: list of launch files to load. Launch files may optionally be tupled with list of args.
+    @param roslaunch_files: list of launch files to load. Each item may also
+      be a tuple where the first item is the launch file and the second item
+      is a string containing arguments.
     @type  roslaunch_files: [str|(str,[str])]
     @param port: roscore/master port override. Set to 0 or None to use default.
     @type  port: int

--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -446,9 +446,13 @@ def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None,
 
     # load the roslaunch_files into the config
     for f in roslaunch_files:
+        if isinstance(f, tuple):
+            f, args = f
+        else:
+            args = None
         try:
             logger.info('loading config file %s'%f)
-            loader.load(f, config, verbose=verbose)
+            loader.load(f, config, argv=args, verbose=verbose)
         except roslaunch.xmlloader.XmlParseException as e:
             raise RLException(e)
         except roslaunch.loader.LoadException as e:

--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -416,7 +416,7 @@ def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None,
     @param roslaunch_files: list of launch files to load. Each item may also
       be a tuple where the first item is the launch file and the second item
       is a string containing arguments.
-    @type  roslaunch_files: [str|(str,[str])]
+    @type  roslaunch_files: [str|(str, str)]
     @param port: roscore/master port override. Set to 0 or None to use default.
     @type  port: int
     @param roslaunch_strs: (optional) roslaunch XML strings to load


### PR DESCRIPTION
Using the roslaunch API to manage multiple launch files, it seems logical that you would be able to specify `arg:=value` pairs; however, the [documentation](http://wiki.ros.org/roslaunch/API%20Usage) does not seem to hint that this is possible. After digging, it is indeed impossible in the current API to do so. This is due to the fact that there is no mechanism to pass any arguments to the XML loader from a ROSLaunchParent. The XML loader currently just looks at `sys.argv` for arguments. This is obviously fine for command-line usage, but breaks any usage from the API.

The way to do this is a question occasionally from users as it is natural to think it is possible:
  * http://answers.ros.org/question/237109/passing-arguments-to-launch-file-from-python-api/
  * http://answers.ros.org/question/198910/how-to-set-args-with-python-roslaunch/

**Simple usage examples.**
  * Single launch file with args:
```python
import roslaunch

uuid = roslaunch.rlutil.get_or_generate_uuid(None, False)
roslaunch.configure_logging(uuid)

cli_args = ['pkg', 'file.launch', 'arg1:=arg1', 'arg2:=arg2']
roslaunch_file = roslaunch.rlutil.resolve_launch_arguments(cli_args)
roslaunch_args = cli_args[2:]
parent = roslaunch.parent.ROSLaunchParent(uuid, roslaunch_file, roslaunch_args=[roslaunch_args])

parent.start()
```
  * Multiple launch files with args:
```python
import roslaunch

uuid = roslaunch.rlutil.get_or_generate_uuid(None, False)
roslaunch.configure_logging(uuid)

cli_args1 = ['pkg1', 'file1.launch', 'arg1:=arg1', 'arg2:=arg2']
cli_args2 = ['pkg2', 'file2.launch', 'arg1:=arg1', 'arg2:=arg2']
roslaunch_file1 = roslaunch.rlutil.resolve_launch_arguments(cli_args1)
roslaunch_args1 = cli_args1[2:]

roslaunch_file2 = roslaunch.rlutil.resolve_launch_arguments(cli_args2)
roslaunch_args2 = cli_args2[2:]

roslaunch_files = roslaunch_file1 + roslaunch_file2
roslaunch_args = [roslaunch_args1, roslaunch_args2]
parent = roslaunch.parent.ROSLaunchParent(uuid, roslaunch_files, roslaunch_args=roslaunch_args)

parent.start()
```