### PR TITLE
place console_bridge macros definition in header and use it everywher…

### DIFF
--- a/tools/rosbag_storage/include/rosbag/bag.h
+++ b/tools/rosbag_storage/include/rosbag/bag.h
@@ -61,24 +61,9 @@
 #include <boost/iterator/iterator_facade.hpp>
 
 #include "console_bridge/console.h"
-// Remove this when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// Remove this include when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
 // in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
-#ifndef CONSOLE_BRIDGE_logDebug
-# define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
-#endif
-#ifndef CONSOLE_BRIDGE_logInform
-# define CONSOLE_BRIDGE_logInform(fmt, ...) \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
-#endif
-#ifndef CONSOLE_BRIDGE_logWarn
-# define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
-#endif
-#ifndef CONSOLE_BRIDGE_logError
-# define CONSOLE_BRIDGE_logError(fmt, ...)  \
-  console_bridge::log(__FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
-#endif
+#include "rosbag/console_bridge_compatibility.h"
 
 namespace rosbag {
 

--- a/tools/rosbag_storage/include/rosbag/console_bridge_compatibility.h
+++ b/tools/rosbag_storage/include/rosbag/console_bridge_compatibility.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017, Open Source Robotics Foundation, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Open Source Robotics Foundation, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSBAG__CONSOLE_BRIDGE_COMPATIBILITY_H_
+#define ROSBAG__CONSOLE_BRIDGE_COMPATIBILITY_H_
+
+#include <console_bridge/console.h>
+
+// Remove this file and it's inclusions when no longer supporting platforms with
+// libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#ifndef CONSOLE_BRIDGE_logError
+# define CONSOLE_BRIDGE_logError(fmt, ...)  \
+  console_bridge::log( \
+    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_ERROR, fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef CONSOLE_BRIDGE_logWarn
+# define CONSOLE_BRIDGE_logWarn(fmt, ...)   \
+  console_bridge::log( \
+    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_WARN,  fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef CONSOLE_BRIDGE_logInform
+# define CONSOLE_BRIDGE_logInform(fmt, ...) \
+  console_bridge::log( \
+    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_INFO,  fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef CONSOLE_BRIDGE_logDebug
+# define CONSOLE_BRIDGE_logDebug(fmt, ...)  \
+  console_bridge::log( \
+    __FILE__, __LINE__, console_bridge::CONSOLE_BRIDGE_LOG_DEBUG, fmt, ##__VA_ARGS__)
+#endif
+
+#endif  // ROSBAG__CONSOLE_BRIDGE_COMPATIBILITY_H_

--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -42,6 +42,9 @@
 #include <boost/foreach.hpp>
 
 #include "console_bridge/console.h"
+// Remove this include when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#include "rosbag/console_bridge_compatibility.h"
 
 #define foreach BOOST_FOREACH
 

--- a/tools/rosbag_storage/src/bz2_stream.cpp
+++ b/tools/rosbag_storage/src/bz2_stream.cpp
@@ -38,6 +38,10 @@
 #include <cstring>
 #include "console_bridge/console.h"
 
+// Remove this include when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#include "rosbag/console_bridge_compatibility.h"
+
 using std::string;
 
 namespace rosbag {
@@ -127,7 +131,7 @@ void BZ2Stream::read(void* ptr, size_t size) {
     case BZ_OK: return;
     case BZ_STREAM_END:
         if (getUnused() || getUnusedLength() > 0)
-            logError("unused data already available");
+            CONSOLE_BRIDGE_logError("unused data already available");
         else {
             char* unused;
             int nUnused;

--- a/tools/rosbag_storage/src/lz4_stream.cpp
+++ b/tools/rosbag_storage/src/lz4_stream.cpp
@@ -38,6 +38,10 @@
 #include <cstring>
 #include "console_bridge/console.h"
 
+// Remove this include when no longer supporting platforms with libconsole-bridge-dev < 0.3.0,
+// in particular Debian Jessie: https://packages.debian.org/jessie/libconsole-bridge-dev
+#include "rosbag/console_bridge_compatibility.h"
+
 using std::string;
 
 namespace rosbag {
@@ -176,7 +180,7 @@ void LZ4Stream::read(void* ptr, size_t size) {
     case ROSLZ4_OK: break;
     case ROSLZ4_STREAM_END:
         if (getUnused() || getUnusedLength() > 0)
-            logError("unused data already available");
+            CONSOLE_BRIDGE_logError("unused data already available");
         else {
             setUnused(lz4s_.input_next);
             setUnusedLength(lz4s_.input_left);


### PR DESCRIPTION
…e console_bridge is included

This is a follow up of https://github.com/ros/ros_comm/pull/1235.

- Add a header to define the namespaces versions of console_bridge macros if they don't exist (for libconsole-bridge-dev < 0.3.0) 
- Use the namespaced versions of the console_bridge macros everywhere
- Include the compatibility header everywhere console_bridge is included

Compared to #1235, this is not necessary to fix downstream packages so doesn't need to be released right now but is a nice to have for both consistency and having deterministic behavior regardless of what was included before.
