### PR TITLE
Check if async connect() is success before read() or wirte() in TransportTCP

### DIFF
--- a/clients/roscpp/include/ros/io.h
+++ b/clients/roscpp/include/ros/io.h
@@ -143,9 +143,11 @@ namespace ros {
 *****************************************************************************/
 
 ROSCPP_DECL int last_socket_error();
+ROSCPP_DECL const char* socket_error_string(int err);
 ROSCPP_DECL const char* last_socket_error_string();
 ROSCPP_DECL bool last_socket_error_is_would_block();
 ROSCPP_DECL int poll_sockets(socket_pollfd *fds, nfds_t nfds, int timeout);
+ROSCPP_DECL int is_async_connected(socket_fd_t &socket, int &err);
 ROSCPP_DECL int set_non_blocking(socket_fd_t &socket);
 ROSCPP_DECL int close_socket(socket_fd_t &socket);
 ROSCPP_DECL int create_signal_pair(signal_fd_t signal_pair[2]);

--- a/clients/roscpp/include/ros/transport/transport_tcp.h
+++ b/clients/roscpp/include/ros/transport/transport_tcp.h
@@ -140,6 +140,7 @@ private:
   void socketUpdate(int events);
 
   socket_fd_t sock_;
+  bool async_connected_;
   bool closed_;
   boost::recursive_mutex close_mutex_;
 

--- a/clients/roscpp/src/libros/io.cpp
+++ b/clients/roscpp/src/libros/io.cpp
@@ -37,6 +37,7 @@
 
 #include <ros/io.h>
 #include <ros/assert.h> // don't need if we dont call the pipe functions.
+#include <ros/file_log.h>
 #include <errno.h> // for EFAULT and co.
 #include <iostream>
 #include <sstream>
@@ -59,15 +60,24 @@ int last_socket_error() {
 		return errno;
 	#endif
 }
+
+const char* socket_error_string(int err) {
+#ifdef WIN32
+    // could fix this to use FORMAT_MESSAGE and print a real string later,
+    // but not high priority.
+    std::stringstream ostream;
+    ostream << "WSA Error: " << err;
+    return ostream.str().c_str();
+#else
+    return strerror(err);
+#endif
+}
+
 const char* last_socket_error_string() {
 	#ifdef WIN32
-		// could fix this to use FORMAT_MESSAGE and print a real string later,
-		// but not high priority.
-		std::stringstream ostream;
-		ostream << "WSA Error: " << WSAGetLastError();
-		return ostream.str().c_str();
+        return socket_error_string(WSAGetLastError());
 	#else
-		return strerror(errno);
+        return socket_error_string(errno);
 	#endif
 }
 
@@ -230,6 +240,100 @@ int poll_sockets(socket_pollfd *fds, nfds_t nfds, int timeout) {
 /*****************************************************************************
 ** Socket Utilities
 *****************************************************************************/
+/**
+ * Checks if the async socket connection is success, failure or connecting.
+ * @param err - WSAGetLastError()/errno on failure.
+ * @return int : 1 on connected, 0 on connecting, -1 on failure.
+ */
+int is_async_connected(socket_fd_t &socket, int &err) {
+    // use zero-timeout select to check if async socket
+    fd_set wfds, exceptfds;
+    FD_ZERO(&wfds);
+    FD_ZERO(&exceptfds);
+    FD_SET(socket, &wfds);
+    FD_SET(socket, &exceptfds);
+    struct timeval tv;
+    tv.tv_sec = 0;
+    tv.tv_usec = 0;
+    int ret = select(socket + 1, NULL, &wfds, &exceptfds, &tv);
+    if (ret == -1)
+    {
+      // select() error
+      ROSCPP_CONN_LOG_DEBUG("select() on socket[%d] failed with error [%s]",
+                            socket, last_socket_error_string());
+      err = last_socket_error();
+      return -1;
+    }
+    else if (ret == 0)
+    {
+      // select() timeout, socket is still connecting
+      err = 0;
+      return 0;
+    }
+    // select() fake wakeup?
+    ROS_ASSERT(FD_ISSET(socket, &wfds) || FD_ISSET(socket, &exceptfds));
+
+    // check connection is success or failure
+#ifdef WIN32
+    // In Windows:
+    //    Success is reported in the writefds set and failure is reported in the exceptfds set.
+    //    If failure, we must then call getsockopt SO_ERROR to determine the error value to describe why the failure occurred
+    ROS_ASSERT((FD_ISSET(socket, &wfds) && !FD_ISSET(socket, &exceptfds)) ||
+               (!FD_ISSET(socket, &wfds) && FD_ISSET(socket, &exceptfds)));
+    if (FD_ISSET(socket, &exceptfds)) {
+      // an error occurred during connection
+      int errinfo;
+      socklen_t errlen = sizeof(int);
+      if (getsockopt(socket, SOL_SOCKET, SO_ERROR, &errinfo, &errlen) == -1)
+      {
+        // getsockopt() error
+        ROSCPP_CONN_LOG_DEBUG("getsockopt() on socket[%d] failed with error [%s]",
+                              socket, last_socket_error_string());
+        err = last_socket_error();
+        return -1;
+      }
+      ROS_ASSERT(errlen == sizeof(int));
+      ROS_ASSERT(errinfo != 0);
+      ROSCPP_CONN_LOG_DEBUG("Async connect on socket[%d] failed with error [%s]",
+                            socket, socket_error_string(errinfo));
+      err = errinfo;
+      return -1;
+    }
+#else
+    // In Linux:
+    //    Both success and failure is reported in the writefds set.
+    //    We must use getsockopt() to read the SO_ERROR option at level SOL_SOCKET to determine whether
+    //    connect() completed successfully (SO_ERROR is zero) or unsuccessfully (SO_ERROR is error code).
+    if (!FD_ISSET(socket, &wfds)) {
+      // wfds is not set, socket is still connecting
+      err = 0;
+      return 0;
+    }
+    // use getsockopt() to check connection is success or failure
+    int errinfo;
+    socklen_t errlen = sizeof(int);
+    if (getsockopt(socket, SOL_SOCKET, SO_ERROR, &errinfo, &errlen) == -1)
+    {
+      // getsockopt() error
+      ROSCPP_CONN_LOG_DEBUG("getsockopt() on socket[%d] failed with error [%s]",
+                            socket, last_socket_error_string());
+      err = last_socket_error();
+      return -1;
+    }
+    ROS_ASSERT(errlen == sizeof(int));
+    if (errinfo != 0)
+    {
+      // an error occurred during connection
+      ROSCPP_CONN_LOG_DEBUG("Async connect on socket[%d] failed with error [%s]",
+                            socket, socket_error_string(errinfo));
+      err = errinfo;
+      return -1;
+    }
+#endif
+    err = 0;
+    return 1;
+}
+
 /**
  * Sets the socket as non blocking.
  * @return int : 0 on success, WSAGetLastError()/errno on failure.

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -50,6 +50,7 @@ bool TransportTCP::s_use_ipv6_ = false;
 
 TransportTCP::TransportTCP(PollSet* poll_set, int flags)
 : sock_(ROS_INVALID_SOCKET)
+, async_connected_(false)
 , closed_(false)
 , expecting_read_(false)
 , expecting_write_(false)
@@ -479,6 +480,22 @@ int32_t TransportTCP::read(uint8_t* buffer, uint32_t size)
   {
     boost::recursive_mutex::scoped_lock lock(close_mutex_);
 
+    // if socket is async and not connected, check if it's conneted
+    if (!(flags_ & SYNCHRONOUS) && !async_connected_ && !closed_) {
+      int ret, err;
+      ret = is_async_connected(sock_, err);
+      if (ret == 1) {
+        ROSCPP_CONN_LOG_DEBUG("Async socket[%d] is connected", sock_);
+        async_connected_ = true;
+      } else if (ret == -1) {
+        ROSCPP_LOG_DEBUG("Async connect on socket [%d] failed with error [%s]", sock_, socket_error_string(err));
+        close();
+      } else {
+        // socket is connecting
+        return 0;
+      }
+    }
+
     if (closed_)
     {
       ROSCPP_LOG_DEBUG("Tried to read on a closed socket [%d]", sock_);
@@ -517,6 +534,22 @@ int32_t TransportTCP::write(uint8_t* buffer, uint32_t size)
 {
   {
     boost::recursive_mutex::scoped_lock lock(close_mutex_);
+
+    // if socket is async and not connected, check if it's conneted
+    if (!(flags_ & SYNCHRONOUS) && !async_connected_ && !closed_) {
+      int ret, err;
+      ret = is_async_connected(sock_, err);
+      if (ret == 1) {
+        ROSCPP_CONN_LOG_DEBUG("Async socket[%d] is connected", sock_);
+        async_connected_ = true;
+      } else if (ret == -1) {
+        ROSCPP_LOG_DEBUG("Async connect on socket [%d] failed with error [%s]", sock_, socket_error_string(err));
+        close();
+      } else {
+        // socket is connecting
+        return 0;
+      }
+    }
 
     if (closed_)
     {


### PR DESCRIPTION
I found a bug in `transport_tcp.cpp` when I using ROS in `Windows Subsystem for Linux (WSL)`.
`TransportTCP::read()` did not check if aync socket is conneted. If socket is asynchronous, it may fails at recv() if its slow to connect (e.g. happens with wireless).
`TransportTCP::read()` and `TransportTCP::write()` needs to check if its connected or not if it's asynchronous.

# Detailed debug log
Test Environment: 
- PC 1 (Windows Subsystem for Linux, wired): RViz
- PC 2 (Ubuntu 16.04, wireless): roscore and other nodes  
```
...
[DEBUG] [1508756684.267337700]: Retrying connection to [pc2:60159] for topic [/kinect/rgb/image_color]
[DEBUG] [1508756684.387001100]: Resolved publisher host [pc2] to [192.168.123.211] for socket [24]
[DEBUG] [1508756684.387432900]: setsockopt failed to set SO_KEEPALIVE on socket [24] [pc2:60159 on socket 24]
[DEBUG] [1508756684.387574800]: setsockopt failed to set TCP_KEEPCNT on socket [24] [pc2:60159 on socket 24]
[DEBUG] [1508756684.388021100]: Adding tcp socket [24] to pollset
[DEBUG] [1508756684.388515700]: Async connect() in progress to [pc2:60159] on socket [24]
[DEBUG] [1508756684.388849400]: recv() on socket [24] failed with error [传输端点尚未连接] (ENGLISH TRANSLATION: The transmission endpoint is not connected yet)
[DEBUG] [1508756684.389211800]: TCP socket [24] closed
[DEBUG] [1508756684.389618800]: Connection::drop(0)
[DEBUG] [1508756684.389992600]: Connection to publisher [TCPROS connection on port 3678 to [pc2:60159 on socket 24]] to topic [/kinect/rgb/image_color] dropped
...
```

# Fix

I add function `is_async_connected()` to `io.h`. Given a socket which is still async connecting, this function will check if the connection is success, failed or still processing.

And I add a private member `async_connected_` to TransportTCP. 
Before every read() or write() on async socket, if async_connected_ is false, it will call `is_async_connected()` to check it. If it's connected, `async_connected_` is set to true.

# Test

## WSL and Ubuntu

I have tested this fix in my multi-machine project using the patched ros_comm (https://github.com/bxwllzz/ros_comm/tree/kinetic-fix-transport-tcp)
- PC 1 (WSL, wireless): ROS Kinetic, RViz
- PC 2 (Ubuntu 16.04, wireless): ROS Kinetic, roscore and other nodes  

## Only on Ubuntu

- PC (Ubuntu 16.04): ROS Kinetic, roscore, RViz and other nodes  

## test_roscpp

I have also run unit_tests by running `catkin_make run_tests` in ros_comm package for both WSL and Ubuntu. `catkin_test_results build/test_results/test_roscpp/` reports no failures. 

Maybe more tests about `is_async_connected()` is needed for native Windows. Because `select()` in WinSock is a little different from that in Unix. I have read documents about WinSock [connect()](https://msdn.microsoft.com/en-us/library/windows/desktop/ms737625(v=vs.85).aspx) [select()](https://msdn.microsoft.com/en-us/library/windows/desktop/ms740141(v=vs.85).aspx) and Unix [connect()](http://man7.org/linux/man-pages/man2/connect.2.html) seriously to implemente `is_async_connected()`.

_If other WSL users wants to try this fix for ROS Kinetic ahead, please clone my branch [kinetic-fix-transport-tcp](https://github.com/bxwllzz/ros_comm/tree/kinetic-fix-transport-tcp) to your catkin workspace._