### PR TITLE
Make RospyLogger.findCaller compatible with Python3 (also, unbreak ROS on Python3)

### DIFF
--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -49,12 +49,12 @@ from rospkg.environment import ROS_LOG_DIR
 class LoggingException(Exception): pass
 
 class RospyLogger(logging.getLoggerClass()):
-    def findCaller(self):
+    def findCaller(self, dummy=False): # Dummy second arg to match Python3 function declaration
         """
         Find the stack frame of the caller so that we can note the source
         file name, line number, and function name with class name if possible.
         """
-        file_name, lineno, func_name = super(RospyLogger, self).findCaller()
+        file_name, lineno, func_name = super(RospyLogger, self).findCaller()[:3]
 
         f = inspect.currentframe()
         if f is not None:
@@ -74,7 +74,10 @@ class RospyLogger(logging.getLoggerClass()):
             except KeyError:  # if the function is unbound, there is no self.
                 pass
             break
-        return file_name, lineno, func_name
+        if sys.version_info > (3, 2):
+            return file_name, lineno, func_name, None # Dummy last argument to match Python3 return type
+        else:
+            return file_name, lineno, func_name
 
 logging.setLoggerClass(RospyLogger)
 


### PR DESCRIPTION
Due to the change in #1043, ROS was broken on Python3. The findCaller function in Python3 logging module takes 2 arguments (including self) compared to only 1 (self) in Python2 and returns 4 values instead of 3 in Python2.

Without this patch, roscore doesn't even start:
```
$ roscore
... logging to /home/kartikmohta/.ros/log/30a1f112-78a5-11e7-bdaf-507b9d9f0576/roslaunch-nyx-23629.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

Traceback (most recent call last):
  File "/opt/ros/lunar_py3/lib/python3.6/site-packages/roslaunch/__init__.py", line 306, in main
    p.start()
  File "/opt/ros/lunar_py3/lib/python3.6/site-packages/roslaunch/parent.py", line 264, in start
    self.logger.info("starting roslaunch parent run")
  File "/usr/lib/python3.6/logging/__init__.py", line 1306, in info
    self._log(INFO, msg, args, **kwargs)
  File "/usr/lib/python3.6/logging/__init__.py", line 1430, in _log
    fn, lno, func, sinfo = self.findCaller(stack_info)
TypeError: findCaller() takes 1 positional argument but 2 were given
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python3.6/logging/__init__.py", line 1430, in _log
    fn, lno, func, sinfo = self.findCaller(stack_info)
TypeError: findCaller() takes 1 positional argument but 2 were given
```