### PR TITLE
rosconsole: replaced 'while(0)' by 'while(false)' in ros/assert.h and ros/console.h

### DIFF
--- a/tools/rosconsole/include/ros/assert.h
+++ b/tools/rosconsole/include/ros/assert.h
@@ -117,7 +117,7 @@
   do { \
     ROS_FATAL("BREAKPOINT HIT\n\tfile = %s\n\tline=%d\n", __FILE__, __LINE__); \
     ROS_ISSUE_BREAK() \
-  } while (0)
+  } while (false)
 
 #define ROS_ASSERT(cond) \
   do { \
@@ -125,7 +125,7 @@
       ROS_FATAL("ASSERTION FAILED\n\tfile = %s\n\tline = %d\n\tcond = %s\n", __FILE__, __LINE__, #cond); \
       ROS_ISSUE_BREAK() \
     } \
-  } while (0)
+  } while (false)
 
 #define ROS_ASSERT_MSG(cond, ...) \
   do { \
@@ -135,14 +135,14 @@
       ROS_FATAL("\n"); \
       ROS_ISSUE_BREAK(); \
     } \
-  } while (0)
+  } while (false)
 
 #define ROS_ASSERT_CMD(cond, cmd) \
   do { \
     if (!(cond)) { \
       cmd; \
     } \
-  } while (0)
+  } while (false)
 
 
 #else

--- a/tools/rosconsole/include/ros/console.h
+++ b/tools/rosconsole/include/ros/console.h
@@ -326,7 +326,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
     { \
       ::ros::console::initialize(); \
     } \
-  } while(0)
+  } while(false)
 
 #define ROSCONSOLE_DEFINE_LOCATION(cond, level, name) \
   ROSCONSOLE_AUTOINIT; \
@@ -378,7 +378,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
     { \
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
     } \
-  } while(0)
+  } while(false)
 
 /**
  * \brief Log to a given named logger at a given verbosity level, only if a given condition has been met, with stream-style formatting
@@ -397,7 +397,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
     { \
       ROSCONSOLE_PRINT_STREAM_AT_LOCATION(args); \
     } \
-  } while(0)
+  } while(false)
 
 /**
  * \brief Log to a given named logger at a given verbosity level, only the first time it is hit when enabled, with printf-style formatting
@@ -415,7 +415,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
       hit = true; \
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
     } \
-  } while(0)
+  } while(false)
 
 // inside a macro which uses args use only well namespaced variable names in order to not overlay variables coming in via args
 /**
@@ -434,7 +434,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
       __ros_log_stream_once__hit__ = true; \
       ROSCONSOLE_PRINT_STREAM_AT_LOCATION(args); \
     } \
-  } while(0)
+  } while(false)
 
 /**
  * \brief Log to a given named logger at a given verbosity level, limited to a specific rate of printing, with printf-style formatting
@@ -454,7 +454,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
       last_hit = now.toSec(); \
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
     } \
-  } while(0)
+  } while(false)
 
 // inside a macro which uses args use only well namespaced variable names in order to not overlay variables coming in via args
 /**
@@ -475,7 +475,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
       __ros_log_stream_throttle__last_hit__ = __ros_log_stream_throttle__now__.toSec(); \
       ROSCONSOLE_PRINT_STREAM_AT_LOCATION(args); \
     } \
-  } while(0)
+  } while(false)
 
 /**
  * \brief Log to a given named logger at a given verbosity level, limited to a specific rate of printing, with printf-style formatting
@@ -495,7 +495,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
       __ros_log_delayed_throttle__last_hit__ = __ros_log_delayed_throttle__now__.toSec(); \
       ROSCONSOLE_PRINT_AT_LOCATION(__VA_ARGS__); \
     } \
-  } while(0)
+  } while(false)
 
 // inside a macro which uses args use only well namespaced variable names in order to not overlay variables coming in via args
 /**
@@ -516,7 +516,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
       __ros_log_stream_delayed_throttle__last_hit__ = __ros_log_stream_delayed_throttle__now__.toSec(); \
       ROSCONSOLE_PRINT_STREAM_AT_LOCATION(args); \
     } \
-  } while(0)
+  } while(false)
 
 /**
  * \brief Log to a given named logger at a given verbosity level, with user-defined filtering, with printf-style formatting
@@ -533,7 +533,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
     { \
       ROSCONSOLE_PRINT_AT_LOCATION_WITH_FILTER(filter, __VA_ARGS__); \
     } \
-  } while(0)
+  } while(false)
 
 /**
  * \brief Log to a given named logger at a given verbosity level, with user-defined filtering, with stream-style formatting
@@ -550,7 +550,7 @@ ROSCONSOLE_DECL std::string formatToString(const char* fmt, ...);
     { \
       ROSCONSOLE_PRINT_STREAM_AT_LOCATION_WITH_FILTER(filter, args); \
     } \
-  } while(0)
+  } while(false)
 
 /**
  * \brief Log to a given named logger at a given verbosity level, with printf-style formatting


### PR DESCRIPTION
to avoid clang-tidys modernize-use-bool-literals warnings.