### PR TITLE
Upstream compatibility

### DIFF
--- a/tools/rostopic/test/check_rostopic_command_line_online.py
+++ b/tools/rostopic/test/check_rostopic_command_line_online.py
@@ -111,7 +111,7 @@ class TestRostopicOnline(unittest.TestCase):
             values = [n for n in values if n != '---']
             self.assertEquals(count, len(values), "wrong number of echos in output:\n"+str(values))
             for n in values:
-                self.assert_('data: hello world ' in n, n)
+                self.assert_('data: "hello world ' in n, n)
 
             if 0:
                 #bw

--- a/tools/rostopic/test/check_rostopic_command_line_online.py
+++ b/tools/rostopic/test/check_rostopic_command_line_online.py
@@ -111,7 +111,7 @@ class TestRostopicOnline(unittest.TestCase):
             values = [n for n in values if n != '---']
             self.assertEquals(count, len(values), "wrong number of echos in output:\n"+str(values))
             for n in values:
-                self.assert_('data: "hello world ' in n, n)
+                self.assert_('data: hello world ' in n, n)
 
             if 0:
                 #bw


### PR DESCRIPTION
There are a number of upstream changes that broke tests. This PR aims to get lunar-devel passing tests again so PRs aren't failing.
- ros/genpy#79 ros/roscpp_core#61 changed python stringification of messages, breaking a test.
- #1014 introduced timing-related stochastic test failures. Due to scheduling / resource contention, `sleep`s and `wait_until`s may be delayed. The `SteadyTimerHelper` test class was not robust to these delays, which was likely the cause of a failing test in #1113 (multipleSteadyTimeCallbacks in timer_callbacks.cpp:220), and forcing retests when #1014 was being considered.
- There is still another failing test, related to ros/roscpp_core#61, I haven't tracked that one down. Maintainers, feel free to add that fix to this branch before merging.