### PR TITLE
add -d option for 'rosmaster' to output LOG_API

### DIFF
--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -71,6 +71,10 @@ def rosmaster_main(argv=sys.argv, stdout=sys.stdout, env=os.environ):
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
+    parser.add_option("-d", "--debug",
+                      dest="debug", action="store_true", default=False,
+                      help="print debug information")
+
     options, args = parser.parse_args(argv[1:])
 
     # only arg that zenmaster supports is __log remapping of logfilename
@@ -82,6 +86,10 @@ def rosmaster_main(argv=sys.argv, stdout=sys.stdout, env=os.environ):
     port = rosmaster.master.DEFAULT_MASTER_PORT
     if options.port:
         port = int(options.port)
+
+    if options.debug:
+        rosmaster.master_api.LOG_API = True
+        logging.getLogger("rosmaster.master").setLevel(logging.DEBUG)
 
     if not options.core:
         print("""


### PR DESCRIPTION
Sometimes, we had seen the CPU Usage of `rosmaster` is quit high (more than 50%). Mostly, this because of calling service call multiple times, without using `persistent` or put `ServiceProxy` within the loop.
To find the node calling these services, enabling LOG_API is very helpful, but currently we do not have to modify source code at this moment ( https://github.com/ros/ros_comm/blob/lunar-devel/tools/rosmaster/src/rosmaster/master_api.py#L137 )
```
rosmaster --core -p 11311 -d __log:=rosmaster.log
tail -f rosmaster.log
```
I'm not sure if we should pass this option from `roscore` -> `roslaunch` -> `rosmaster` like https://github.com/ros/ros_comm/commit/08f6bf06fe4e68efbf6b2c13b558a4d5298d1a41#diff-8517d9bf19c03b642c67e5d937dae851

