### PR TITLE
TOPIC TOOLS: add initial_topic param

### DIFF
--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -103,6 +103,8 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/relay.test)
   add_rostest(test/relay_stealth.test)
   add_rostest(test/lazy_transport.test)
+  add_rostest(test/mux_initial_none.test)
+  add_rostest(test/mux_initial_other.test)
   ## Latched test disabled until underlying issue in roscpp is resolved,
   ## #3385, #3434.
   #rosbuild_add_rostest(test/relay_latched.test)

--- a/tools/topic_tools/test/mux_initial_none.test
+++ b/tools/topic_tools/test/mux_initial_none.test
@@ -1,0 +1,20 @@
+<launch>
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub1"
+        args="pub -r 10 input1 std_msgs/String input1"/>
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub2"
+        args="pub -r 5 input2 std_msgs/String input2"/>
+
+  <!-- Initial topic is __none -->
+  <node pkg="topic_tools" type="mux" name="mux_initial_none" output="screen"
+        args="output input1 input2">
+    <param name="initial_topic" value="__none" />
+  </node>
+
+  <!-- Test that mux initially has no input because initial_topic param is set to __none -->
+  <test test-name="mux_initial_topic_none_test" pkg="rostest" type="hztest">
+    <param name="topic" value="output"/>
+    <param name="hz" value="0"/>
+    <param name="hzerror" value="0"/>
+    <param name="test_duration" value="1.0" />
+  </test>
+</launch>

--- a/tools/topic_tools/test/mux_initial_other.test
+++ b/tools/topic_tools/test/mux_initial_other.test
@@ -1,0 +1,21 @@
+<launch>
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub1"
+        args="pub -r 10 input1 std_msgs/String input1"/>
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub2"
+        args="pub -r 5 input2 std_msgs/String input2"/>
+
+  <!-- Initial topic non default -->
+  <node pkg="topic_tools" type="mux" name="mux_explicit" output="screen"
+        args="output input1 input2">
+    <param name="initial_topic" value="input2" />
+  </node>
+
+  <!-- Test that initialy mux chooses input2 as specified in param -->
+  <test test-name="mux_hztest_explicit" pkg="rostest" type="hztest">
+    <param name="topic" value="output"/>
+    <param name="hz" value="5.0"/>
+    <param name="hzerror" value="0.5"/>
+    <param name="test_duration" value="1.0" />
+  </test>
+
+</launch>


### PR DESCRIPTION
On a ROS-based robot my lab works on, we use topic_tools/mux to manage potential wrenches from the autonomous controller, an xbox controller, and an rf based controller. We need the option to, on startup, have none of these inputs selected (for safety), so that we have to explicitly select one before anything will move. To do this we mux, we needed to use a dummy topic. 

This adds an optional private parameter to mux, "initial_topic" which will set the input topic the mux will use on startup. Additionally, it can be set to "__none" for no initial topic. If the param is not set, the default behavior or choosing the first input in the arguments is used.