### PR TITLE
Fixed warn of --max-splits without --split

### DIFF
--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -62,7 +62,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("bz2,j", "use BZ2 compression")
       ("lz4", "use LZ4 compression")
       ("split", po::value<int>()->implicit_value(0), "Split the bag file and continue recording when maximum size or maximum duration reached.")
-      ("max-splits", po::value<int>()->default_value(0), "Keep a maximum of N bag files, when reaching the maximum erase the oldest one to keep a constant number of files.")
+      ("max-splits", po::value<int>(), "Keep a maximum of N bag files, when reaching the maximum erase the oldest one to keep a constant number of files.")
       ("topic", po::value< std::vector<std::string> >(), "topic to record")
       ("size", po::value<uint64_t>(), "The maximum size of the bag to record in MB.")
       ("duration", po::value<std::string>(), "Record a bag of maximum duration in seconds, unless 'm', or 'h' is appended.")

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -108,6 +108,7 @@ RecorderOptions::RecorderOptions() :
     limit(0),
     split(false),
     max_size(0),
+    max_splits(0),
     max_duration(-1.0),
     node(""),
     min_space(1024 * 1024 * 1024),


### PR DESCRIPTION
`rosbag record` always gives this warning even without specifying `--max-splits`:
> [ WARN] [1510806945.020499157]: --max-splits is ignored without --split

The `--max-splits` option has a default value causing the program to always think that `--max-splits` is specified. This fix removes the default command-line option value but still properly initialises the value to 0.