### PR TITLE
Fix CMake Error: xmlrpcvalue_base64 not built by..

### DIFF
--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -1,2 +1,4 @@
 catkin_add_gtest(xmlrpcvalue_base64 xmlrpcvalue_base64.cpp)
-target_link_libraries(xmlrpcvalue_base64 xmlrpcpp)
+if(TARGET xmlrpcvalue_base64)
+  target_link_libraries(xmlrpcvalue_base64 xmlrpcpp)
+endif()


### PR DESCRIPTION
Error occurs when using ```catkin build``` or ```catkin_make_isolated --install```.
catkin_make_isolated didn't complain without the ```--install``` option.

```
CMake Error at .../xmlrpcpp/test/CMakeLists.txt:2 (target_link_libraries):
  Cannot specify link libraries for target "xmlrpcvalue_base64" which is not
  built by this project.
```

NOTE: I am running an unsupported distribution, openSUSE Tumbleweed. I checked other packages and saw the gtests were linked similarly and surrounded with an if-statement.