### PR TITLE
improve SteadyTimer tests

### DIFF
--- a/test/test_roscpp/test/src/timer_callbacks.cpp
+++ b/test/test_roscpp/test/src/timer_callbacks.cpp
@@ -78,9 +78,11 @@ class SteadyTimerHelper
 
       if (!first)
       {
-        if (fabsf(e.current_expected.toSec() - e.current_real.toSec()) > 0.1f)
+        double time_error = e.current_real.toSec() - e.current_expected.toSec();
+        // Strict check if called early, loose check if called late.
+        if (time_error > 0.2 || time_error < -0.01)
         {
-          ROS_ERROR("Call came at wrong time (%f vs. %f)", e.current_expected.toSec(), e.current_real.toSec());
+          ROS_ERROR("Call came at wrong time (expected: %f, actual %f)", e.current_expected.toSec(), e.current_real.toSec());
           failed_ = true;
         }
       }


### PR DESCRIPTION
Instead of checking when the callback was actually called, check for when it was added to the callback queue.
(Not sure why it was done differently in the WallTimer tests in the first place)...

If I understand things correctly this *should* make the test more reliable and be a better solution than #1118 
So if the tests fail because the callbacks in the queue are delayed, this should fix it (or at least be better). If the source of the sporadic test failures is that the thread actually sleeps too long, this doesn't change anything and thresholds might still need to be loosened up a bit like in #1118 or #1119 