### PR TITLE
backward compatibility with libconsole-bridge in Jessie

### DIFF
--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -74,6 +74,12 @@
 # undef logError
 #endif
 
+// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#ifndef CONSOLE_BRIDGE_logDebug
+  #define CONSOLE_BRIDGE_logDebug logDebug
+#endif
+
 namespace rosbag {
 
 namespace bagmode

--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -43,6 +43,12 @@
 
 #include "console_bridge/console.h"
 
+// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#ifndef CONSOLE_BRIDGE_logError
+  #define CONSOLE_BRIDGE_logError logError
+#endif
+
 #define foreach BOOST_FOREACH
 
 using std::map;


### PR DESCRIPTION
Follow up of #1205.