### PR TITLE
[kinetic-devel] Created public get_topic_list() function for use in other scripts.

### DIFF
--- a/tools/rostopic/test/test_rostopic.py
+++ b/tools/rostopic/test/test_rostopic.py
@@ -281,12 +281,19 @@ class TestRostopic(unittest.TestCase):
         # test main entry
         rostopic.rostopicmain([cmd, 'list'])
 
-        # test directly
+        # test through running command
         topics = ['/chatter', '/foo/chatter', '/bar/chatter', '/rosout', '/rosout_agg'] 
 
         with fakestdout() as b:
             rostopic.rostopicmain([cmd, 'list'])
             v = [x.strip() for x in b.getvalue().split('\n') if x.strip()]
+            self.failIf(set(topics)-set(v))
+
+        # test through public function
+        topics = ['/chatter', '/foo/chatter', '/bar/chatter', '/rosout', '/rosout_agg'] 
+
+        with fakestdout() as b:
+            v = rostopic.get_topic_list()
             self.failIf(set(topics)-set(v))
 
         # publishers-only


### PR DESCRIPTION
@dirk-thomas I determined that the issue with my previous pull request (#1146) was that the change was based on the lunar branch, rather than the branch I was developing the pull request for (kinetic). In my attempt to move the pull request to be based on kinetic-devel I accidentally butchered the old pull request.

The issues you referred to in the old pull request have been resolved, and running `rostopic list` functions fully as expected.

---

Resolves issue #946.

The only function in rostopic for listing the available topics is built exclusively for the command line interface; this adds a public function for other applications that want a list of topics.

Usage:
```
import rostopic
publishers, subscribers = rostopic.get_topic_list()
for topic, type, node_count in publishers:
    print("Publisher: %s, [%s] (%d nodes)" % (topic, type, node_count))
for topic, type, node_count in subscribers:
    print("Subscriber: %s, [%s] (%d nodes)" % (topic, type, node_count))
```