### PR TITLE
Removed deprecated dynamic exception specifications

### DIFF
--- a/tools/rosbag_storage/include/rosbag/bag_player.h
+++ b/tools/rosbag_storage/include/rosbag/bag_player.h
@@ -77,7 +77,7 @@ class BagPlayer
 {
 public:
   /* Constructor expecting the filename of a bag */
-  BagPlayer(const std::string &filename) throw(BagException);
+  BagPlayer(const std::string &filename);
 
   /* Register a callback for a specific topic and type */
   template<class T>

--- a/tools/rosbag_storage/src/bag_player.cpp
+++ b/tools/rosbag_storage/src/bag_player.cpp
@@ -5,7 +5,7 @@
 namespace rosbag
 {
 
-BagPlayer::BagPlayer(const std::string &fname) throw(BagException) {
+BagPlayer::BagPlayer(const std::string &fname) {
     bag.open(fname, rosbag::bagmode::Read);
     ros::Time::init();
     View v(bag);


### PR DESCRIPTION
```
.../ros_comm/tools/rosbag_storage/include/rosbag/bag_player.h:80:42: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
   BagPlayer(const std::string &filename) throw(BagException);
                                          ^~~~~
.../ros_comm/tools/rosbag_storage/src/bag_player.cpp:8:48: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
 BagPlayer::BagPlayer(const std::string &fname) throw(BagException) {
                                                ^~~~~
```

http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2010/n3051.html says it all:

>Exception specifications have proven close to worthless in practice, while adding a measurable overhead to programs. The feature should be deprecated. The one exception to the rule is the empty throw specification which could serve a legitimate optimizing role if the requirement to call the runtime unexpected mechanism was relaxed in this case.