### PR TITLE
[bug] fixes #1158

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -650,6 +650,7 @@ class XmlLoader(loader.Loader):
                 if ifunless_test(self, tag, context):
                     self._check_attrs(tag, context, ros_config, XmlLoader.GROUP_ATTRS)
                     child_ns = self._ns_clear_params_attr(name, tag, context, ros_config)
+                    child_ns.params = list(child_ns.params) # copy is needed here to enclose new params
                     default_machine = \
                         self._recurse_load(ros_config, tag.childNodes, child_ns, \
                                                default_machine, is_core, verbose)

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -370,6 +370,7 @@ class XmlLoader(loader.Loader):
                     
             child_ns = self._ns_clear_params_attr('node', tag, context, ros_config, node_name=name)
             param_ns = child_ns.child(name)
+            param_ns.params = [] # This is necessary because child() does not make a copy of the param list.
                 
             # required attributes
             pkg, node_type = self.reqd_attrs(tag, context, ('pkg', 'type'))

--- a/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
@@ -78,6 +78,7 @@ class TestDumpParams(unittest.TestCase):
             '/node_rosparam/dict1/knees': 3,
             '/node_rosparam/dict1/toes': 4,
             '/node_rosparam/tilde1': 'foo',
+            '/node_rosparam/local_param': 'baz',
 
             '/node_rosparam2/tilde1': 'foo',
 

--- a/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
@@ -77,6 +77,9 @@ class TestDumpParams(unittest.TestCase):
             '/node_rosparam/dict1/shoulders': 2,
             '/node_rosparam/dict1/knees': 3,
             '/node_rosparam/dict1/toes': 4,
+            '/node_rosparam/tilde1': 'foo',
+
+            '/node_rosparam2/tilde1': 'foo',
 
             '/inline_str': 'value1',
             '/inline_list': [1, 2, 3, 4],

--- a/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
@@ -103,3 +103,6 @@ class TestDumpParams(unittest.TestCase):
                 elif v != output_val[k]:
                     self.fail("key [%s] value [%s] does not match output: %s"%(k, v, output_val[k])) 
         self.assertEquals(val, output_val)
+        for k in ('/node_rosparam/tilde2', '/node_rosparam2/tilde2', '/node_rosparam2/local_param'):
+            if k in output_val:
+                self.fail("key [%s] should not be in output: %s"%(k, output_val))

--- a/tools/roslaunch/test/xml/test-dump-rosparam.launch
+++ b/tools/roslaunch/test/xml/test-dump-rosparam.launch
@@ -9,6 +9,7 @@
   </group>
 
   <node pkg="package" type="test_base" name="node_rosparam">
+    <param name="local_param" value="baz" />
     <rosparam file="$(find roslaunch)/test/dump-params.yaml" command="load" />      
   </node>
 

--- a/tools/roslaunch/test/xml/test-dump-rosparam.launch
+++ b/tools/roslaunch/test/xml/test-dump-rosparam.launch
@@ -1,13 +1,18 @@
 <launch>
 
+  <param name="~tilde1" value="foo" />
   <rosparam file="$(find roslaunch)/test/dump-params.yaml" command="load" />
   
   <group ns="rosparam">
+    <param name="~tilde2" value="bar" />
     <rosparam file="$(find roslaunch)/test/dump-params.yaml" command="load" />
   </group>
 
   <node pkg="package" type="test_base" name="node_rosparam">
     <rosparam file="$(find roslaunch)/test/dump-params.yaml" command="load" />      
+  </node>
+
+  <node pkg="package" type="test_base" name="node_rosparam2">
   </node>
 
   <rosparam param="inline_str">value1</rosparam>


### PR DESCRIPTION
XmlLoader and LoaderContext no longer share the param list to child 'node' contexts.
This was causing the creation of unintended private parameters when the tilde notation was used.