### PR TITLE
Use HTTP/1.1 in XMLRPC Server

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -77,6 +77,9 @@ def isstring(s):
         return isinstance(s, str)
 
 class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
+
+    protocol_version = 'HTTP/1.1'
+
     def log_message(self, format, *args):
         if 0:
             SimpleXMLRPCRequestHandler.log_message(self, format, *args)
@@ -86,6 +89,9 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     Adds ThreadingMixin to SimpleXMLRPCServer to support multiple concurrent
     requests via threading. Also makes logging toggleable.
     """
+
+    daemon_threads = True
+
     def __init__(self, addr, log_requests=1):
         """
         Overrides SimpleXMLRPCServer to set option to allow_reuse_address.


### PR DESCRIPTION
This PR activates HTTP/1.1 in the XMLRPC Server and fixes the CTRL-C issues that were reported in https://github.com/ros/ros_comm/pull/371

Setting daemon_threads to True allows the program to terminate.