### PR TITLE
added execute argument to rosparam, to load the output of a command as yaml

### DIFF
--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -364,7 +364,7 @@ class Loader(object):
         else:
             ros_config.add_param(Param(param_name, param_value), verbose=verbose)
         
-    def load_rosparam(self, context, ros_config, cmd, param, file_, text, verbose=True):
+    def load_rosparam(self, context, ros_config, cmd, param, file_, execute, text, verbose=True):
         """
         Load rosparam setting
         
@@ -376,7 +376,9 @@ class Loader(object):
         @type  cmd: str
         @param file_: filename for rosparam to use or None
         @type  file_: str
-        @param text: text for rosparam to load. Ignored if file_ is set.
+        @param execute: command to execute for rosparam load or None
+        @type  execute: str
+        @param text: text for rosparam to load. Ignored if file_ or execute are set.
         @type  text: str
         @raise ValueError: if parameters cannot be processed into valid rosparam setting
         """
@@ -387,7 +389,12 @@ class Loader(object):
                 raise ValueError("file does not exist [%s]"%file_)
             if cmd == 'delete':
                 raise ValueError("'file' attribute is invalid with 'delete' command.")
-
+        elif execute is not None:
+            if cmd == 'delete':
+                raise ValueError("'execute' attribute is invalid with 'delete' command.")
+            if cmd == 'dump':
+                raise ValueError("'execute' attribute is invalid with 'dump' command.")
+ 
         full_param = ns_join(context.ns, param) if param else context.ns
 
         if cmd == 'dump':
@@ -399,6 +406,28 @@ class Loader(object):
             if file_:
                 with open(file_, 'r') as f:
                     text = f.read()
+            elif execute:
+                try:
+                    if type(execute) == unicode:
+                        execute = execute.encode('utf-8') #attempt to force to string for shlex/subprocess
+                except NameError:
+                    pass
+                if verbose:
+                    print("... executing command param [%s]" % execute)
+                import subprocess, shlex #shlex rocks
+                try:
+                    p = subprocess.Popen(shlex.split(execute), stdout=subprocess.PIPE)
+                    text = p.communicate()[0]
+                    if not isinstance(text, str):
+                        text = text.decode('utf-8')
+                    if p.returncode != 0:
+                        raise ValueError("Cannot load command parameter [%s]: command [%s] returned with code [%s]"%(name, execute, p.returncode))
+                except OSError as e:
+                    if e.errno == 2:
+                        raise ValueError("Cannot load command parameter [%s]: no such command [%s]"%(name, execute))
+                    raise
+                if text is None:
+                    raise ValueError("parameter: unable to get output of command [%s]"%execute)
                     
             # parse YAML text
             # - lazy import: we have to import rosparam in oder to to configure the YAML constructors

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -222,12 +222,12 @@ class XmlLoader(loader.Loader):
     # 'ns' attribute is now deprecated and is an alias for
     # 'param'. 'param' is required if the value is a non-dictionary
     # type
-    ROSPARAM_OPT_ATTRS = ('command', 'ns', 'file', 'param', 'subst_value')
+    ROSPARAM_OPT_ATTRS = ('command', 'ns', 'file', 'execute', 'param', 'subst_value')
     @ifunless
     def _rosparam_tag(self, tag, context, ros_config, verbose=True):
         try:
             self._check_attrs(tag, context, ros_config, XmlLoader.ROSPARAM_OPT_ATTRS)
-            cmd, ns, file, param, subst_value = self.opt_attrs(tag, context, (XmlLoader.ROSPARAM_OPT_ATTRS))
+            cmd, ns, file, execute, param, subst_value = self.opt_attrs(tag, context, (XmlLoader.ROSPARAM_OPT_ATTRS))
             subst_value = _bool_attr(subst_value, False, 'subst_value')
             # ns atribute is a bit out-moded and is only left in for backwards compatibility
             param = ns_join(ns or '', param or '')
@@ -237,7 +237,7 @@ class XmlLoader(loader.Loader):
             value = _get_text(tag)
             if subst_value:
                 value = self.resolve_args(value, context)
-            self.load_rosparam(context, ros_config, cmd, param, file, value, verbose=verbose)
+            self.load_rosparam(context, ros_config, cmd, param, file, execute, value, verbose=verbose)
 
         except ValueError as e:
             raise loader.LoadException("error loading <rosparam> tag: \n\t"+str(e)+"\nXML is %s"%tag.toxml())


### PR DESCRIPTION
This PR add a "execute" argument to <rosparam> tag of roslaunch files. This allows to load parameters from the output of a command, similar to the "command" attribute of <param> tag.

The command to be executed is specified by an argument called "execute", as argument "command" is already used to specify if parameters must be loaded/dumped/deleted.

"execute" argument will be ignored if "file" argument is set. 

The output of the executed command must be a valid yaml file, otherwise it is not loaded.
 
This PR is similar to #1045, but does not need to set an additional root name for the parameters loaded.

Check the attached example files:

```
$ cat $HOME/rosparam_example.yaml
parameter_1: hello
parameter_2: 2000
root_parameter:
  child_parameter_1: 1000
  child_parameter_2: child_2

$ cat $HOME/test_rosparam.launch 
<launch>
  <rosparam command="load" execute="cat $(env HOME)/rosparam_example.yaml" />
</launch>

$ roslaunch ./test_rosparam.launch 
... logging to /home/robotnik/.ros/log/7d6e0f1e-9fcc-11e7-b4fb-e4a7a00a8c8c/roslaunch-thorondor-17632.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
Done checking log file disk usage. Usage is <1GB.

started roslaunch server http://thorondor:43653/

SUMMARY
========

PARAMETERS
 * /parameter_1: hello
 * /parameter_2: 2000
 * /root_parameter/child_parameter_1: 1000
 * /root_parameter/child_parameter_2: child_2
 * /rosdistro: lunar
 * /rosversion: 1.13.2

$ rosparam dump 
parameter_1: hello
parameter_2: 2000
root_parameter: {child_parameter_1: 1000, child_parameter_2: child_2}
rosdistro: 'lunar'
```

