### PR TITLE
Removed unreachable exceptions.

### DIFF
--- a/clients/rospy/src/rospy/rosconsole.py
+++ b/clients/rospy/src/rospy/rosconsole.py
@@ -181,5 +181,3 @@ def main(argv=None):
         error(1, str(e))
     except KeyboardInterrupt:
         pass
-    except rospy.ROSInterruptException:
-        pass

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -203,7 +203,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
                 err_msg = "Unable to establish ssh connection to [%s%s:%s]: %s"%(username_str, address, port, e)
             except socket.error as e:
                 # #1824
-                if e[0] == 111:
+                if e.args[0] == 111:
                     err_msg = "network connection refused by [%s:%s]"%(address, port)
                 else:
                     err_msg = "network error connecting to [%s:%s]: %s"%(address, port, str(e))

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -2123,4 +2123,3 @@ def rostopicmain(argv=None):
         sys.stderr.write("ERROR: %s\n"%str(e))
         sys.exit(1)
     except KeyboardInterrupt: pass
-    except rospy.ROSInterruptException: pass


### PR DESCRIPTION
`ROSInterruptException` is a subclass of `KeyboardInterrupt` and both exceptions are being handled the same way (`pass`). I removed the `ROSInterruptException` handling since it was placed after the `KeyboardInterrupt` and was thus unreachable.