### PR TITLE
[kinetic] Close sockets when server responds with HTTP/1.0

### DIFF
--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -370,7 +370,7 @@ void XMLRPCManager::releaseXMLRPCClient(XmlRpcClient *c)
   {
     if (c == i->client_)
     {
-      if (shutting_down_)
+      if (shutting_down_ || !c->getKeepOpen())
       {
         // if we are shutting down we won't be re-using the client
         i->client_->close();

--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -471,16 +471,10 @@ XmlRpcClient::parseResponse(XmlRpcValue& result)
       
   _response = "";
 
-  if (_header.size() < 8 || _header.find("HTTP/") != 0)
-    XmlRpcUtil::error("Error XmlRpcClient::parseResponse: Header does not start with protocol");
-  else
-  {
-    const unsigned protocolVersion = atoi(&_header[5]) * 10 + atoi(&_header[7]);
-    if (protocolVersion == 10)
-    {
-      setKeepOpen(false);
-      close();
-    }
+  // Close connection if protocol is HTTP/1.0
+  if (_header.size() > 8 && _header[5] == '1' && _header[7] == '0') {
+    setKeepOpen(false);
+    close();
   }
 
   _header = "";

--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -472,7 +472,7 @@ XmlRpcClient::parseResponse(XmlRpcValue& result)
   _response = "";
 
   // Close connection if protocol is HTTP/1.0
-  if (_header.size() > 8 && _header[5] == '1' && _header[7] == '0') {
+  if (_header.rfind("HTTP/1.0", 0) == 0) {
     setKeepOpen(false);
     close();
   }


### PR DESCRIPTION
This PR tries to detect that the server responds with HTTP/1.0 and closes the connection accordingly in the manager.

I moved the clearing part of header_ to the end of parseResponse(). Putting setKeepOpen(false) into readHeader() didn't work for me as the internal state machine is affected by it. The header_ member is public but I couldn't find any usage of it, so I would assume that this doesn't affect anybody.