### PR TITLE
added parameter to stop client libraries from generating topics list

### DIFF
--- a/clients/roscpp/include/ros/rosout_appender.h
+++ b/clients/roscpp/include/ros/rosout_appender.h
@@ -75,6 +75,7 @@ protected:
   boost::mutex queue_mutex_;
   boost::condition_variable queue_condition_;
   bool shutting_down_;
+  bool disable_topics_;
 
   boost::thread publish_thread_;
 };

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -38,6 +38,7 @@
 #include "ros/topic_manager.h"
 #include "ros/advertise_options.h"
 #include "ros/names.h"
+#include "ros/param.h"
 
 #include <rosgraph_msgs/Log.h>
 
@@ -102,7 +103,14 @@ void ROSOutAppender::log(::ros::console::Level level, const char* str, const cha
   msg->file = file;
   msg->function = function;
   msg->line = line;
-  this_node::getAdvertisedTopics(msg->topics);
+  
+  // check parameter server/cache for omit_topics flag
+  // the same parameter is checked in rosout.py for the same purpose
+  ros::param::getCached("/rosout_disable_topics_generation", disable_topics_);
+
+  if (!disable_topics_){
+    this_node::getAdvertisedTopics(msg->topics);
+  }
 
   if (level == ::ros::console::levels::Fatal || level == ::ros::console::levels::Error)
   {

--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -85,7 +85,20 @@ def _rosout(level, msg, fname, line, func):
                 try:
                     _in_rosout = True
                     msg = str(msg)
-                    topics = get_topic_manager().get_topics()
+
+                    # check parameter server/cache for omit_topics flag
+                    # the same parameter is checked in rosout_appender.cpp for the same purpose
+                    # parameter accesses are cached automatically in python
+                    if rospy.has_param("/rosout_disable_topics_generation"):
+                        disable_topics_ = rospy.get_param("/rosout_disable_topics_generation")
+                    else:
+                        disable_topics_ = False
+
+                    if not disable_topics_:
+                        topics = get_topic_manager().get_topics()
+                    else:
+                        topics = ""
+
                     l = Log(level=level, name=str(rospy.names.get_caller_id()), msg=str(msg), topics=topics, file=fname, line=line, function=func)
                     l.header.stamp = Time.now()
                     _rosout_pub.publish(l)


### PR DESCRIPTION
The cached parameter /rosout_disable_topics_generation stops rospy and roscpp from generating the list of topics and sending them over the network stack as part of their log messages. It does not stop rosout from printing an empty topics list.