### PR TITLE
add time when timer expired to timer events

### DIFF
--- a/clients/roscpp/include/ros/forwards.h
+++ b/clients/roscpp/include/ros/forwards.h
@@ -132,9 +132,11 @@ struct TimerEvent
 {
   Time last_expected;                     ///< In a perfect world, this is when the last callback should have happened
   Time last_real;                         ///< When the last callback actually happened
+  Time last_expired;                      ///< When the last timer actually expired and the callback was added to the queue
 
   Time current_expected;                  ///< In a perfect world, this is when the current callback should be happening
   Time current_real;                      ///< This is when the current callback was actually called (Time::now() as of the beginning of the callback)
+  Time current_expired;                   ///< When the current timer actually expired and the callback was added to the queue
 
   struct
   {
@@ -150,9 +152,11 @@ struct WallTimerEvent
 {
   WallTime last_expected;                 ///< In a perfect world, this is when the last callback should have happened
   WallTime last_real;                     ///< When the last callback actually happened
+  WallTime last_expired;                  ///< When the last timer actually expired and the callback was added to the queue
 
   WallTime current_expected;              ///< In a perfect world, this is when the current callback should be happening
   WallTime current_real;                  ///< This is when the current callback was actually called (Time::now() as of the beginning of the callback)
+  WallTime current_expired;               ///< When the current timer actually expired and the callback was added to the queue
 
   struct
   {
@@ -168,9 +172,11 @@ struct SteadyTimerEvent
 {
   SteadyTime last_expected;            ///< In a perfect world, this is when the last callback should have happened
   SteadyTime last_real;                ///< When the last callback actually happened
+  SteadyTime last_expired;             ///< When the last timer actually expired and the callback was added to the queue
 
   SteadyTime current_expected;         ///< In a perfect world, this is when the current callback should be happening
   SteadyTime current_real;             ///< This is when the current callback was actually called (SteadyTime::now() as of the beginning of the callback)
+  SteadyTime current_expired;          ///< When the current timer actually expired and the callback was added to the queue
 
   struct
   {

--- a/clients/roscpp/src/libros/steady_timer.cpp
+++ b/clients/roscpp/src/libros/steady_timer.cpp
@@ -71,7 +71,7 @@ void TimerManager<SteadyTime, WallDuration, SteadyTimerEvent>::threadFunc()
           current = SteadyTime::now();
 
           //ROS_DEBUG("Scheduling timer callback for timer [%d] of period [%f], [%f] off expected", info->handle, info->period.toSec(), (current - info->next_expected).toSec());
-          CallbackInterfacePtr cb(boost::make_shared<TimerQueueCallback>(this, info, info->last_expected, info->last_real, info->next_expected));
+          CallbackInterfacePtr cb(boost::make_shared<TimerQueueCallback>(this, info, info->last_expected, info->last_real, info->next_expected, info->last_expired, current));
           info->callback_queue->addCallback(cb, (uint64_t)info.get());
 
           waiting_.pop_front();

--- a/test/test_roscpp/test/src/timer_callbacks.cpp
+++ b/test/test_roscpp/test/src/timer_callbacks.cpp
@@ -74,16 +74,17 @@ class SteadyTimerHelper
     void callback(const SteadyTimerEvent& e)
     {
       bool first = last_call_.isZero();
-      last_call_ = e.current_real;
+      last_call_ = e.current_expired;
 
       if (!first)
       {
-        double time_error = e.current_real.toSec() - e.current_expected.toSec();
+        double time_error = e.current_expired.toSec() - e.current_expected.toSec();
         // Strict check if called early, loose check if called late.
         // Yes, this is very loose, but must pass in high-load, containerized/virtualized, contentious environments.
         if (time_error > 5.0 || time_error < -0.01)
         {
-          ROS_ERROR("Call came at wrong time (expected: %f, actual %f)", e.current_expected.toSec(), e.current_real.toSec());
+          ROS_ERROR("Call came at wrong time (expected: %f, expired: %f, callback: %f)",
+                    e.current_expected.toSec(), e.current_expired.toSec(), e.current_real.toSec());
           failed_ = true;
         }
       }
@@ -367,16 +368,17 @@ public:
   void callback(const WallTimerEvent& e)
   {
     bool first = last_call_.isZero();
-    last_call_ = e.current_real;
+    last_call_ = e.current_expired;
 
     if (!first)
     {
-      double time_error = e.current_real.toSec() - e.current_expected.toSec();
+      double time_error = e.current_expired.toSec() - e.current_expected.toSec();
       // Strict check if called early, loose check if called late.
       // Yes, this is very loose, but must pass in high-load, containerized/virtualized, contentious environments.
       if (time_error > 5.0 || time_error < -0.01)
       {
-        ROS_ERROR("Call came at wrong time (expected: %f, actual %f)", e.current_expected.toSec(), e.current_real.toSec());
+        ROS_ERROR("Call came at wrong time (expected: %f, expired: %f, callback: %f)",
+                  e.current_expected.toSec(), e.current_expired.toSec(), e.current_real.toSec());
         failed_ = true;
       }
     }


### PR DESCRIPTION
When the a timer expires, the callback is added to the queue.
So the callback is then then popped from the queue at some later point (for which the time is recored as current_real in the timer event).
This adds the time of when the timer actually expired to the timer event info,
in the hope that this will make debugging easier and provide a better base to test the timers.

I'm not really sure if it would be ok to add something to the timer events...
This is mainly meant as a base for discussion (see #1120 and #1129) and the possibility to test if the timer test can be improved using the `current_expired` time instead of `current_real`.