### PR TITLE
Don't need to see the full stack trace for ResourceNotFound

### DIFF
--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -36,6 +36,7 @@ from __future__ import print_function
 
 import os
 import logging
+import rospkg
 import sys
 import traceback
 
@@ -315,6 +316,12 @@ def main(argv=sys.argv):
     except ValueError as e:
         # TODO: need to trap better than this high-level trap
         roslaunch_core.printerrlog(str(e))
+        roslaunch_core.printerrlog('The traceback for the exception was written to the log file')
+        if logger:
+            logger.error(traceback.format_exc())
+        sys.exit(1)
+    except rospkg.ResourceNotFound as e:
+        roslaunch_core.printerrlog("Resource not found: " + str(e))
         roslaunch_core.printerrlog('The traceback for the exception was written to the log file')
         if logger:
             logger.error(traceback.format_exc())

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -215,6 +215,13 @@ def _validate_args(parser, options, args):
     if len([x for x in [options.node_list, options.find_node, options.node_args, options.ros_args] if x]) > 1:
         parser.error("only one of [--nodes, --find-node, --args --ros-args] may be specified")
     
+def handle_exception(roslaunch_core, logger, msg, e):
+    roslaunch_core.printerrlog(msg + str(e))
+    roslaunch_core.printerrlog('The traceback for the exception was written to the log file')
+    if logger:
+        logger.error(traceback.format_exc())
+    sys.exit(1)
+
 def main(argv=sys.argv):
     options = None
     logger = None
@@ -308,24 +315,12 @@ def main(argv=sys.argv):
             p.spin()
 
     except RLException as e:
-        roslaunch_core.printerrlog(str(e))
-        roslaunch_core.printerrlog('The traceback for the exception was written to the log file')
-        if logger:
-            logger.error(traceback.format_exc())
-        sys.exit(1)
+        handle_exception(roslaunch_core, logger, "RLException: ", e)
     except ValueError as e:
         # TODO: need to trap better than this high-level trap
-        roslaunch_core.printerrlog(str(e))
-        roslaunch_core.printerrlog('The traceback for the exception was written to the log file')
-        if logger:
-            logger.error(traceback.format_exc())
-        sys.exit(1)
+        handle_exception(roslaunch_core, logger, "Value error: ", e)
     except rospkg.ResourceNotFound as e:
-        roslaunch_core.printerrlog("Resource not found: " + str(e))
-        roslaunch_core.printerrlog('The traceback for the exception was written to the log file')
-        if logger:
-            logger.error(traceback.format_exc())
-        sys.exit(1)
+        handle_exception(roslaunch_core, logger, "Resource not found: ", e)
     except Exception as e:
         traceback.print_exc()
         sys.exit(1)


### PR DESCRIPTION
The user typed in something wrong, or is missing a package, or hasn't sourced the right setup script.

The example that prompted this was using $(find package) where that package wasn't on the path:

```
<?xml version="1.0"?>
<launch>
  <param name="robot_description" command="$(find xacro)/xacro.py '$(find bad_package)/urdf/foo.xacro'" />
</launch>
```

The result is a screen full of traceback, followed by a screen full of ROS path output, the line that explains which package wasn't found was sandwiched in-between and is easy to miss.

This eliminates the traceback (but still a lot of ROS path with catkin tools with a workspace with a lot of packages).

Are there other exceptions that are similar that ought to be handled the same?

It would be nice to consolidate the duplicate code in ValueError and RLException above this.
