### PR TITLE
Change rospy.Rate hz type description from int to float

### DIFF
--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -53,7 +53,7 @@ class Rate(object):
         """
         Constructor.
         @param hz: hz rate to determine sleeping
-        @type  hz: int
+        @type  hz: float
         @param reset: if True, timer is reset when rostime moved backward. [default: False]
         @type  reset: bool
         """


### PR DESCRIPTION
The rospy.Rate constructor can take a float `hz` param, even less that 1 (for rates, that are less frequent than 1 per second). I tested it, and it works OK.

Incorrect type description makes my IDE crazy.