### PR TITLE
only use CLOCK_MONOTONIC if not on osx

### DIFF
--- a/clients/roscpp/src/libros/internal_timer_manager.cpp
+++ b/clients/roscpp/src/libros/internal_timer_manager.cpp
@@ -25,8 +25,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-// make sure we use CLOCK_MONOTONIC for the condition variable
+// Make sure we use CLOCK_MONOTONIC for the condition variable if not Apple.
+#ifndef __APPLE__
 #define BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
+#endif
 
 #include "ros/timer_manager.h"
 #include "ros/internal_timer_manager.h"

--- a/clients/roscpp/src/libros/steady_timer.cpp
+++ b/clients/roscpp/src/libros/steady_timer.cpp
@@ -25,8 +25,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-// make sure we use CLOCK_MONOTONIC for the condition variable
+// Make sure we use CLOCK_MONOTONIC for the condition variable if not Apple.
+#ifndef __APPLE__
 #define BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
+#endif
 
 #include "ros/steady_timer.h"
 #include "ros/timer_manager.h"


### PR DESCRIPTION
I'm not sure if this is the cleanest solution, but it resolves the following compilation error:
> /usr/local/include/boost/thread/pthread/condition_variable_fwd.hpp:42:13: error: use of undeclared identifier 'pthread_condattr_setclock'; did you mean 'pthread_condattr_setpshared'?
            pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
            ^~~~~~~~~~~~~~~~~~~~~~~~~
            pthread_condattr_setpshared
