### PR TITLE
fix xmlrpc timeout using monotonic clock

### DIFF
--- a/utilities/xmlrpcpp/CMakeLists.txt
+++ b/utilities/xmlrpcpp/CMakeLists.txt
@@ -5,13 +5,13 @@ if(NOT WIN32)
   set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Wextra")
 endif()
 
-find_package(catkin REQUIRED COMPONENTS cpp_common)
+find_package(catkin REQUIRED COMPONENTS cpp_common rostime)
 
 # The CFG_EXTRAS is only for compatibility, to be removed in Lunar.
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES xmlrpcpp
-  CATKIN_DEPENDS cpp_common
+  CATKIN_DEPENDS cpp_common rostime
   CFG_EXTRAS xmlrpcpp-extras.cmake
 )
 

--- a/utilities/xmlrpcpp/CMakeLists.txt
+++ b/utilities/xmlrpcpp/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(xmlrpcpp
   libb64/src/cencode.c
 )
 
+target_link_libraries(xmlrpcpp ${catkin_LIBRARIES})
 if(WIN32)
   target_link_libraries(xmlrpcpp ws2_32)
 endif()

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcDispatch.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcDispatch.h
@@ -58,7 +58,7 @@ namespace XmlRpc {
     //! Clear all sources from the monitored sources list. Sources are closed.
     void clear();
 
-    // helper
+    // helper returning current steady/monotonic time
     double getTime();
 
     // A source to monitor and what to monitor it for

--- a/utilities/xmlrpcpp/package.xml
+++ b/utilities/xmlrpcpp/package.xml
@@ -19,8 +19,10 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>cpp_common</build_depend>
+  <build_depend version_gte="0.6.9">rostime</build_depend>
 
   <run_depend>cpp_common</run_depend>
+  <run_depend version_gte="0.6.9">rostime</run_depend>
 
   <export>
     <rosdoc external="http://xmlrpcpp.sourceforge.net/doc/hierarchy.html"/>

--- a/utilities/xmlrpcpp/package.xml
+++ b/utilities/xmlrpcpp/package.xml
@@ -1,4 +1,4 @@
-<package>
+<package format="2">
   <name>xmlrpcpp</name>
   <version>1.13.5</version>
   <description>
@@ -18,11 +18,8 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>cpp_common</build_depend>
-  <build_depend version_gte="0.6.9">rostime</build_depend>
-
-  <run_depend>cpp_common</run_depend>
-  <run_depend version_gte="0.6.9">rostime</run_depend>
+  <depend>cpp_common</depend>
+  <depend version_gte="0.6.9">rostime</depend>
 
   <export>
     <rosdoc external="http://xmlrpcpp.sourceforge.net/doc/hierarchy.html"/>

--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -223,7 +223,17 @@ XmlRpcDispatch::getTime()
 	  ((double) tbuff.timezone * 60));
 #else
   struct timespec ts;
+# ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+  clock_serv_t cclock;
+  mach_timespec_t mts;
+  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+  clock_get_time(cclock, &mts);
+  mach_port_deallocate(mach_task_self(), cclock);
+  ts.tv_sec = mts.tv_sec;
+  ts.tv_nsec = mts.tv_nsec;
+#else
   clock_gettime(CLOCK_MONOTONIC, &ts);
+#endif
   return (ts.tv_sec + ts.tv_nsec / 1000000000.0);
 #endif /* USE_FTIME */
 }

--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -3,6 +3,8 @@
 #include "xmlrpcpp/XmlRpcSource.h"
 #include "xmlrpcpp/XmlRpcUtil.h"
 
+#include "ros/time.h"
+
 #include <math.h>
 #include <errno.h>
 #include <sys/timeb.h>
@@ -222,47 +224,10 @@ XmlRpcDispatch::getTime()
   return ((double) tbuff.time + ((double)tbuff.millitm / 1000.0) +
 	  ((double) tbuff.timezone * 60));
 #else
-/*
- * copied from ros_steadytime in rostime/src/time.cpp
- */
-#ifndef WIN32
-  timespec ts;
-#if defined(__APPLE__)
-  // On macOS use clock_get_time.
-  clock_serv_t cclock;
-  mach_timespec_t mts;
-  host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
-  clock_get_time(cclock, &mts);
-  mach_port_deallocate(mach_task_self(), cclock);
-  ts.tv_sec = mts.tv_sec;
-  ts.tv_nsec = mts.tv_nsec;
-#else  // defined(__APPLE__)
-  // Otherwise use clock_gettime.
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-#endif  // defined(__APPLE__)
-  return (ts.tv_sec + ts.tv_nsec / 1000000000.0);
-#else /* WIN32 */
-  static LARGE_INTEGER cpu_frequency, performance_count;
-  // These should not ever fail since XP is already end of life:
-  // From https://msdn.microsoft.com/en-us/library/windows/desktop/ms644905(v=vs.85).aspx and
-  //      https://msdn.microsoft.com/en-us/library/windows/desktop/ms644904(v=vs.85).aspx:
-  // "On systems that run Windows XP or later, the function will always succeed and will
-  //  thus never return zero."
-  QueryPerformanceFrequency(&cpu_frequency);
-  if (cpu_frequency.QuadPart == 0) {
-    throw NoHighPerformanceTimersException();
-  }
-  QueryPerformanceCounter(&performance_count);
-  double steady_time = performance_count.QuadPart / (double) cpu_frequency.QuadPart;
-  int64_t steady_sec = floor(steady_time);
-  int64_t steady_nsec = boost::math::round((steady_time - steady_sec) * 1e9);
+  uint32_t sec, nsec;
 
-  // Throws an exception if we go out of 32-bit range
-  normalizeSecNSecUnsigned(steady_sec, steady_nsec);
-
-  return (steady_sec + steady_nsec / 1000000000.0);
-#endif /* WIN32 */
-
+  ros_steadytime(sec, nsec);
+  return ((double)sec + (double)nsec / 1e9);
 #endif /* USE_FTIME */
 }
 

--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -226,7 +226,7 @@ XmlRpcDispatch::getTime()
 #else
   uint32_t sec, nsec;
 
-  ros_steadytime(sec, nsec);
+  ros::ros_steadytime(sec, nsec);
   return ((double)sec + (double)nsec / 1e9);
 #endif /* USE_FTIME */
 }

--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -222,11 +222,9 @@ XmlRpcDispatch::getTime()
   return ((double) tbuff.time + ((double)tbuff.millitm / 1000.0) +
 	  ((double) tbuff.timezone * 60));
 #else
-  struct timeval	tv;
-  struct timezone	tz;
-
-  gettimeofday(&tv, &tz);
-  return (tv.tv_sec + tv.tv_usec / 1000000.0);
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (ts.tv_sec + ts.tv_nsec / 1000000000.0);
 #endif /* USE_FTIME */
 }
 

--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -15,7 +15,7 @@ catkin_add_gtest(test_client
   ../libb64/src/cdecode.c
   ../libb64/src/cencode.c
 )
-target_link_libraries(test_client mock_socket)
+target_link_libraries(test_client mock_socket ${catkin_LIBRARIES})
 
 catkin_add_gtest(test_dispatch
   test_dispatch.cpp
@@ -25,7 +25,7 @@ catkin_add_gtest(test_dispatch
   ../libb64/src/cdecode.c
   ../libb64/src/cencode.c
 )
-target_link_libraries(test_dispatch mock_socket)
+target_link_libraries(test_dispatch mock_socket ${catkin_LIBRARIES})
 set_target_properties(test_dispatch PROPERTIES
   LINK_FLAGS
   "-Wl,--wrap=select -Wl,--wrap=poll"


### PR DESCRIPTION
in XmlRpcDispatch::work the _endTime check was using system time instead of monotonic time,
so when time was set back it didn't process all events..