### PR TITLE
Improves the stability of SteadyTimerHelper.

### DIFF
--- a/test/test_roscpp/test/src/timer_callbacks.cpp
+++ b/test/test_roscpp/test/src/timer_callbacks.cpp
@@ -128,7 +128,7 @@ class SteadyTimerHelper
       else
       {
         // If this call was very delayed (beyond the next period), the timer will be
-        // scheduled to call back immediately (next expected is set to the current time)
+        // scheduled to call back immediately (next expected is set to the current time).
         expected_next_call_ = std::max(e.current_expected + expected_period_, start);
       }
 


### PR DESCRIPTION
Due to scheduling / resource contention, `sleep`s and `wait_until`s may be delayed. The `SteadyTimerHelper` test class was not robust to these delays, which was likely the cause of a failing test (`multipleSteadyTimeCallbacks` in `timer_callbacks.cpp`:220).