### PR TITLE
rosnode: Return exit code 1 if there is an error.

### DIFF
--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -808,9 +808,12 @@ def rosnodemain(argv=None):
             _fullusage()
     except socket.error:
         print("Network communication failed. Most likely failed to communicate with master.", file=sys.stderr)
+        sys.exit(1)
     except rosgraph.MasterError as e:
         print("ERROR: "+str(e), file=sys.stderr)
+        sys.exit(1)
     except ROSNodeException as e:
         print("ERROR: "+str(e), file=sys.stderr)
+        sys.exit(1)
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
Return with exit code 1 if there is an error in the rosnode tool (e.g. because roscore is not running).
This resolves #1171.

I tested manually by calling `rosnode list` with both roscore running/not running and the result was good. I also ran `rostest rosnode rosnode.test` and `nosetests test_rosnode_command_offline.py`, both passed.
Please let me know in case I should do more testing (I do not know how to provoke other errors than roscore not running, though).

Since I only have a running workstation with Kinetic at the moment, I did the PR for kinetic-devel. What exactly is the policy here? I guess when this is accepted, it should also be merged into lunar-devel.