### PR TITLE
Static-cast unused parameters in TransportTCP.

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -186,7 +186,7 @@ void TransportTCP::setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint
       ROS_DEBUG("setsockopt failed to set TCP_KEEPIDLE on socket [%d] [%s]", sock_, cached_remote_host_.c_str());
     }
 #else
-    static_cast<void>(idle);
+    (void)idle;
 #endif
 
 #if defined(SOL_TCP) && defined(TCP_KEEPINTVL)
@@ -196,7 +196,7 @@ void TransportTCP::setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint
       ROS_DEBUG("setsockopt failed to set TCP_KEEPINTVL on socket [%d] [%s]", sock_, cached_remote_host_.c_str());
     }
 #else
-    static_cast<void>(interval);
+    (void)interval;
 #endif
 
 #if defined(SOL_TCP) && defined(TCP_KEEPCNT)
@@ -206,7 +206,7 @@ void TransportTCP::setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint
       ROS_DEBUG("setsockopt failed to set TCP_KEEPCNT on socket [%d] [%s]", sock_, cached_remote_host_.c_str());
     }
 #else
-    static_cast<void>(count);
+    (void)count;
 #endif
   }
   else

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -185,6 +185,8 @@ void TransportTCP::setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint
     {
       ROS_DEBUG("setsockopt failed to set TCP_KEEPIDLE on socket [%d] [%s]", sock_, cached_remote_host_.c_str());
     }
+#else
+    static_cast<void>(idle);
 #endif
 
 #if defined(SOL_TCP) && defined(TCP_KEEPINTVL)
@@ -193,6 +195,8 @@ void TransportTCP::setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint
     {
       ROS_DEBUG("setsockopt failed to set TCP_KEEPINTVL on socket [%d] [%s]", sock_, cached_remote_host_.c_str());
     }
+#else
+    static_cast<void>(interval);
 #endif
 
 #if defined(SOL_TCP) && defined(TCP_KEEPCNT)
@@ -201,6 +205,8 @@ void TransportTCP::setKeepAlive(bool use, uint32_t idle, uint32_t interval, uint
     {
       ROS_DEBUG("setsockopt failed to set TCP_KEEPCNT on socket [%d] [%s]", sock_, cached_remote_host_.c_str());
     }
+#else
+    static_cast<void>(count);
 #endif
   }
   else


### PR DESCRIPTION
Silences some warnings under macOS.