### PR TITLE
Fixes #1262 - bad IPv6 initialization order.

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -316,17 +316,6 @@ void start()
     }
   }
 
-  char* env_ipv6 = NULL;
-#ifdef _MSC_VER
-  _dupenv_s(&env_ipv6, NULL, "ROS_IPV6");
-#else
-  env_ipv6 = getenv("ROS_IPV6");
-#endif
-
-  bool use_ipv6 = (env_ipv6 && strcmp(env_ipv6,"on") == 0);
-  TransportTCP::s_use_ipv6_ = use_ipv6;
-  XmlRpc::XmlRpcSocket::s_use_ipv6_ = use_ipv6;
-
 #ifdef _MSC_VER
   if (env_ipv6)
   {
@@ -430,6 +419,19 @@ end:
   }
 }
 
+void check_ipv6_environment() {
+  char* env_ipv6 = NULL;
+#ifdef _MSC_VER
+  _dupenv_s(&env_ipv6, NULL, "ROS_IPV6");
+#else
+  env_ipv6 = getenv("ROS_IPV6");
+#endif
+
+  bool use_ipv6 = (env_ipv6 && strcmp(env_ipv6,"on") == 0);
+  TransportTCP::s_use_ipv6_ = use_ipv6;
+  XmlRpc::XmlRpcSocket::s_use_ipv6_ = use_ipv6;
+}
+
 void init(const M_string& remappings, const std::string& name, uint32_t options)
 {
   if (!g_atexit_registered)
@@ -453,6 +455,7 @@ void init(const M_string& remappings, const std::string& name, uint32_t options)
 #ifndef WIN32
     signal(SIGPIPE, SIG_IGN);
 #endif
+    check_ipv6_environment();
     network::init(remappings);
     master::init(remappings);
     // names:: namespace is initialized by this_node


### PR DESCRIPTION
ROS_IPV6 environment variable was checked after first connection could be established.
This commit moves this check into early initialization.