### PR TITLE
Fixed corrupted messages when reopening a rosbag with a different file (#1176)

### DIFF
--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -180,6 +180,8 @@ void Bag::close() {
     chunks_.clear();
     connection_indexes_.clear();
     curr_chunk_connection_indexes_.clear();
+
+    init();
 }
 
 void Bag::closeWrite() {

--- a/tools/rosbag_storage/src/chunked_file.cpp
+++ b/tools/rosbag_storage/src/chunked_file.cpp
@@ -148,6 +148,8 @@ void ChunkedFile::close() {
     filename_.clear();
     
     clearUnused();
+    offset_ = 0;
+    compressed_in_ = 0;
 }
 
 // Read/write modes


### PR DESCRIPTION
* Cleaned up more state in Bag::close() and ChunkedFile::close()
* It was not investigated how exactly the bug worked

I kept #1188 as-is to demonstrate the failing test. (I think I remember that the CI only builds the latest commit in a pull-request, right?)