### PR TITLE
[roslaunch-check] Use roslaunch.core.printerrlog for printing error message.

### DIFF
--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -38,6 +38,7 @@ import sys
 
 import rospkg
 
+import roslaunch
 import roslaunch.rlutil
 import rosunit
 
@@ -116,7 +117,7 @@ if __name__ == '__main__':
             message = "roslaunch check [%s] failed"%(roslaunch_path)
             f.write(rosunit.junitxml.test_failure_junit_xml(test_name, message, stdout=error_msg,
                     class_name="roslaunch.RoslaunchCheck", testcase_name="%s_%s" % (pkg, outname)))
-        print("wrote test file to [%s]"%test_file)
+        roslaunch.core.printerrlog("wrote test file to [%s]"%test_file)
         sys.exit(1)
     else:
         print("passed")

--- a/tools/roslaunch/src/roslaunch/rlutil.py
+++ b/tools/roslaunch/src/roslaunch/rlutil.py
@@ -219,10 +219,10 @@ def check_roslaunch(f, use_test_depends=False):
             print(e, file=sys.stderr)
             miss_all = True
         if miss_all:
-            print("Missing package dependencies: %s/package.xml: %s"%(pkg, ', '.join(miss)), file=sys.stderr)
+            roslaunch.core.printerrlog("Missing package dependencies: %s/package.xml: %s"%(pkg, ', '.join(miss)), file=sys.stderr)
             errors.append("Missing package dependencies: %s/package.xml: %s"%(pkg, ', '.join(miss)))
         elif miss:
-            print("Missing package dependencies: %s/package.xml: %s (notify upstream maintainer)"%(pkg, ', '.join(miss)), file=sys.stderr)
+            roslaunch.core.printerrlog("Missing package dependencies: %s/package.xml: %s (notify upstream maintainer)"%(pkg, ', '.join(miss)), file=sys.stderr)
     
     # load all node defs
     nodes = []


### PR DESCRIPTION
Errors are printed without much stress, which makes hard to find the specific error occurred.