### PR TITLE
add stealth mode for topic_tools/relay

### DIFF
--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -101,6 +101,7 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/throttle_simtime.test)
   add_rostest(test/drop.test)
   add_rostest(test/relay.test)
+  add_rostest(test/relay_stealth.test)
   add_rostest(test/lazy_transport.test)
   ## Latched test disabled until underlying issue in roscpp is resolved,
   ## #3385, #3434.

--- a/tools/topic_tools/test/relay_stealth.test
+++ b/tools/topic_tools/test/relay_stealth.test
@@ -1,0 +1,21 @@
+<launch>
+  <node name="topic_pub" pkg="rostopic" type="rostopic"
+	args="pub -r 10 /original_topic std_msgs/String foo" />
+  <node name="topic_relay" pkg="topic_tools" type="relay"
+	args="/original_topic /original_topic/relay">
+    <rosparam>
+      lazy: true
+    </rosparam>
+  </node>
+  <test test-name="test_relay_stealth"
+	pkg="topic_tools" type="test_relay_stealth.py" />
+
+  <node name="relay_stealth" pkg="topic_tools" type="relay"
+	args="/original_topic/relay /relay_stealth/output"
+	output="screen">
+    <rosparam>
+      stealth: true
+      monitor_topic: /original_topic/relay
+    </rosparam>
+  </node>
+</launch>

--- a/tools/topic_tools/test/test_relay_stealth.py
+++ b/tools/topic_tools/test/test_relay_stealth.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import rospy
+import unittest
+from std_msgs.msg import String
+
+
+class TestRelayStealth(unittest.TestCase):
+    def out_callback(self, msg):
+        self.out_msg_count += 1
+
+    def monitor_callback(self, msg):
+        self.monitor_msg_count += 1
+
+    def test_stealth_relay(self):
+        self.out_msg_count = 0
+        self.monitor_msg_count = 0
+        sub_out = rospy.Subscriber("/relay_stealth/output", String,
+                                   self.out_callback, queue_size=1)
+        for i in range(5):
+            if sub_out.get_num_connections() == 0:
+                rospy.sleep(1)
+        self.assertTrue(sub_out.get_num_connections() > 0)
+
+        rospy.sleep(5)
+        self.assertEqual(self.out_msg_count, 0)
+
+        sub_monitor = rospy.Subscriber("/original_topic/relay", String,
+                                       self.monitor_callback, queue_size=1)
+        rospy.sleep(5)
+        self.assertGreater(self.monitor_msg_count, 0)
+        self.assertGreater(self.out_msg_count, 0)
+
+        cnt = self.out_msg_count
+        sub_monitor.unregister()
+
+        rospy.sleep(3)
+        self.assertLess(abs(cnt - self.out_msg_count), 30)
+
+
+if __name__ == '__main__':
+    import rostest
+    rospy.init_node("test_relay_stealth")
+    rostest.rosrun("topic_tools", "test_relay_stealth", TestRelayStealth)


### PR DESCRIPTION
This PR is for adding "stealth mode" to `topic_tools/relay` node.
This is almost the same as a normal relay but it relays only if topic specified by param `~monitor_topic` is being subscribed by any other nodes except itself.

When input topic of relay and monitor topic are pointing to the same topic (this is by default), it looks like the relay node subscribes input topic only when other nodes also subscribe the input topic, which means subscribing without increment subscription count.

This feature is useful for publishing topic for visualization with lazy transport (c.f. https://github.com/ros/nodelet_core/blob/indigo-devel/nodelet_topic_tools/include/nodelet_topic_tools/nodelet_lazy.h ).
For example, lazy-transport-enabled nodes don't subscribe input topics unless other nodes subscribe the output topics of the nodes, but some nodes are expected to always subscribe topics (e.g. `RViZ`) and this breaks "laziness" of the nodes.
By putting `relay` node with stealth mode between `RViZ` and lazy node, this issue will be solved.