### PR TITLE
Fix rostopic hz and bw in Python 3

### DIFF
--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -426,9 +426,11 @@ class ROSTopicBandwidth(object):
         self.lock = threading.Lock()
         self.last_printed_tn = 0
         self.sizes =[]
-        self.times =[]        
-        self.window_size = window_size or 100
-                
+        self.times =[]
+        if window_size < 0:
+            window_size = 100
+        self.window_size = window_size
+
     def callback(self, data):
         """ros sub callback"""
         with self.lock:

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1528,7 +1528,7 @@ def _rostopic_cmd_bw(argv=sys.argv):
     from optparse import OptionParser
     parser = OptionParser(usage="usage: %prog bw /topic", prog=NAME)
     parser.add_option("-w", "--window",
-                      dest="window_size", default=None,
+                      dest="window_size", default=-1,
                       help="window size, in # of messages, for calculating rate", metavar="WINDOW")
     options, args = parser.parse_args(args)
     if len(args) == 0:

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -426,11 +426,9 @@ class ROSTopicBandwidth(object):
         self.lock = threading.Lock()
         self.last_printed_tn = 0
         self.sizes =[]
-        self.times =[]
-        if window_size < 0:
-            window_size = 100
-        self.window_size = window_size
-
+        self.times =[]        
+        self.window_size = window_size or 100
+                
     def callback(self, data):
         """ros sub callback"""
         with self.lock:

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1536,7 +1536,7 @@ def _rostopic_cmd_bw(argv=sys.argv):
     if len(args) > 1:
         parser.error("you may only specify one input topic")
     try:
-        window_size = int(options.window_size)
+        window_size = int(options.window_size) if options.window_size else None
     except:
         parser.error("window size must be an integer")
     topic = rosgraph.names.script_resolve_name('rostopic', args[0])

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1528,7 +1528,7 @@ def _rostopic_cmd_bw(argv=sys.argv):
     from optparse import OptionParser
     parser = OptionParser(usage="usage: %prog bw /topic", prog=NAME)
     parser.add_option("-w", "--window",
-                      dest="window_size", default=-1,
+                      dest="window_size", default=None,
                       help="window size, in # of messages, for calculating rate", metavar="WINDOW")
     options, args = parser.parse_args(args)
     if len(args) == 0:

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1488,11 +1488,7 @@ def _rostopic_cmd_hz(argv):
     if len(args) == 0:
         parser.error("topic must be specified")        
     try:
-        if options.window_size != -1:
-            import string
-            window_size = string.atoi(options.window_size)
-        else:
-            window_size = options.window_size
+        window_size = int(options.window_size)
     except:
         parser.error("window size must be an integer")
 
@@ -1540,11 +1536,7 @@ def _rostopic_cmd_bw(argv=sys.argv):
     if len(args) > 1:
         parser.error("you may only specify one input topic")
     try:
-        if options.window_size:
-            import string
-            window_size = string.atoi(options.window_size)
-        else:
-            window_size = options.window_size
+        window_size = int(options.window_size)
     except:
         parser.error("window size must be an integer")
     topic = rosgraph.names.script_resolve_name('rostopic', args[0])

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1536,7 +1536,7 @@ def _rostopic_cmd_bw(argv=sys.argv):
     if len(args) > 1:
         parser.error("you may only specify one input topic")
     try:
-        window_size = int(options.window_size) if options.window_size else None
+        window_size = int(options.window_size) if options.window_size is not None else None
     except:
         parser.error("window size must be an integer")
     topic = rosgraph.names.script_resolve_name('rostopic', args[0])


### PR DESCRIPTION
The window_size argument was converted to int using string.atoi but it's not present in Python3. Just use int(.) for both Python 2 & 3.