### PR TITLE
Created public get_topic_list() function for use in other scripts.

### DIFF
--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1119,41 +1119,58 @@ def _rostopic_list_bag(bag_file, topic=None):
                     break
 
 def _sub_rostopic_list(master, pubs, subs, publishers_only, subscribers_only, verbose, indent=''):
+    if verbose:
+        topic_types = _master_get_topic_types(master)
+
+        if not subscribers_only:
+            print("\n%sPublished topics:"%indent)
+            for t, y, l in pubs:
+                if len(l) > 1:
+                    print(indent+" * %s [%s] %s publishers"%(t, y, len(l)))
+                else:
+                    print(indent+" * %s [%s] 1 publisher"%(t, y))                    
+
+        if not publishers_only:
+            print(indent)
+            print(indent+"Subscribed topics:")
+            for t, y, l in subs:
+                if len(l) > 1:
+                    print(indent+" * %s [%s] %s subscribers"%(t, y, len(l)))
+                else:
+                    print(indent+" * %s [%s] 1 subscriber"%(t, y))
+        print('')
+    else:
+        if publishers_only:
+            topics = [t for t,_,_ in pubs]
+        elif subscribers_only:
+            topics = [t for t,_,_ in subs]
+        else:
+            topics = list(set([t for t,_,_ in pubs] + [t for t,_,_ in subs]))                
+        topics.sort()
+        print('\n'.join(["%s%s"%(indent, t) for t in topics]))
+
+def get_topic_list():
     def topic_type(t, topic_types):
         matches = [t_type for t_name, t_type in topic_types if t_name == t]
         if matches:
             return matches[0]
         return 'unknown type'
 
-    if verbose:
-        topic_types = _master_get_topic_types(master)
+    # Return an array of tuples; (<topic>, <type>, <node_count>)
+    master = rosgraph.Master('/rostopic')
+    state = master.getSystemState()
+    topic_types = _master_get_topic_types(master)
+    
+    pubs, subs, _ = state
+    pubs_out = []
+    for topic, nodes in pubs:
+        pubs_out.append((topic, topic_type(topic, topic_types), nodes))
+    subs_out = []
+    for topic, nodes in subs:
+        subs_out.append((topic, topic_type(topic, topic_types), nodes))
 
-        if not subscribers_only:
-            print("\n%sPublished topics:"%indent)
-            for t, l in pubs:
-                if len(l) > 1:
-                    print(indent+" * %s [%s] %s publishers"%(t, topic_type(t, topic_types), len(l)))
-                else:
-                    print(indent+" * %s [%s] 1 publisher"%(t, topic_type(t, topic_types)))                    
-
-        if not publishers_only:
-            print(indent)
-            print(indent+"Subscribed topics:")
-            for t,l in subs:
-                if len(l) > 1:
-                    print(indent+" * %s [%s] %s subscribers"%(t, topic_type(t, topic_types), len(l)))
-                else:
-                    print(indent+" * %s [%s] 1 subscriber"%(t, topic_type(t, topic_types)))
-        print('')
-    else:
-        if publishers_only:
-            topics = [t for t,_ in pubs]
-        elif subscribers_only:
-            topics = [t for t,_ in subs]
-        else:
-            topics = list(set([t for t,_ in pubs] + [t for t,_ in subs]))                
-        topics.sort()
-        print('\n'.join(["%s%s"%(indent, t) for t in topics]))
+    # List of published topics, list of subscribed topics.
+    return (pubs_out, subs_out)
 
 # #3145
 def _rostopic_list_group_by_host(master, pubs, subs):
@@ -1163,7 +1180,7 @@ def _rostopic_list_group_by_host(master, pubs, subs):
     """
     def build_map(master, state, uricache):
         tmap = {}
-        for topic, tnodes in state:
+        for topic, ttype, tnodes in state:
             for p in tnodes:
                 if not p in uricache:
                    uricache[p] = master.lookupNode(p)
@@ -1202,14 +1219,7 @@ def _rostopic_list(topic, verbose=False,
     
     master = rosgraph.Master('/rostopic')
     try:
-        state = master.getSystemState()
-
-        pubs, subs, _ = state
-        if topic:
-            # filter based on topic
-            topic_ns = rosgraph.names.make_global_ns(topic)        
-            subs = (x for x in subs if x[0] == topic or x[0].startswith(topic_ns))
-            pubs = (x for x in pubs if x[0] == topic or x[0].startswith(topic_ns))
+        pubs, subs = get_topic_list()
             
     except socket.error:
         raise ROSTopicIOException("Unable to communicate with master!")
@@ -1249,9 +1259,7 @@ def get_info_text(topic):
 
     master = rosgraph.Master('/rostopic')
     try:
-        state = master.getSystemState()
-
-        pubs, subs, _ = state
+        pubs, subs = get_topic_list()
         # filter based on topic
         subs = [x for x in subs if x[0] == topic]
         pubs = [x for x in pubs if x[0] == topic]

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1141,11 +1141,11 @@ def _sub_rostopic_list(master, pubs, subs, publishers_only, subscribers_only, ve
         print('')
     else:
         if publishers_only:
-            topics = [t for t,_,_ in pubs]
+            topics = [t for t, _, _ in pubs]
         elif subscribers_only:
-            topics = [t for t,_,_ in subs]
+            topics = [t for t, _, _ in subs]
         else:
-            topics = list(set([t for t,_,_ in pubs] + [t for t,_,_ in subs]))                
+            topics = list(set([t for t, _, _ in pubs] + [t for t, _, _ in subs]))                
         topics.sort()
         print('\n'.join(["%s%s"%(indent, t) for t in topics]))
 

--- a/tools/rostopic/test/test_rostopic.py
+++ b/tools/rostopic/test/test_rostopic.py
@@ -292,9 +292,8 @@ class TestRostopic(unittest.TestCase):
         # test through public function
         topics = ['/chatter', '/foo/chatter', '/bar/chatter', '/rosout', '/rosout_agg'] 
 
-        with fakestdout() as b:
-            v = rostopic.get_topic_list()
-            self.failIf(set(topics)-set(v))
+        v = rostopic.get_topic_list()
+        self.failIf(set(topics)-set(v))
 
         # publishers-only
         topics = ['/chatter', '/foo/chatter', '/bar/chatter', '/rosout', '/rosout_agg'] 

--- a/tools/rostopic/test/test_rostopic.py
+++ b/tools/rostopic/test/test_rostopic.py
@@ -281,12 +281,19 @@ class TestRostopic(unittest.TestCase):
         # test main entry
         rostopic.rostopicmain([cmd, 'list'])
 
-        # test directly
+        # test through running command
         topics = ['/chatter', '/foo/chatter', '/bar/chatter', '/rosout', '/rosout_agg'] 
 
         with fakestdout() as b:
             rostopic.rostopicmain([cmd, 'list'])
             v = [x.strip() for x in b.getvalue().split('\n') if x.strip()]
+            self.failIf(set(topics)-set(v))
+
+        # test through public function
+        topics = ['/chatter', '/foo/chatter', '/bar/chatter', '/rosout', '/rosout_agg'] 
+
+        with fakestdout() as b:
+            v = rostopic.get_topic_list()
             self.failIf(set(topics)-set(v))
 
         # publishers-only


### PR DESCRIPTION
A third pull request since #1146 required changes and #1151 was based on kinetic-devel. I would have reopened #1146 but I broke it or something.

Resolves issue #946.

The only function in rostopic for listing the available topics is built exclusively for the command line interface; this adds a public function for other applications that want a list of topics.

Usage:
```
import rostopic
publishers, subscribers = rostopic.get_topic_list()
for topic, type, nodes in publishers:
    print("Publisher: %s, [%s] (%d nodes)" % (topic, type, len(nodes)))
for topic, type, nodes in subscribers:
    print("Subscriber: %s, [%s] (%d nodes)" % (topic, type, len(nodes)))
```