### PR TITLE
fix minor memory leak

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -590,6 +590,7 @@ void shutdown()
     g_internal_queue_thread.join();
   }
 
+  delete g_rosout_appender;
   g_rosout_appender = 0;
 
   if (g_started)


### PR DESCRIPTION
when ros shutdowns, g_rosout_appender should be deleted first then set the pointer to be 0.