### PR TITLE
Tests and bug fixes for XmlRpcServer

### DIFF
--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
@@ -14,6 +14,8 @@
 #ifndef MAKEDEPEND
 # include <map>
 # include <string>
+# include <vector>
+# include <poll.h>
 #endif
 
 #include "xmlrpcpp/XmlRpcDispatch.h"
@@ -87,10 +89,13 @@ namespace XmlRpc {
   protected:
 
     //! Accept a client connection request
-    virtual void acceptConnection();
+    virtual unsigned acceptConnection();
 
     //! Create a new connection object for processing requests from a specific client.
     virtual XmlRpcServerConnection* createConnection(int socket);
+
+    //! Count number of free file descriptors
+    int countFreeFDs();
 
     // Whether the introspection API is supported by this server
     bool _introspectionEnabled;
@@ -108,6 +113,18 @@ namespace XmlRpc {
 
     int _port;
 
+    // Flag indicating that accept had an error and needs to be retried.
+    bool _accept_error;
+    // If we cannot accept(), retry after this many seconds. Hopefully there
+    // will be more free file descriptors later.
+    static const double ACCEPT_RETRY_INTERVAL_SEC;
+    // Retry time for accept.
+    double _accept_retry_time_sec;
+
+    // Minimum number of free file descriptors before rejecting clients.
+    static const int FREE_FD_BUFFER;
+    // List of all file descriptors, used for counting open files.
+    std::vector<struct pollfd> pollfds;
   };
 } // namespace XmlRpc
 

--- a/utilities/xmlrpcpp/package.xml
+++ b/utilities/xmlrpcpp/package.xml
@@ -22,6 +22,8 @@
 
   <run_depend>cpp_common</run_depend>
 
+  <test_depend>boost</test_depend>
+
   <export>
     <rosdoc external="http://xmlrpcpp.sourceforge.net/doc/hierarchy.html"/>
   </export>

--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -7,6 +7,22 @@ catkin_add_gtest(test_base64 test_base64.cpp)
 target_link_libraries(test_base64 xmlrpcpp)
 set_target_properties(test_base64 PROPERTIES COMPILE_FLAGS -std=c++11)
 
+# Some of the tests that follow use boost threads.
+find_package(Boost REQUIRED COMPONENTS system thread)
+include_directories(${Boost_INCLUDE_DIRS})
+
+add_library(test_fixtures test_fixtures.cpp)
+target_link_libraries(test_fixtures ${Boost_LIBRARIES})
+
+catkin_add_gtest(HelloTest HelloTest.cpp)
+target_link_libraries(HelloTest xmlrpcpp ${Boost_LIBRARIES})
+
+catkin_add_gtest(test_dispatch_live test_dispatch_live.cpp)
+target_link_libraries(test_dispatch_live xmlrpcpp test_fixtures ${Boost_LIBRARIES})
+
+catkin_add_gtest(test_ulimit test_ulimit.cpp)
+target_link_libraries(test_ulimit xmlrpcpp test_fixtures ${Boost_LIBRARIES})
+
 add_library(mock_socket mock_socket.cpp)
 
 catkin_add_gtest(test_client

--- a/utilities/xmlrpcpp/test/HelloTest.cpp
+++ b/utilities/xmlrpcpp/test/HelloTest.cpp
@@ -41,26 +41,31 @@ using XmlRpc::XmlRpcClient;
 using XmlRpc::XmlRpcValue;
 
 // No arguments, result is "Hello".
-class Hello : public XmlRpcServerMethod {
+class Hello : public XmlRpcServerMethod
+{
 public:
   Hello(XmlRpcServer* s) : XmlRpcServerMethod("Hello", s) {}
 
-  void execute(XmlRpcValue& params, XmlRpcValue& result) {
+  void execute(XmlRpcValue& params, XmlRpcValue& result)
+  {
     (void)params;
     result = "Hello";
   }
 
-  std::string help() {
+  std::string help()
+  {
     return std::string("Say hello");
   }
 };
 
 // One argument is passed, result is "Hello, " + arg.
-class HelloName : public XmlRpcServerMethod {
+class HelloName : public XmlRpcServerMethod
+{
 public:
   HelloName(XmlRpcServer* s) : XmlRpcServerMethod("HelloName", s) {}
 
-  void execute(XmlRpcValue& params, XmlRpcValue& result) {
+  void execute(XmlRpcValue& params, XmlRpcValue& result)
+  {
     std::string resultString = "Hello, ";
     resultString += std::string(params[0]);
     result = resultString;
@@ -68,11 +73,13 @@ public:
 };
 
 // A variable number of arguments are passed, all doubles, result is their sum.
-class Sum : public XmlRpcServerMethod {
+class Sum : public XmlRpcServerMethod
+{
 public:
   Sum(XmlRpcServer* s) : XmlRpcServerMethod("Sum", s) {}
 
-  void execute(XmlRpcValue& params, XmlRpcValue& result) {
+  void execute(XmlRpcValue& params, XmlRpcValue& result)
+  {
     int nArgs = params.size();
     double sum = 0.0;
     for (int i = 0; i < nArgs; ++i)
@@ -81,17 +88,21 @@ public:
   }
 };
 
-class XmlRpcTest : public ::testing::Test {
+class XmlRpcTest : public ::testing::Test
+{
 protected:
   XmlRpcTest() : hello(&s), helloName(&s), sum(&s), port(0), done(false) {}
 
-  void work() {
-    while (!done) {
+  void work()
+  {
+    while (!done)
+    {
       s.work(0.1); // run the worker queue for 100ms
     }
   }
 
-  virtual void SetUp() {
+  virtual void SetUp()
+  {
     // XmlRpc::setVerbosity(5);
 
     // Create the server socket. Passing 0 for the port number requests that
@@ -107,7 +118,8 @@ protected:
     server_thread = boost::thread(boost::mem_fn(&XmlRpcTest::work), this);
   }
 
-  virtual void TearDown() {
+  virtual void TearDown()
+  {
     // TODO(austin): determine if we need to do anything here to avoid
     // leaking resources
     done = true;
@@ -129,7 +141,8 @@ protected:
   boost::thread server_thread;
 };
 
-TEST_F(XmlRpcTest, Introspection) {
+TEST_F(XmlRpcTest, Introspection)
+{
   XmlRpcClient c("localhost", port);
 
   // Use introspection API to look up the supported methods
@@ -163,7 +176,8 @@ TEST_F(XmlRpcTest, Introspection) {
   EXPECT_EQ(result, XmlRpcValue(""));
 }
 
-TEST_F(XmlRpcTest, Hello) {
+TEST_F(XmlRpcTest, Hello)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue noArgs, result;
 
@@ -173,7 +187,8 @@ TEST_F(XmlRpcTest, Hello) {
   EXPECT_EQ(result, XmlRpcValue("Hello"));
 }
 
-TEST_F(XmlRpcTest, HelloURI) {
+TEST_F(XmlRpcTest, HelloURI)
+{
   XmlRpcClient c("localhost", port, "/");
   XmlRpcValue noArgs, result;
 
@@ -183,7 +198,8 @@ TEST_F(XmlRpcTest, HelloURI) {
   EXPECT_EQ(result, XmlRpcValue("Hello"));
 }
 
-TEST_F(XmlRpcTest, HelloName) {
+TEST_F(XmlRpcTest, HelloName)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue oneArg, result;
 
@@ -194,7 +210,8 @@ TEST_F(XmlRpcTest, HelloName) {
   EXPECT_EQ(result, XmlRpcValue("Hello, Chris"));
 }
 
-TEST_F(XmlRpcTest, Sum) {
+TEST_F(XmlRpcTest, Sum)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue result;
 
@@ -218,7 +235,8 @@ TEST_F(XmlRpcTest, Sum) {
   EXPECT_EQ(result, fault);
 }
 
-TEST_F(XmlRpcTest, Multicall) {
+TEST_F(XmlRpcTest, Multicall)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue result;
 

--- a/utilities/xmlrpcpp/test/HelloTest.cpp
+++ b/utilities/xmlrpcpp/test/HelloTest.cpp
@@ -1,0 +1,258 @@
+/*
+ * Unit tests for XmlRpc++
+ *
+ * Copyright (C) 2017, Zoox Inc
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Austin Hendrix <austin@zoox.com>
+ * Loosely based on HelloServer.cpp and HelloClient.cpp by Chris Morley
+ *
+ */
+
+#include "xmlrpcpp/XmlRpc.h"
+#include "xmlrpcpp/XmlRpcClient.h"
+#include "xmlrpcpp/XmlRpcServer.h"
+#include "xmlrpcpp/XmlRpcServerMethod.h"
+
+#include <iostream>
+#include <stdlib.h>
+#include <boost/thread/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <functional>
+
+#include <gtest/gtest.h>
+
+using XmlRpc::XmlRpcServerMethod;
+using XmlRpc::XmlRpcServer;
+using XmlRpc::XmlRpcClient;
+using XmlRpc::XmlRpcValue;
+
+// No arguments, result is "Hello".
+class Hello : public XmlRpcServerMethod {
+public:
+  Hello(XmlRpcServer* s) : XmlRpcServerMethod("Hello", s) {}
+
+  void execute(XmlRpcValue& params, XmlRpcValue& result) {
+    (void)params;
+    result = "Hello";
+  }
+
+  std::string help() {
+    return std::string("Say hello");
+  }
+};
+
+// One argument is passed, result is "Hello, " + arg.
+class HelloName : public XmlRpcServerMethod {
+public:
+  HelloName(XmlRpcServer* s) : XmlRpcServerMethod("HelloName", s) {}
+
+  void execute(XmlRpcValue& params, XmlRpcValue& result) {
+    std::string resultString = "Hello, ";
+    resultString += std::string(params[0]);
+    result = resultString;
+  }
+};
+
+// A variable number of arguments are passed, all doubles, result is their sum.
+class Sum : public XmlRpcServerMethod {
+public:
+  Sum(XmlRpcServer* s) : XmlRpcServerMethod("Sum", s) {}
+
+  void execute(XmlRpcValue& params, XmlRpcValue& result) {
+    int nArgs = params.size();
+    double sum = 0.0;
+    for (int i = 0; i < nArgs; ++i)
+      sum += double(params[i]);
+    result = sum;
+  }
+};
+
+class XmlRpcTest : public ::testing::Test {
+protected:
+  XmlRpcTest() : hello(&s), helloName(&s), sum(&s), port(0), done(false) {}
+
+  void work() {
+    while (!done) {
+      s.work(0.1); // run the worker queue for 100ms
+    }
+  }
+
+  virtual void SetUp() {
+    // XmlRpc::setVerbosity(5);
+
+    // Create the server socket. Passing 0 for the port number requests that
+    // the OS randomly select an available port.
+    s.bindAndListen(0);
+    // Retrieve the assigned port number.
+    port = s.get_port();
+
+    // Enable introspection.
+    s.enableIntrospection(true);
+
+    // Start the worker thread.
+    server_thread = boost::thread(boost::mem_fn(&XmlRpcTest::work), this);
+  }
+
+  virtual void TearDown() {
+    // TODO(austin): determine if we need to do anything here to avoid
+    // leaking resources
+    done = true;
+    server_thread.join();
+    s.shutdown();
+  }
+
+  // The server and its methods
+  XmlRpcServer s;
+  Hello hello;
+  HelloName helloName;
+  Sum sum;
+
+  // Server port number (for clients)
+  int port;
+
+  // Server thread
+  bool done;
+  boost::thread server_thread;
+};
+
+TEST_F(XmlRpcTest, Introspection) {
+  XmlRpcClient c("localhost", port);
+
+  // Use introspection API to look up the supported methods
+  XmlRpcValue noArgs, result;
+
+  ASSERT_TRUE(c.execute("system.listMethods", noArgs, result));
+
+  XmlRpcValue methods;
+  methods[0] = "Hello";
+  methods[1] = "HelloName";
+  methods[2] = "Sum";
+  methods[3] = "system.listMethods";
+  methods[4] = "system.methodHelp";
+  methods[5] = "system.multicall";
+  EXPECT_EQ(result, methods);
+
+  // Use introspection API to get the help string for the Hello method
+  XmlRpcValue oneArg;
+  oneArg[0] = "Hello";
+
+  ASSERT_TRUE(c.execute("system.methodHelp", oneArg, result));
+
+  EXPECT_EQ(result, XmlRpcValue("Say hello"));
+
+  // Use introspection API to get the help string for the HelloName method
+  // This should be the default help string, ie empty string.
+  oneArg[0] = "HelloName";
+
+  ASSERT_TRUE(c.execute("system.methodHelp", oneArg, result));
+
+  EXPECT_EQ(result, XmlRpcValue(""));
+}
+
+TEST_F(XmlRpcTest, Hello) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue noArgs, result;
+
+  // Call the Hello method
+  ASSERT_TRUE(c.execute("Hello", noArgs, result));
+
+  EXPECT_EQ(result, XmlRpcValue("Hello"));
+}
+
+TEST_F(XmlRpcTest, HelloURI) {
+  XmlRpcClient c("localhost", port, "/");
+  XmlRpcValue noArgs, result;
+
+  // Call the Hello method
+  ASSERT_TRUE(c.execute("Hello", noArgs, result));
+
+  EXPECT_EQ(result, XmlRpcValue("Hello"));
+}
+
+TEST_F(XmlRpcTest, HelloName) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue oneArg, result;
+
+  // Call the HelloName method
+  oneArg[0] = "Chris";
+  ASSERT_TRUE(c.execute("HelloName", oneArg, result));
+
+  EXPECT_EQ(result, XmlRpcValue("Hello, Chris"));
+}
+
+TEST_F(XmlRpcTest, Sum) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue result;
+
+  // Add up an array of numbers
+  XmlRpcValue numbers;
+  numbers[0] = 33.33;
+  numbers[1] = 112.57;
+  numbers[2] = 76.1;
+  EXPECT_EQ(numbers.size(), 3);
+
+  ASSERT_TRUE(c.execute("Sum", numbers, result));
+  EXPECT_DOUBLE_EQ(double(result), 222.0);
+
+  // Test the "no such method" fault
+  ASSERT_TRUE(c.execute("NoSuchMethod", numbers, result));
+  EXPECT_TRUE(c.isFault());
+
+  XmlRpcValue fault;
+  fault["faultCode"] = -1;
+  fault["faultString"] = "NoSuchMethod: unknown method name";
+  EXPECT_EQ(result, fault);
+}
+
+TEST_F(XmlRpcTest, Multicall) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue result;
+
+  // Test the multicall method. It accepts one arg, an array of structs
+  XmlRpcValue multicall, expected_result;
+  multicall[0][0]["methodName"] = "Sum";
+  multicall[0][0]["params"][0] = 5.0;
+  multicall[0][0]["params"][1] = 9.0;
+  expected_result[0][0] = 14.0;
+
+  multicall[0][1]["methodName"] = "NoSuchMethod";
+  multicall[0][1]["params"][0] = "";
+  expected_result[1]["faultCode"] = -1;
+  expected_result[1]["faultString"] = "NoSuchMethod: unknown method name";
+
+  multicall[0][2]["methodName"] = "Sum";
+  // Missing params
+  expected_result[2]["faultCode"] = -1;
+  expected_result[2]["faultString"] = "system.multicall: Invalid argument "
+                                      "(expected a struct with members "
+                                      "methodName and params)";
+
+  multicall[0][3]["methodName"] = "Sum";
+  multicall[0][3]["params"][0] = 10.5;
+  multicall[0][3]["params"][1] = 12.5;
+  expected_result[3][0] = 23.0;
+
+  ASSERT_TRUE(c.execute("system.multicall", multicall, result));
+  EXPECT_EQ(result, expected_result);
+  EXPECT_EQ(result.toXml(), expected_result.toXml());
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/utilities/xmlrpcpp/test/test_dispatch_live.cpp
+++ b/utilities/xmlrpcpp/test/test_dispatch_live.cpp
@@ -41,7 +41,8 @@
 
 using namespace XmlRpc;
 
-TEST_F(XmlRpcTest, Hello) {
+TEST_F(XmlRpcTest, Hello)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue noArgs, result;
 
@@ -53,7 +54,8 @@ TEST_F(XmlRpcTest, Hello) {
   EXPECT_EQ(result, hello);
 }
 
-TEST_F(XmlRpcTest, HelloNonBlock) {
+TEST_F(XmlRpcTest, HelloNonBlock)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue noArgs, result;
 
@@ -61,7 +63,8 @@ TEST_F(XmlRpcTest, HelloNonBlock) {
   ASSERT_TRUE(c.executeNonBlock("Hello", noArgs));
 
   bool done = false;
-  for (int i = 0; i < 30; i++) {
+  for (int i = 0; i < 30; i++)
+  {
     done = c.executeCheckDone(result);
     if (done)
       break;
@@ -75,7 +78,8 @@ TEST_F(XmlRpcTest, HelloNonBlock) {
   EXPECT_EQ(result, hello);
 }
 
-TEST_F(XmlRpcTest, HelloNonBlock2) {
+TEST_F(XmlRpcTest, HelloNonBlock2)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue noArgs, result;
 
@@ -86,7 +90,8 @@ TEST_F(XmlRpcTest, HelloNonBlock2) {
   ASSERT_TRUE(c.executeNonBlock("Hello", noArgs));
 
   bool done = false;
-  for (int i = 0; i < 100; i++) {
+  for (int i = 0; i < 100; i++)
+  {
     done = c.executeCheckDone(result);
     if (done)
       break;
@@ -104,7 +109,8 @@ TEST_F(XmlRpcTest, HelloNonBlock2) {
   EXPECT_EQ(result, hello);
 }
 
-TEST_F(XmlRpcTest, ClientDisconnect) {
+TEST_F(XmlRpcTest, ClientDisconnect)
+{
   XmlRpcClient* c = new XmlRpcClient("localhost", port);
   XmlRpcValue noArgs, result;
 
@@ -121,7 +127,8 @@ TEST_F(XmlRpcTest, ClientDisconnect) {
   hello.hello_mutex.unlock();
 }
 
-TEST_F(XmlRpcTest, ServerDisconnect) {
+TEST_F(XmlRpcTest, ServerDisconnect)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue noArgs, result;
 
@@ -139,7 +146,8 @@ TEST_F(XmlRpcTest, ServerDisconnect) {
 
   // Run the client to completion
   bool done = false;
-  for (int i = 0; i < 100; i++) {
+  for (int i = 0; i < 100; i++)
+  {
     done = c.executeCheckDone(result);
     if (done)
       break;
@@ -155,7 +163,8 @@ TEST_F(XmlRpcTest, ServerDisconnect) {
   EXPECT_EQ(result, XmlRpcValue()); // Expect empty result
 }
 
-TEST_F(XmlRpcTest, ServerDisconnect2) {
+TEST_F(XmlRpcTest, ServerDisconnect2)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue noArgs, result;
 

--- a/utilities/xmlrpcpp/test/test_dispatch_live.cpp
+++ b/utilities/xmlrpcpp/test/test_dispatch_live.cpp
@@ -1,0 +1,180 @@
+/*
+ * Unit tests for XmlRpc++
+ *
+ * Copyright (C) 2017, Zoox Inc
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Austin Hendrix <austin@zoox.com>
+ * Loosley based on HelloServer.cpp and HelloClient.cpp by Chris Morley
+ *
+ */
+
+#include "xmlrpcpp/XmlRpc.h"
+
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include <iostream>
+#include <functional>
+
+#include <gtest/gtest.h>
+
+#include "test_fixtures.h"
+
+using namespace XmlRpc;
+
+TEST_F(XmlRpcTest, Hello) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue noArgs, result;
+
+  // Call the Hello method
+  ASSERT_TRUE(c.execute("Hello", noArgs, result));
+
+  EXPECT_FALSE(c.isFault());
+  XmlRpcValue hello("Hello");
+  EXPECT_EQ(result, hello);
+}
+
+TEST_F(XmlRpcTest, HelloNonBlock) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue noArgs, result;
+
+  // Call the Hello method, non-blocking
+  ASSERT_TRUE(c.executeNonBlock("Hello", noArgs));
+
+  bool done = false;
+  for (int i = 0; i < 30; i++) {
+    done = c.executeCheckDone(result);
+    if (done)
+      break;
+    // run the client's dispatch loop to service the respond when it comes back
+    c._disp.work(0.1);
+  }
+
+  ASSERT_TRUE(done);
+
+  XmlRpcValue hello("Hello");
+  EXPECT_EQ(result, hello);
+}
+
+TEST_F(XmlRpcTest, HelloNonBlock2) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue noArgs, result;
+
+  // Lock the hello mutex so that the service call cannot return immediately
+  hello.hello_mutex.lock();
+
+  // Call the Hello method, non-blocking
+  ASSERT_TRUE(c.executeNonBlock("Hello", noArgs));
+
+  bool done = false;
+  for (int i = 0; i < 100; i++) {
+    done = c.executeCheckDone(result);
+    if (done)
+      break;
+    // run the client's dispatch loop to service the respond when it comes back
+    c._disp.work(0.1);
+
+    // unlock the hello mutex after 10 cycles
+    if (i == 10)
+      hello.hello_mutex.unlock();
+  }
+
+  ASSERT_TRUE(done);
+
+  XmlRpcValue hello("Hello");
+  EXPECT_EQ(result, hello);
+}
+
+TEST_F(XmlRpcTest, ClientDisconnect) {
+  XmlRpcClient* c = new XmlRpcClient("localhost", port);
+  XmlRpcValue noArgs, result;
+
+  // Lock the hello mutex so that the service call cannot return immediately
+  hello.hello_mutex.lock();
+
+  // Call the Hello method, non-blocking
+  ASSERT_TRUE(c->executeNonBlock("Hello", noArgs));
+
+  // Destroy the client before the server can answer
+  delete c;
+
+  // Unlock the mutex so the server can finish
+  hello.hello_mutex.unlock();
+}
+
+TEST_F(XmlRpcTest, ServerDisconnect) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue noArgs, result;
+
+  XmlRpc::setVerbosity(3);
+
+  // Stop calling the work method on the server
+  server_done = true;
+  server_thread.join();
+
+  // Call the Hello method, non-blocking
+  ASSERT_TRUE(c.executeNonBlock("Hello", noArgs));
+
+  // Destroy the server before it can answer
+  s.shutdown();
+
+  // Run the client to completion
+  bool done = false;
+  for (int i = 0; i < 100; i++) {
+    done = c.executeCheckDone(result);
+    if (done)
+      break;
+    // run the client's dispatch loop to service the respond when it comes back
+    c._disp.work(0.1);
+  }
+
+  // The client should return true because the request is done, even though it
+  // timed out and wasn't able to complete.
+  EXPECT_TRUE(done);
+  EXPECT_EQ(-1, c.getfd());
+
+  EXPECT_EQ(result, XmlRpcValue()); // Expect empty result
+}
+
+TEST_F(XmlRpcTest, ServerDisconnect2) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue noArgs, result;
+
+  // Stop calling the work method on the server
+  server_done = true;
+  server_thread.join();
+  // Close the server socket to reads (ie incoming connections)
+  shutdown(s.getfd(), SHUT_RD);
+
+  // Call the Hello method. Expect failure since the server socket is not
+  // accepting new connections.
+  ASSERT_FALSE(c.execute("Hello", noArgs, result));
+
+  XmlRpcValue hello; // Expect empty result
+  EXPECT_EQ(result, hello);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/utilities/xmlrpcpp/test/test_fixtures.cpp
+++ b/utilities/xmlrpcpp/test/test_fixtures.cpp
@@ -27,7 +27,8 @@
 
 using namespace XmlRpc;
 
-void Hello::execute(XmlRpcValue& params, XmlRpcValue& result) {
+void Hello::execute(XmlRpcValue& params, XmlRpcValue& result)
+{
   (void)params;
   boost::unique_lock<boost::mutex> lock(hello_mutex);
   result = "Hello";
@@ -35,13 +36,16 @@ void Hello::execute(XmlRpcValue& params, XmlRpcValue& result) {
 
 XmlRpcTest::XmlRpcTest() : hello(&s), port(0), server_done(false) {}
 
-void XmlRpcTest::work() {
-  while (!server_done) {
+void XmlRpcTest::work()
+{
+  while (!server_done)
+  {
     s.work(0.1); // run the worker queue for 100ms
   }
 }
 
-void XmlRpcTest::SetUp() {
+void XmlRpcTest::SetUp()
+{
   // XmlRpc::setVerbosity(5);
 
   // Create the server socket on the specified port
@@ -55,11 +59,13 @@ void XmlRpcTest::SetUp() {
   server_thread = boost::thread(boost::mem_fn(&XmlRpcTest::work), this);
 }
 
-void XmlRpcTest::TearDown() {
+void XmlRpcTest::TearDown()
+{
   // TODO(austin): determine if we need to do anything here to avoid
   // leaking resources
   server_done = true;
-  if (server_thread.joinable()) {
+  if (server_thread.joinable())
+  {
     server_thread.join();
   }
   s.shutdown();

--- a/utilities/xmlrpcpp/test/test_fixtures.cpp
+++ b/utilities/xmlrpcpp/test/test_fixtures.cpp
@@ -1,0 +1,69 @@
+/*
+ * Unit tests for XmlRpc++
+ *
+ * Copyright (C) 2017, Zoox Inc
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Austin Hendrix <austin@zoox.com>
+ * Loosley based on HelloServer.cpp by Chris Morley
+ *
+ */
+
+#include "test_fixtures.h"
+// No arguments, result is "Hello".
+
+using namespace XmlRpc;
+
+void Hello::execute(XmlRpcValue& params, XmlRpcValue& result) {
+  (void)params;
+  boost::unique_lock<boost::mutex> lock(hello_mutex);
+  result = "Hello";
+}
+
+XmlRpcTest::XmlRpcTest() : hello(&s), port(0), server_done(false) {}
+
+void XmlRpcTest::work() {
+  while (!server_done) {
+    s.work(0.1); // run the worker queue for 100ms
+  }
+}
+
+void XmlRpcTest::SetUp() {
+  // XmlRpc::setVerbosity(5);
+
+  // Create the server socket on the specified port
+  s.bindAndListen(0);
+  port = s.get_port();
+
+  // Enable introspection
+  s.enableIntrospection(true);
+
+  // Start the worker thread
+  server_thread = boost::thread(boost::mem_fn(&XmlRpcTest::work), this);
+}
+
+void XmlRpcTest::TearDown() {
+  // TODO(austin): determine if we need to do anything here to avoid
+  // leaking resources
+  server_done = true;
+  if (server_thread.joinable()) {
+    server_thread.join();
+  }
+  s.shutdown();
+
+  // Reset verbosity in case a test raises the verbosity.
+  XmlRpc::setVerbosity(0);
+}

--- a/utilities/xmlrpcpp/test/test_fixtures.h
+++ b/utilities/xmlrpcpp/test/test_fixtures.h
@@ -28,7 +28,8 @@
 #include <gtest/gtest.h>
 
 // No arguments, result is "Hello".
-class Hello : public XmlRpc::XmlRpcServerMethod {
+class Hello : public XmlRpc::XmlRpcServerMethod
+{
 public:
   Hello(XmlRpc::XmlRpcServer* s) : XmlRpc::XmlRpcServerMethod("Hello", s) {}
 
@@ -39,7 +40,8 @@ public:
   boost::mutex hello_mutex;
 };
 
-class XmlRpcTest : public ::testing::Test {
+class XmlRpcTest : public ::testing::Test
+{
 protected:
   XmlRpcTest();
 

--- a/utilities/xmlrpcpp/test/test_fixtures.h
+++ b/utilities/xmlrpcpp/test/test_fixtures.h
@@ -1,0 +1,62 @@
+/*
+ * Unit tests for XmlRpc++
+ *
+ * Copyright (C) 2017, Zoox Inc
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Austin Hendrix <austin@zoox.com>
+ *
+ */
+
+#include "xmlrpcpp/XmlRpc.h"
+
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/thread.hpp>
+#include <gtest/gtest.h>
+
+// No arguments, result is "Hello".
+class Hello : public XmlRpc::XmlRpcServerMethod {
+public:
+  Hello(XmlRpc::XmlRpcServer* s) : XmlRpc::XmlRpcServerMethod("Hello", s) {}
+
+  virtual ~Hello() {}
+
+  void execute(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& result);
+
+  boost::mutex hello_mutex;
+};
+
+class XmlRpcTest : public ::testing::Test {
+protected:
+  XmlRpcTest();
+
+  void work();
+
+  virtual void SetUp();
+
+  virtual void TearDown();
+
+  // The server and its methods
+  XmlRpc::XmlRpcServer s;
+  Hello hello;
+
+  // Server port number (for clients)
+  int port;
+
+  // Server thread
+  bool server_done;
+  boost::thread server_thread;
+};

--- a/utilities/xmlrpcpp/test/test_ulimit.cpp
+++ b/utilities/xmlrpcpp/test/test_ulimit.cpp
@@ -1,0 +1,77 @@
+/*
+ * Unit tests for XmlRpc++
+ *
+ * Copyright (C) 2017, Zoox Inc
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Author: Austin Hendrix <austin@zoox.com>
+ *
+ */
+
+#include "test_fixtures.h"
+
+#include <sys/resource.h>
+
+using namespace XmlRpc;
+
+TEST_F(XmlRpcTest, Ulimit) {
+  XmlRpcClient c("localhost", port);
+  XmlRpcValue noArgs, result;
+
+  // Call the Hello method
+  ASSERT_TRUE(c.execute("Hello", noArgs, result));
+
+  EXPECT_FALSE(c.isFault());
+  XmlRpcValue hello("Hello");
+  EXPECT_EQ(result, hello);
+
+  c.close();
+  result.clear();
+
+  // Get the current open file limits and check that we have a reasonable
+  // margin. We need to reduce the limit to 8 open files to starve the server
+  // side, so we would need 9 or 10 open files for it to work correctly
+  // Ensuring that we have a hard limit of at least 64 file descriptors gives
+  // a very wide margin above that.
+  struct rlimit limit = {.rlim_cur = 0, .rlim_max = 0};
+  ASSERT_EQ(0, getrlimit(RLIMIT_NOFILE, &limit));
+  ASSERT_LT(64, limit.rlim_max);
+  ASSERT_LT(64, limit.rlim_cur);
+
+  // Reduce the number of open file descriptors so that we can create a client
+  // but can't accept the connection on the server side. 32 is more than the
+  // number of currently open files, but less than minimum unused file
+  // descriptors. We expect the server to be able to accept the connection and
+  // then immediately reject it without servicing it.
+  limit.rlim_cur = 32;
+  ASSERT_EQ(0, setrlimit(RLIMIT_NOFILE, &limit));
+
+  XmlRpcClient c2("127.0.0.1", port);
+  EXPECT_FALSE(c2.execute("Hello", noArgs, result));
+
+  // Raise the limit and verify that clients can connect again
+  limit.rlim_cur = limit.rlim_max;
+  ASSERT_EQ(0, setrlimit(RLIMIT_NOFILE, &limit));
+  c2.close();
+  EXPECT_TRUE(c2.execute("Hello", noArgs, result));
+  EXPECT_EQ(result, hello);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/utilities/xmlrpcpp/test/test_ulimit.cpp
+++ b/utilities/xmlrpcpp/test/test_ulimit.cpp
@@ -27,7 +27,8 @@
 
 using namespace XmlRpc;
 
-TEST_F(XmlRpcTest, Ulimit) {
+TEST_F(XmlRpcTest, Ulimit)
+{
   XmlRpcClient c("localhost", port);
   XmlRpcValue noArgs, result;
 


### PR DESCRIPTION
Add integration tests for the XmlRpcServer interacting with an XmlRpcClient in the same process, particularly around the behavior when the server process runs out of available file handles.

Update the XmlRpcServer with two different mitigations for file handle exhaustion (Fixes #914, replaces #960 and #977):
 * Measure the number of free file handles and reject incoming connections if the pool of free file descriptors is too small. This actively rejects incoming clients instead of waiting for complete file
handle exhaustion, which would leave clients in a pending state until a file descriptor becomes free.
 * If accept fails due to complete file handle exhaustion, temporarily stop calling accept on this socket. This prevents a busy-loop where poll() believes the listening socket is readable, but accept() fails to
allocate a file descriptor and leaves the socket in a readable state.