### PR TITLE
rosbag: Fixed parameters being sometimes interpreted as bags

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -267,17 +267,17 @@ def play_cmd(argv):
     if options.pause_topics:
         cmd.extend(['--pause-topics'] + options.pause_topics)
 
-    # prevent bag files to be passed as --topics or --pause-topics
-    if options.topics or options.pause_topics:
-        cmd.extend(['--bags'])
-
-    cmd.extend(args)
-
     if options.rate_control_topic:
         cmd.extend(['--rate-control-topic', str(options.rate_control_topic)])
 
     if options.rate_control_max_delay:
         cmd.extend(['--rate-control-max-delay', str(options.rate_control_max_delay)])
+
+    # prevent bag files to be passed as --topics or --pause-topics
+    if options.topics or options.pause_topics:
+        cmd.extend(['--bags'])
+
+    cmd.extend(args)
 
     old_handler = signal.signal(
         signal.SIGTERM,


### PR DESCRIPTION
--rate-control-topic and --rate-control-topic-max-delay where being
added between --bags and the actual bag names, causing these parameters
to be interpreted as bag names as well.

I added a `print(cmd)` to demonstrate the parameter placement:

---
Current:
```
rosbag play *.bag --clock --topics  /topic_a /topic_b
['/opt/ros/lunar/lib/rosbag/play', '--clock', '--hz', '100', '--queue', '100', '--rate', '1.0', '--delay', '0.2', '--start', '0.0', '--topics', '/topic_a', '/topic_b', '--bags', '--rate-control-max-delay', '1.0', 'a.bag', 'b.bag']
[ INFO] [1507733536.137724128] [/play_1507733536128627639]: Opening --rate-control-max-delay
[FATAL] [1507733536.137904876] [/play_1507733536128627639]: Error opening file: --rate-control-max-delay
```
---
After fix:
```
rosbag play *.bag --clock --topics  /topic_a /topic_b
['/opt/ros/lunar/lib/rosbag/play', '--clock', '--hz', '100', '--queue', '100', '--rate', '1.0', '--delay', '0.2', '--start', '0.0', '--topics', '/topic_a', '/topic_b', '--rate-control-max-delay', '1.0', '--bags', 'a.bag', 'b.bag']
[ INFO] [1507733590.064799417] [/play_1507733590055977230]: Opening a.bag
[ INFO] [1507733590.138103723] [/play_1507733590055977230]: Opening b.bag
```