### PR TITLE
Performance improvement for lower/upper bound

### DIFF
--- a/tools/rosbag_storage/src/view.cpp
+++ b/tools/rosbag_storage/src/view.cpp
@@ -281,9 +281,10 @@ void View::updateQueries(BagQuery* q) {
         multiset<IndexEntry> const& index = j->second;
 
         // lower_bound/upper_bound do a binary search to find the appropriate range of Index Entries given our time range
-
-        std::multiset<IndexEntry>::const_iterator begin = index.lower_bound({ q->query.getStartTime(), 0, 0 });
-        std::multiset<IndexEntry>::const_iterator end   = index.upper_bound({ q->query.getEndTime()  , 0, 0 });
+        IndexEntry start_time_lookup_entry = { q->query.getStartTime(), 0, 0 };
+        IndexEntry end_time_lookup_entry   = { q->query.getEndTime()  , 0, 0 };
+        std::multiset<IndexEntry>::const_iterator begin = index.lower_bound(start_time_lookup_entry);
+        std::multiset<IndexEntry>::const_iterator end   = index.upper_bound(end_time_lookup_entry);
 	    
         // Make sure we are at the right beginning
         while (begin != index.begin() && begin->time >= q->query.getStartTime())

--- a/tools/rosbag_storage/src/view.cpp
+++ b/tools/rosbag_storage/src/view.cpp
@@ -282,9 +282,9 @@ void View::updateQueries(BagQuery* q) {
 
         // lower_bound/upper_bound do a binary search to find the appropriate range of Index Entries given our time range
 
-        std::multiset<IndexEntry>::const_iterator begin = std::lower_bound(index.begin(), index.end(), q->query.getStartTime(), IndexEntryCompare());
-        std::multiset<IndexEntry>::const_iterator end   = std::upper_bound(index.begin(), index.end(), q->query.getEndTime(),   IndexEntryCompare());
-
+        std::multiset<IndexEntry>::const_iterator begin = index.lower_bound({ q->query.getStartTime(), 0, 0 });
+        std::multiset<IndexEntry>::const_iterator end   = index.upper_bound({ q->query.getEndTime()  , 0, 0 });
+	    
         // Make sure we are at the right beginning
         while (begin != index.begin() && begin->time >= q->query.getStartTime())
         {


### PR DESCRIPTION
Changed updateQueries() to use member functions of `multiset` instead of `std::lower_bound` and `std::upper_bound`

Without this change, playing a bag file containing over 200K messages (under a single topic) yields in a major performance hit.
Running performance diagnostic shows that most of the time is spent in `std::advance` and `std::distance` which are used inside `std::lower_bound` and `std::upper_bound`. 

From [cppreference - lower_bound](http://en.cppreference.com/w/cpp/algorithm/lower_bound):
> Complexity
The number of comparisons performed is logarithmic in the distance between first and last (At most log2(last - first) + O(1) comparisons). **However, for non-RandomAccessIterators, the number of iterator increments is linear.** 

Changing to `std::multiset<IndexEntry>::lower_bound` results in a major performance improvement.
I have not measure the improvement, but I have a bag file containing a video of a stopwatch. In my code, for each `sensor_msgs::Image` I try to find a matching (single) message.Just by looking at the playback, I can see that the FPS is now fast enough to show a real second, whereas without this change, 1 second in the video (time it took for the stop watch to advanced by 1 second) took about **17 seconds** in the real world!