### PR TITLE
rosbag rollovers based on nice wall-clock values with changable datestring format.

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -112,6 +112,7 @@ struct ROSBAG_DECL RecorderOptions
     std::string min_space_str;
 
     std::vector<std::string> topics;
+    std::string file_timestamp_format_str;
 };
 
 class ROSBAG_DECL Recorder
@@ -151,7 +152,7 @@ private:
     bool shouldSubscribeToTopic(std::string const& topic, bool from_node = false);
 
     template<class T>
-    static std::string timeToStr(T ros_t);
+    static std::string timeToStr(T ros_t, const std::string &format="%Y-%m-%d-%H-%M-%S");
 
 private:
     RecorderOptions               options_;

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -113,6 +113,7 @@ struct ROSBAG_DECL RecorderOptions
 
     std::vector<std::string> topics;
     std::string file_timestamp_format_str;
+    bool nice_split_times;
 };
 
 class ROSBAG_DECL Recorder

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -230,7 +230,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     }
     if (vm.count("time-format"))
     {
-        opts.file_timestamp_format_str = vm["time-format"].as<std::string>();
+      opts.file_timestamp_format_str = vm["time-format"].as<std::string>();
     }
     if (vm.count("size"))
     {

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -67,6 +67,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("size", po::value<uint64_t>(), "The maximum size of the bag to record in MB.")
       ("duration", po::value<std::string>(), "Record a bag of maximum duration in seconds, unless 'm', or 'h' is appended.")
       ("time-format", po::value<std::string>()->default_value("%Y-%m-%d-%H-%M-%S"), "Change format of timestamps used in the output filename (Default: %Y-%m-%d-%H-%M-%S).")
+      ("nice-split-times", "Split bag files at nice wall-clock times")
       ("node", po::value<std::string>(), "Record all topics subscribed to by a specific node.");
 
   
@@ -231,6 +232,10 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     if (vm.count("time-format"))
     {
       opts.file_timestamp_format_str = vm["time-format"].as<std::string>();
+    }
+    if (vm.count("nice-split-times"))
+    {
+      opts.nice_split_times = true;
     }
     if (vm.count("size"))
     {

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -66,6 +66,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("topic", po::value< std::vector<std::string> >(), "topic to record")
       ("size", po::value<uint64_t>(), "The maximum size of the bag to record in MB.")
       ("duration", po::value<std::string>(), "Record a bag of maximum duration in seconds, unless 'm', or 'h' is appended.")
+      ("time-format", po::value<std::string>()->default_value("%Y-%m-%d-%H-%M-%S"), "Change format of timestamps used in the output filename (Default: %Y-%m-%d-%H-%M-%S).")
       ("node", po::value<std::string>(), "Record all topics subscribed to by a specific node.");
 
   
@@ -226,6 +227,10 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       opts.max_duration = ros::Duration(duration * multiplier);
       if (opts.max_duration <= ros::Duration(0))
         throw ros::Exception("Duration must be positive.");
+    }
+    if (vm.count("time-format"))
+    {
+        opts.file_timestamp_format_str = vm["time-format"].as<std::string>();
     }
     if (vm.count("size"))
     {

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -112,7 +112,8 @@ RecorderOptions::RecorderOptions() :
     max_duration(-1.0),
     node(""),
     min_space(1024 * 1024 * 1024),
-    min_space_str("1G")
+    min_space_str("1G"),
+    file_timestamp_format_str("%Y-%m-%d-%H-%M-%S")
 {
 }
 
@@ -269,14 +270,14 @@ bool Recorder::shouldSubscribeToTopic(std::string const& topic, bool from_node) 
 }
 
 template<class T>
-std::string Recorder::timeToStr(T ros_t)
+string Recorder::timeToStr(T ros_t, const std::string &format)
 {
     (void)ros_t;
     std::stringstream msg;
     const boost::posix_time::ptime now=
         boost::posix_time::second_clock::local_time();
     boost::posix_time::time_facet *const f=
-        new boost::posix_time::time_facet("%Y-%m-%d-%H-%M-%S");
+        new boost::posix_time::time_facet(format.c_str());
     msg.imbue(std::locale(msg.getloc(),f));
     msg << now;
     return msg.str();
@@ -345,7 +346,7 @@ void Recorder::updateFilenames() {
     if (prefix.length() > 0)
         parts.push_back(prefix);
     if (options_.append_date)
-        parts.push_back(timeToStr(ros::WallTime::now()));
+        parts.push_back(timeToStr(ros::WallTime::now(), options_.file_timestamp_format_str));
     if (options_.split)
         parts.push_back(boost::lexical_cast<string>(split_count_));
 

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -169,6 +169,23 @@ int Recorder::run() {
 
     start_time_ = ros::Time::now();
 
+    // Calculate a shift if we're splitting on time duration.  We want to
+    // end up splitting on "nice" wall clock values.  To do this we shift the
+    // start time by the time elapsed since the "previous" nice interval would
+    // have started.
+    if (options_.max_duration.toSec() > 0 && options_.split)
+    {
+        // Our last interval number
+        unsigned int prev_interval = (unsigned int) (floor(start_time_.toSec() / options_.max_duration.toSec()));
+
+        // This is the ros::Time that marks the beginning of the interval we've started recording in.
+        ros::Time prev_rollover_time;
+        prev_rollover_time.fromSec(prev_interval * options_.max_duration.toSec());
+
+        // Shift the start time backwards by our 'elapsed' time since the previous period begin
+        start_time_ -= (start_time_ - prev_rollover_time);
+    }
+
     // Don't bother doing anything if we never got a valid time
     if (!nh.ok())
         return 0;

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -113,7 +113,8 @@ RecorderOptions::RecorderOptions() :
     node(""),
     min_space(1024 * 1024 * 1024),
     min_space_str("1G"),
-    file_timestamp_format_str("%Y-%m-%d-%H-%M-%S")
+    file_timestamp_format_str("%Y-%m-%d-%H-%M-%S"),
+    nice_split_times(false)
 {
 }
 
@@ -169,11 +170,10 @@ int Recorder::run() {
 
     start_time_ = ros::Time::now();
 
-    // Calculate a shift if we're splitting on time duration.  We want to
-    // end up splitting on "nice" wall clock values.  To do this we shift the
+    // We want to end up splitting on "nice" wall clock values.  To do this we shift the
     // start time by the time elapsed since the "previous" nice interval would
     // have started.
-    if (options_.max_duration.toSec() > 0 && options_.split)
+    if (options_.nice_split_times && options_.max_duration.toSec() > 0 && options_.split)
     {
         // Our last interval number
         unsigned int prev_interval = (unsigned int) (floor(start_time_.toSec() / options_.max_duration.toSec()));

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -287,7 +287,7 @@ bool Recorder::shouldSubscribeToTopic(std::string const& topic, bool from_node) 
 }
 
 template<class T>
-string Recorder::timeToStr(T ros_t, const std::string &format)
+std::string Recorder::timeToStr(T ros_t, const std::string &format)
 {
     (void)ros_t;
     std::stringstream msg;

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -88,6 +88,7 @@ def record_cmd(argv):
     parser.add_option(      "--size",          dest="size",                         type='int',   action="store", help="record a bag of maximum size SIZE MB. (Default: infinite)", metavar="SIZE")
     parser.add_option(      "--duration",      dest="duration",                     type='string',action="store", help="record a bag of maximum duration DURATION in seconds, unless 'm', or 'h' is appended.", metavar="DURATION")
     parser.add_option(      "--time-format",   dest="time_format",                  type='string',action="store", help="Change format of timestamps used in the output filename (Default: %Y-%m-%d-%H-%M-%S).", metavar="FORMAT")
+    parser.add_option(      "--nice-split-times", dest="nice_split_times",             action="store_true",          help="Split bag files at nice wall-clock times")
     parser.add_option("-b", "--buffsize",      dest="buffsize",      default=256,   type='int',   action="store", help="use an internal buffer of SIZE MB (Default: %default, 0 = infinite)", metavar="SIZE")
     parser.add_option("--chunksize",           dest="chunksize",     default=768,   type='int',   action="store", help="Advanced. Record to chunks of SIZE KB (Default: %default)", metavar="SIZE")
     parser.add_option("-l", "--limit",         dest="num",           default=0,     type='int',   action="store", help="only record NUM messages on each topic")
@@ -127,6 +128,7 @@ def record_cmd(argv):
             cmd.extend(["--max-splits", str(options.max_splits)])
     if options.duration:    cmd.extend(["--duration", options.duration])
     if options.time_format: cmd.extend(["--time-format", options.time_format])
+    if options.nice_split_times: cmd.extend(["--nice-split-times"])
     if options.size:        cmd.extend(["--size", str(options.size)])
     if options.node:
         cmd.extend(["--node", options.node])

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -87,6 +87,7 @@ def record_cmd(argv):
     parser.add_option(      "--max-splits",    dest="max_splits",                   type='int',   action="store", help="Keep a maximum of N bag files, when reaching the maximum erase the oldest one to keep a constant number of files.", metavar="MAX_SPLITS")
     parser.add_option(      "--size",          dest="size",                         type='int',   action="store", help="record a bag of maximum size SIZE MB. (Default: infinite)", metavar="SIZE")
     parser.add_option(      "--duration",      dest="duration",                     type='string',action="store", help="record a bag of maximum duration DURATION in seconds, unless 'm', or 'h' is appended.", metavar="DURATION")
+    parser.add_option(      "--time-format",   dest="time_format",                  type='string',action="store", help="Change format of timestamps used in the output filename (Default: %Y-%m-%d-%H-%M-%S).", metavar="FORMAT")
     parser.add_option("-b", "--buffsize",      dest="buffsize",      default=256,   type='int',   action="store", help="use an internal buffer of SIZE MB (Default: %default, 0 = infinite)", metavar="SIZE")
     parser.add_option("--chunksize",           dest="chunksize",     default=768,   type='int',   action="store", help="Advanced. Record to chunks of SIZE KB (Default: %default)", metavar="SIZE")
     parser.add_option("-l", "--limit",         dest="num",           default=0,     type='int',   action="store", help="only record NUM messages on each topic")
@@ -125,6 +126,7 @@ def record_cmd(argv):
         if options.max_splits:
             cmd.extend(["--max-splits", str(options.max_splits)])
     if options.duration:    cmd.extend(["--duration", options.duration])
+    if options.time_format: cmd.extend(["--time-format", options.time_format])
     if options.size:        cmd.extend(["--size", str(options.size)])
     if options.node:
         cmd.extend(["--node", options.node])


### PR DESCRIPTION
Addresses  #1280 for ~~`kinetic-devel`~~ `lunar-devel` (retargeted)

- Adds `--time-format` option to `rosbag record` to change the string formatting used for datestrings in the generated bag files.
- Changes rosbag split behavior when `--duration` is used.

The new behavior now splits at nice wall clock times.  For example, for `--duration=5m` the split times would be at 00:00, 00:05, 00:10, etc.  The first bag file created will have it's duration shortened to shift the interval splitting onto the nice times