### PR TITLE
Fix stack frame identification in rospy logging.

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -159,7 +159,7 @@ def _base_logger(msg, *args, **kwargs):
 
     if once:
         caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
-        if _logging_once(caller_id, throttle):
+        if _logging_once(caller_id):
             logfunc(msg, *args)
     elif throttle:
         caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -83,7 +83,7 @@ class RospyLogger(logging.getLoggerClass()):
             pass
 
         if sys.version_info > (3, 2):
-            # Dummy last argument to match Python3 return type.
+            # Dummy last argument to match Python3 return type
             return co.co_filename, f.f_lineno, func_name, None
         else:
             return co.co_filename, f.f_lineno, func_name

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -68,10 +68,10 @@ class RospyLogger(logging.getLoggerClass()):
             f = f.f_back
 
         # Jump up two more frames, as the logger methods have been double wrapped.
-        if f.f_back:
+        if f.f_back and f.f_code and f.f_code.co_name == '_base_logger':
             f = f.f_back
-        if f.f_back:
-            f = f.f_back
+            if f.f_back:
+                f = f.f_back
         co = f.f_code
         func_name = co.co_name
 


### PR DESCRIPTION
A possible solution to the issue introduced in #948.

Definitely hacky; should almost certainly be covered by some tests.

----

Manual verification was by means of the following trivial script:

```
import rospy

rospy.init_node('test')

r = rospy.Rate(10)
while not rospy.is_shutdown():
   rospy.loginfo('regular logging')
   rospy.loginfo_throttle(0.5, 'throttled logging')
   rospy.loginfo('named logging', logger_name='foobar')
   r.sleep()
```

Running this, I can `rostopic echo /rosout` and verify that all the `file:` fields point to this script name.

However, in the course of playing with this, I noted that the following does _not_ work:

```
rospy.loginfo('named throttled logging', logger_name='foobar', logger_throttle=0.5)
```

It crashes on account of the throttle code's assumption that the caller is two stack frames up, whereas in this case it is only one.

FYI @ggallagher01 