### PR TITLE
Fixed an out of bounds read in void rosbag::View::iterator::increment()

### DIFF
--- a/tools/rosbag_storage/src/view.cpp
+++ b/tools/rosbag_storage/src/view.cpp
@@ -136,7 +136,7 @@ void View::iterator::increment() {
     {
         std::multiset<IndexEntry>::const_iterator last_iter = iters_.back().iter;
     
-        while (iters_.back().iter == last_iter)
+        while (!iters_.empty() && iters_.back().iter == last_iter)
         {
             iters_.back().iter++;
             if (iters_.back().iter == iters_.back().range->end)


### PR DESCRIPTION
- Only triggered if reduce_overlap_ = true
- When iters_.size() == 1 and iters_.pop_back() gets called in the loop,
  the next loop condition check would read from iters_.back(), but
  iters_ would be empty by then.

See https://github.com/ros/ros_comm/issues/1176#issuecomment-337029676