### PR TITLE
Test and fix uninitialized data in XmlRpcClient

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -49,18 +49,22 @@ const char * XmlRpcClient::connectionStateStr(ClientConnectionState state) {
 }
 
 XmlRpcClient::XmlRpcClient(const char* host, int port, const char* uri/*=0*/)
+  : _connectionState(NO_CONNECTION),
+  _host(host),
+  _port(port),
+  _sendAttempts(0),
+  _bytesWritten(0),
+  _executing(false),
+  _eof(false),
+  _isFault(false),
+  _contentLength(0)
 {
   XmlRpcUtil::log(1, "XmlRpcClient new client: host %s, port %d.", host, port);
 
-  _host = host;
-  _port = port;
   if (uri)
     _uri = uri;
   else
     _uri = "/RPC2";
-  _connectionState = NO_CONNECTION;
-  _executing = false;
-  _eof = false;
 
   // Default to keeping the connection open until an explicit close is done
   setKeepOpen();


### PR DESCRIPTION
Fix test problems that were exposed by uninitialized memory, properly initialize memory and add tests for proper memory initialization.

Since uninitialized memory was causing the retry logic to be skipped in these tests, the tests have been updated to properly test the retry logic in the client.