### PR TITLE
More tolerant and unified timer tests

### DIFF
--- a/test/test_roscpp/test/src/timer_callbacks.cpp
+++ b/test/test_roscpp/test/src/timer_callbacks.cpp
@@ -80,7 +80,8 @@ class SteadyTimerHelper
       {
         double time_error = e.current_real.toSec() - e.current_expected.toSec();
         // Strict check if called early, loose check if called late.
-        if (time_error > 0.5 || time_error < -0.01)
+        // Yes, this is very loose, but must pass in high-load, containerized/virtualized, contentious environments.
+        if (time_error > 5.0 || time_error < -0.01)
         {
           ROS_ERROR("Call came at wrong time (expected: %f, actual %f)", e.current_expected.toSec(), e.current_real.toSec());
           failed_ = true;
@@ -366,15 +367,16 @@ public:
   void callback(const WallTimerEvent& e)
   {
     bool first = last_call_.isZero();
-    WallTime last_call = last_call_;
-    last_call_ = WallTime::now();
-    WallTime start = last_call_;
+    last_call_ = e.current_real;
 
     if (!first)
     {
-      if (fabsf(expected_next_call_.toSec() - start.toSec()) > 0.1f)
+      double time_error = e.current_real.toSec() - e.current_expected.toSec();
+      // Strict check if called early, loose check if called late.
+      // Yes, this is very loose, but must pass in high-load, containerized/virtualized, contentious environments.
+      if (time_error > 5.0 || time_error < -0.01)
       {
-        ROS_ERROR("Call came at wrong time (%f vs. %f)", expected_next_call_.toSec(), start.toSec());
+        ROS_ERROR("Call came at wrong time (expected: %f, actual %f)", e.current_expected.toSec(), e.current_real.toSec());
         failed_ = true;
       }
     }
@@ -414,28 +416,12 @@ public:
         setPeriod(p, true);
       }
     }
-    else
-    { 
-      expected_next_call_ = e.current_expected + expected_period_;
-    }
-
-    WallTime end = WallTime::now();
-    last_duration_ = end - start;
 
     ++total_calls_;
   }
 
   void setPeriod(const WallDuration p, bool reset=false)
   {
-    if(reset)
-    {
-      expected_next_call_ = WallTime::now() + p;
-    }
-    else
-    {
-      expected_next_call_ = last_call_ + p;
-    }
-    
     timer_.setPeriod(p, reset);
     expected_period_ = p;
   }
@@ -448,9 +434,7 @@ public:
   }
 
   WallTime last_call_;
-  WallTime expected_next_call_;
   WallDuration expected_period_;
-  WallDuration last_duration_;
 
   bool failed_;
 


### PR DESCRIPTION
This is a proposed update to #1129 (not direct to devel). It:
- unifies `WallTimerHelper` with updates made to `SteadyTimerHelper`, and
- dramatically relaxes late checks for timer tests, since it was shown in #1129 that the checks are sensitive to high-load scheduling, and needed to be relaxed to avoid stochastic failures.