### PR TITLE
use namespaced macros instead of deprecated macros

### DIFF
--- a/tools/rosbag_storage/src/bz2_stream.cpp
+++ b/tools/rosbag_storage/src/bz2_stream.cpp
@@ -127,7 +127,7 @@ void BZ2Stream::read(void* ptr, size_t size) {
     case BZ_OK: return;
     case BZ_STREAM_END:
         if (getUnused() || getUnusedLength() > 0)
-            logError("unused data already available");
+            CONSOLE_BRIDGE_logError("unused data already available");
         else {
             char* unused;
             int nUnused;

--- a/tools/rosbag_storage/src/lz4_stream.cpp
+++ b/tools/rosbag_storage/src/lz4_stream.cpp
@@ -176,7 +176,7 @@ void LZ4Stream::read(void* ptr, size_t size) {
     case ROSLZ4_OK: break;
     case ROSLZ4_STREAM_END:
         if (getUnused() || getUnusedLength() > 0)
-            logError("unused data already available");
+            CONSOLE_BRIDGE_logError("unused data already available");
         else {
             setUnused(lz4s_.input_next);
             setUnusedLength(lz4s_.input_left);


### PR DESCRIPTION
The rest of rosbag uses the new namespaced macros. 
Given that the old console bridge macros are undefined in:
https://github.com/ros/ros_comm/blob/35d1e0d788890fe1e33c71a4f97dcdfc3c4f074a/tools/rosbag_storage/include/rosbag/bag.h#L65-L76
The rest of the code base needs to use the new ones