### PR TITLE
Make master process explicitly 'required' for parent launch

### DIFF
--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -100,7 +100,7 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
 
     _logger.info("process[master]: launching with args [%s]"%args)
     log_output = False
-    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, None)
+    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, None, required=True)
 
 def create_node_process(run_id, node, master_uri):
     """


### PR DESCRIPTION
In the existing implementation, if `rosmaster` dies, the parent launch will continue running unaffected.

This is particularly unpleasant when the launch is a standalone `roscore`. Adding the required argument here causes any roslaunch process manager that brings up `rosmaster` to also come down if `rosmaster` dies unexpectedly.