### PR TITLE
add --set-master-logger-level option for 'rosmaster' to output LOG_API

### DIFF
--- a/tools/roslaunch/scripts/roscore
+++ b/tools/roslaunch/scripts/roscore
@@ -56,6 +56,9 @@ def _get_optparse():
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
+    parser.add_option("--set-master-logger-level",
+                      dest="master_logger_level", default=False, type=str,
+                      help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
     return parser
 
 

--- a/tools/roslaunch/scripts/roscore
+++ b/tools/roslaunch/scripts/roscore
@@ -56,7 +56,7 @@ def _get_optparse():
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
-    parser.add_option("--set-master-logger-level",
+    parser.add_option("--master-logger-level",
                       dest="master_logger_level", default=False, type=str,
                       help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
     return parser

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -181,6 +181,9 @@ def _get_optparse():
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds). Only valid for core services.", metavar="TIMEOUT")
+    parser.add_option("--set-master-logger-level",
+                      dest="master_logger_level", default=False, type=str,
+                      help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
 
     return parser
     
@@ -310,7 +313,8 @@ def main(argv=sys.argv):
             p = roslaunch_parent.ROSLaunchParent(uuid, args, roslaunch_strs=roslaunch_strs,
                     is_core=options.core, port=options.port, local_only=options.local_only,
                     verbose=options.verbose, force_screen=options.force_screen,
-                    num_workers=options.num_workers, timeout=options.timeout)
+                    num_workers=options.num_workers, timeout=options.timeout,
+                    master_logger_level=options.master_logger_level)
             p.start()
             p.spin()
 

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -181,7 +181,7 @@ def _get_optparse():
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds). Only valid for core services.", metavar="TIMEOUT")
-    parser.add_option("--set-master-logger-level",
+    parser.add_option("--master-logger-level",
                       dest="master_logger_level", default=False, type=str,
                       help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
 

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -400,7 +400,9 @@ class ROSLaunchRunner(object):
             validate_master_launch(m, self.is_core, self.is_rostest)
 
             printlog("auto-starting new master")
-            p = create_master_process(self.run_id, m.type, get_ros_root(), m.get_port(), self.num_workers, self.timeout, self.master_logger_level)
+            p = create_master_process(
+                self.run_id, m.type, get_ros_root(), m.get_port(), self.num_workers,
+                self.timeout, master_logger_level=self.master_logger_level)
             self.pm.register_core_proc(p)
             success = p.start()
             if not success:

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -235,7 +235,7 @@ class ROSLaunchRunner(object):
     monitored.
     """
     
-    def __init__(self, run_id, config, server_uri=None, pmon=None, is_core=False, remote_runner=None, is_child=False, is_rostest=False, num_workers=NUM_WORKERS, timeout=None):
+    def __init__(self, run_id, config, server_uri=None, pmon=None, is_core=False, remote_runner=None, is_child=False, is_rostest=False, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
         """
         @param run_id: /run_id for this launch. If the core is not
             running, this value will be used to initialize /run_id. If
@@ -264,6 +264,8 @@ class ROSLaunchRunner(object):
         @type num_workers: int
         @param timeout: If this is the core, the socket-timeout to use.
         @type timeout: Float or None
+        @param master_logger_level: Specify roscore's rosmaster.master logger level, use default if it is False.
+        @type master_logger_level: str or False
         """
         if run_id is None:
             raise RLException("run_id is None")
@@ -281,6 +283,7 @@ class ROSLaunchRunner(object):
         self.is_rostest = is_rostest
         self.num_workers = num_workers
         self.timeout = timeout
+        self.master_logger_level = master_logger_level
         self.logger = logging.getLogger('roslaunch')
         self.pm = pmon or start_process_monitor()
 
@@ -397,7 +400,7 @@ class ROSLaunchRunner(object):
             validate_master_launch(m, self.is_core, self.is_rostest)
 
             printlog("auto-starting new master")
-            p = create_master_process(self.run_id, m.type, get_ros_root(), m.get_port(), self.num_workers, self.timeout)
+            p = create_master_process(self.run_id, m.type, get_ros_root(), m.get_port(), self.num_workers, self.timeout, self.master_logger_level)
             self.pm.register_core_proc(p)
             success = p.start()
             if not success:

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -89,7 +89,7 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
     # zenmaster is deprecated and aliased to rosmaster
     if type_ in [Master.ROSMASTER, Master.ZENMASTER]:        
         package = 'rosmaster'        
-        args = [master, '--core', '-p', str(port), '-w', str(num_workers), '--set-master-logger-level', str(master_logger_level)]
+        args = [master, '--core', '-p', str(port), '-w', str(num_workers), '--master-logger-level', str(master_logger_level)]
         if timeout is not None:
             args += ['-t', str(timeout)]
     else:

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -63,7 +63,7 @@ def _next_counter():
     _counter += 1
     return _counter
 
-def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None):
+def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
     """
     Launch a master
     @param type_: name of master executable (currently just Master.ZENMASTER)
@@ -77,17 +77,19 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
     @param timeout: socket timeout for connections.
     @type  timeout: float
     @raise RLException: if type_ or port is invalid
+    @param master_logger_level: rosmaster.master logger debug level
+    @type  master_logger_level=: str or False
     """    
     if port < 1 or port > 65535:
         raise RLException("invalid port assignment: %s"%port)
 
-    _logger.info("create_master_process: %s, %s, %s, %s, %s", type_, ros_root, port, num_workers, timeout)
+    _logger.info("create_master_process: %s, %s, %s, %s, %s, %s", type_, ros_root, port, num_workers, timeout, master_logger_level)
     # catkin/fuerte: no longer use ROS_ROOT-relative executables, search path instead
     master = type_
     # zenmaster is deprecated and aliased to rosmaster
     if type_ in [Master.ROSMASTER, Master.ZENMASTER]:        
         package = 'rosmaster'        
-        args = [master, '--core', '-p', str(port), '-w', str(num_workers)]
+        args = [master, '--core', '-p', str(port), '-w', str(num_workers), '--set-master-logger-level', str(master_logger_level)]
         if timeout is not None:
             args += ['-t', str(timeout)]
     else:

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -92,7 +92,7 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
         args = [master, '--core', '-p', str(port), '-w', str(num_workers)]
         if timeout is not None:
             args += ['-t', str(timeout)]
-        if master_logger_level is not False:
+        if master_logger_level:
             args += ['--master-logger-level', str(master_logger_level)]
     else:
         raise RLException("unknown master typ_: %s"%type_)

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -89,9 +89,11 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
     # zenmaster is deprecated and aliased to rosmaster
     if type_ in [Master.ROSMASTER, Master.ZENMASTER]:        
         package = 'rosmaster'        
-        args = [master, '--core', '-p', str(port), '-w', str(num_workers), '--master-logger-level', str(master_logger_level)]
+        args = [master, '--core', '-p', str(port), '-w', str(num_workers)]
         if timeout is not None:
             args += ['-t', str(timeout)]
+        if master_logger_level is not False:
+            args += ['--master-logger-level', str(master_logger_level)]
     else:
         raise RLException("unknown master typ_: %s"%type_)
 

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -73,7 +73,7 @@ class ROSLaunchParent(object):
     """
 
     def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,
-            verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None):
+            verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
         """
         @param run_id: UUID of roslaunch session
         @type  run_id: str
@@ -101,6 +101,8 @@ class ROSLaunchParent(object):
         @param timeout: If this is the core, the socket-timeout to use.
         @type timeout: Float or None
         @throws RLException
+        @param master_logger_level: Specify roscore's rosmaster.master logger level, use default if it is False.
+        @type master_logger_level: str or False
         """
         
         self.logger = logging.getLogger('roslaunch.parent')
@@ -116,6 +118,7 @@ class ROSLaunchParent(object):
         self.verbose = verbose
         self.num_workers = num_workers
         self.timeout = timeout
+        self.master_logger_level = master_logger_level
 
         # I don't think we should have to pass in so many options from
         # the outside into the roslaunch parent. One possibility is to
@@ -152,7 +155,7 @@ class ROSLaunchParent(object):
             raise RLException("pm is not initialized")
         if self.server is None:
             raise RLException("server is not initialized")
-        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout)
+        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout,master_logger_level=self.master_logger_level)
 
         # print runner info to user, put errors last to make the more visible
         if self.is_core:

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -155,7 +155,7 @@ class ROSLaunchParent(object):
             raise RLException("pm is not initialized")
         if self.server is None:
             raise RLException("server is not initialized")
-        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout,master_logger_level=self.master_logger_level)
+        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout, master_logger_level=self.master_logger_level)
 
         # print runner info to user, put errors last to make the more visible
         if self.is_core:

--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -118,7 +118,7 @@ WARNING ACHTUNG WARNING ACHTUNG WARNING
             logger.info("set rosmaster.master logger level '{}'".format(options.master_logger_level))
             logging.getLogger("rosmaster.master").setLevel(levels[options.master_logger_level.lower()])
         else:
-            logger.error("--master-logger-level received unkonwn option '{}'".format(options.master_logger_level))
+            logger.error("--master-logger-level received unknown option '{}'".format(options.master_logger_level))
 
     try:
         logger.info("Starting ROS Master Node")

--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -113,10 +113,10 @@ WARNING ACHTUNG WARNING ACHTUNG WARNING
         socket.setdefaulttimeout(float(options.timeout))
 
     if options.master_logger_level:
-        level = {'debug': logging.DEBUG, 'info': logging.INFO, 'warn': logging.WARN, 'error': logging.ERROR, 'fatal': logging.FATAL}
-        if options.master_logger_level in level.keys():
+        levels = {'debug': logging.DEBUG, 'info': logging.INFO, 'warn': logging.WARN, 'error': logging.ERROR, 'fatal': logging.FATAL}
+        if options.master_logger_level in levels.keys():
             logger.info("set rosmaster.master logger level '{}'".format(options.master_logger_level))
-            logging.getLogger("rosmaster.master").setLevel(level[options.master_logger_level])
+            logging.getLogger("rosmaster.master").setLevel(levels[options.master_logger_level])
         else:
             logger.error("--master-logger-level received unkonwn option '{}'".format(options.master_logger_level))
 

--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -71,7 +71,7 @@ def rosmaster_main(argv=sys.argv, stdout=sys.stdout, env=os.environ):
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
-    parser.add_option("--set-master-logger-level",
+    parser.add_option("--master-logger-level",
                       dest="master_logger_level", default=False, type=str,
                       help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
 
@@ -118,7 +118,7 @@ WARNING ACHTUNG WARNING ACHTUNG WARNING
             logger.info("set rosmaster.master logger level '{}'".format(options.master_logger_level))
             logging.getLogger("rosmaster.master").setLevel(level[options.master_logger_level])
         else:
-            logger.error("--set-master-logger-level received unkonwn option '{}'".format(options.master_logger_level))
+            logger.error("--master-logger-level received unkonwn option '{}'".format(options.master_logger_level))
 
     try:
         logger.info("Starting ROS Master Node")

--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -116,6 +116,7 @@ WARNING ACHTUNG WARNING ACHTUNG WARNING
         levels = {'debug': logging.DEBUG, 'info': logging.INFO, 'warn': logging.WARN, 'error': logging.ERROR, 'fatal': logging.FATAL}
         if options.master_logger_level.lower() in levels.keys():
             logger.info("set rosmaster.master logger level '{}'".format(options.master_logger_level))
+            rosmaster.master_api.LOG_API = True
             logging.getLogger("rosmaster.master").setLevel(levels[options.master_logger_level.lower()])
         else:
             logger.error("--master-logger-level received unknown option '{}'".format(options.master_logger_level))

--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -114,9 +114,9 @@ WARNING ACHTUNG WARNING ACHTUNG WARNING
 
     if options.master_logger_level:
         levels = {'debug': logging.DEBUG, 'info': logging.INFO, 'warn': logging.WARN, 'error': logging.ERROR, 'fatal': logging.FATAL}
-        if options.master_logger_level in levels.keys():
+        if options.master_logger_level.lower() in levels.keys():
             logger.info("set rosmaster.master logger level '{}'".format(options.master_logger_level))
-            logging.getLogger("rosmaster.master").setLevel(levels[options.master_logger_level])
+            logging.getLogger("rosmaster.master").setLevel(levels[options.master_logger_level.lower()])
         else:
             logger.error("--master-logger-level received unkonwn option '{}'".format(options.master_logger_level))
 

--- a/tools/rosmaster/src/rosmaster/main.py
+++ b/tools/rosmaster/src/rosmaster/main.py
@@ -71,6 +71,10 @@ def rosmaster_main(argv=sys.argv, stdout=sys.stdout, env=os.environ):
     parser.add_option("-t", "--timeout",
                       dest="timeout",
                       help="override the socket connection timeout (in seconds).", metavar="TIMEOUT")
+    parser.add_option("--set-master-logger-level",
+                      dest="master_logger_level", default=False, type=str,
+                      help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
+
     options, args = parser.parse_args(argv[1:])
 
     # only arg that zenmaster supports is __log remapping of logfilename
@@ -107,6 +111,14 @@ WARNING ACHTUNG WARNING ACHTUNG WARNING
         logger.info("Setting socket timeout to %s" % options.timeout)
         import socket
         socket.setdefaulttimeout(float(options.timeout))
+
+    if options.master_logger_level:
+        level = {'debug': logging.DEBUG, 'info': logging.INFO, 'warn': logging.WARN, 'error': logging.ERROR, 'fatal': logging.FATAL}
+        if options.master_logger_level in level.keys():
+            logger.info("set rosmaster.master logger level '{}'".format(options.master_logger_level))
+            logging.getLogger("rosmaster.master").setLevel(level[options.master_logger_level])
+        else:
+            logger.error("--set-master-logger-level received unkonwn option '{}'".format(options.master_logger_level))
 
     try:
         logger.info("Starting ROS Master Node")


### PR DESCRIPTION
extended version of #1173 
```
$ roscore --master-logger-level debug
$ tail -f ${HOME}/.ros/log/latest/master.log 
```
will output LOG_API messages