### PR TITLE
Fix publishing of selected topics from bag file

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -271,13 +271,13 @@ def play_cmd(argv):
     if options.topics or options.pause_topics:
         cmd.extend(['--bags'])
 
+    cmd.extend(args)
+
     if options.rate_control_topic:
         cmd.extend(['--rate-control-topic', str(options.rate_control_topic)])
 
     if options.rate_control_max_delay:
         cmd.extend(['--rate-control-max-delay', str(options.rate_control_max_delay)])
-
-    cmd.extend(args)
 
     old_handler = signal.signal(
         signal.SIGTERM,


### PR DESCRIPTION
Selecting a subset of topics to publish from a bag file is not working, seems to be a regression from d1d1711.
```
$ rosbag play --topics /tf test.bag
Usage: rosbag play BAGFILE1 [BAGFILE2 BAGFILE3 ...]
rosbag: error: You must specify at least 1 bag file to play back.
```
```
$ rosbag play test.bag --topics /tf
[ INFO] [1504144739.942816979]: Opening --rate-control-max-delay
[FATAL] [1504144739.943025646]: Error opening file: --rate-control-max-delay
```