### PR TITLE
Add process listeners to XML RPC server instance

### DIFF
--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -286,7 +286,10 @@ class ROSLaunchParent(object):
         if self.process_listeners:
             for l in self.process_listeners:
                 self.runner.pm.add_process_listener(l)
-        
+                # Add listeners to server as well, otherwise they won't be
+                # called when a node on a remote machine dies.
+                self.server.add_process_listener(l)
+
     def spin_once(self):
         """
         Run the parent roslaunch event loop once


### PR DESCRIPTION
I recently noticed a bug in the roslaunch API: When I pass a ProcessListener to ROSLaunchParent, it should be called whenever a node that was launched with it dies. However, this was not working for nodes that are launched on a remote machine.  See [corresponding question on ROS Ansers](https://answers.ros.org/question/277789/monitor-remote-nodes-with-roslaunch-api/).

I digged into the code and found out that the callback calls are already forwarded to the server, but on the server side there are multiple objects holding a list of ProcessListeners that is not properly synchronized, i.e. the instance that receives the callback call from the remote machine does not have the listeners that were passed to the ROSLaunchParent.

The change I propose fixes this (at least it is working well for me now).  However, as the code is quite complicated and I don't have a complete oversight of what is going on there, I would be grateful if someone with a better understanding could check this to make sure there are no undesired side effects.

The PR is based on kinetic-devel as I currently do not have a setup to test with lunar.