### PR TITLE
ignore headers with zero stamp in statistics

### DIFF
--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -100,7 +100,10 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
       std_msgs::Header header;
       ros::serialization::IStream stream(m.message_start, m.num_bytes - (m.message_start - m.buf.get()));
       ros::serialization::deserialize(stream, header);
-      stats.age_list.push_back(received_time - header.stamp);
+      if (!header.stamp.isZero())
+      {
+        stats.age_list.push_back(received_time - header.stamp);
+      }
     }
     catch (ros::serialization::StreamOverrunException& e)
     {


### PR DESCRIPTION
Fix [issue](http://build.ros.org/view/Ldev/job/Ldev__ros_comm__ubuntu_xenial_amd64/62/testReport/junit/rostest.runner/RosTest/teststamped_topic_statistics_with_empty_timestamp/) related to ros/roscpp_core#61.