### PR TITLE
backward compatibility with libconsole-bridge in Jessie (take 3)

### DIFF
--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -62,25 +62,23 @@
 
 #include "console_bridge/console.h"
 
-#ifdef logDebug
-# ifndef CONSOLE_BRIDGE_logDebug
-#  define CONSOLE_BRIDGE_logDebug logDebug
-# endif
+// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#ifndef CONSOLE_BRIDGE_logDebug
+# define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
 #endif
-#ifdef logInform
-# ifndef CONSOLE_BRIDGE_logInform
-#  define CONSOLE_BRIDGE_logInform logInform
-# endif
+#ifndef CONSOLE_BRIDGE_logInform
+# define CONSOLE_BRIDGE_logInform(fmt, ...) \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
 #endif
-#ifdef logWarn
-# ifndef CONSOLE_BRIDGE_logWarn
-#  define CONSOLE_BRIDGE_logWarn logWarn
-# endif
+#ifndef CONSOLE_BRIDGE_logWarn
+# define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
 #endif
-#ifdef logError
-# ifndef CONSOLE_BRIDGE_logError
-#  define CONSOLE_BRIDGE_logError logError
-# endif
+#ifndef CONSOLE_BRIDGE_logError
+# define CONSOLE_BRIDGE_logError(fmt, ...)  \
+  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
 #endif
 
 namespace rosbag {

--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -85,7 +85,7 @@
 # else
 // Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
 // in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
-#  define CONSOLE_BRIDGE_logInform logWarn
+#  define CONSOLE_BRIDGE_logWarn logWarn
 # endif
 #endif
 #if defined logError

--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -61,7 +61,6 @@
 #include <boost/iterator/iterator_facade.hpp>
 
 #include "console_bridge/console.h"
-
 // Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
 // in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
 #ifndef CONSOLE_BRIDGE_logDebug

--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -61,39 +61,24 @@
 #include <boost/iterator/iterator_facade.hpp>
 
 #include "console_bridge/console.h"
-#if defined logDebug
-# ifdef CONSOLE_BRIDGE_logDebug
-#  undef logDebug
-# else
-// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
-// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+
+#ifdef logDebug
+# ifndef CONSOLE_BRIDGE_logDebug
 #  define CONSOLE_BRIDGE_logDebug logDebug
 # endif
 #endif
-#if defined logInform
-# ifdef CONSOLE_BRIDGE_logInform
-#  undef logInform
-# else
-// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
-// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#ifdef logInform
+# ifndef CONSOLE_BRIDGE_logInform
 #  define CONSOLE_BRIDGE_logInform logInform
 # endif
 #endif
-#if defined logWarn
-# ifdef CONSOLE_BRIDGE_logWarn
-#  undef logWarn
-# else
-// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
-// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#ifdef logWarn
+# ifndef CONSOLE_BRIDGE_logWarn
 #  define CONSOLE_BRIDGE_logWarn logWarn
 # endif
 #endif
-#if defined logError
-# ifdef CONSOLE_BRIDGE_logError
-#  undef logError
-# else
-// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
-// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#ifdef logError
+# ifndef CONSOLE_BRIDGE_logError
 #  define CONSOLE_BRIDGE_logError logError
 # endif
 #endif

--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -71,10 +71,22 @@
 # endif
 #endif
 #if defined logInform
-# undef logInform
+# ifdef CONSOLE_BRIDGE_logInform
+#  undef logInform
+# else
+// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#  define CONSOLE_BRIDGE_logInform logInform
+# endif
 #endif
 #if defined logWarn
-# undef logWarn
+# ifdef CONSOLE_BRIDGE_logWarn
+#  undef logWarn
+# else
+// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#  define CONSOLE_BRIDGE_logInform logWarn
+# endif
 #endif
 #if defined logError
 # ifdef CONSOLE_BRIDGE_logError


### PR DESCRIPTION
I didnt follow the original discussions regarding console bridge support, so forgive me if this has been discussed before.
Shouldn't all macros be treated the same ?
I'd expect any package including this header to not be able to use logWarn or logInform anymore while they're still able to use logError and logDebug. Is that the expected behavior ?