### PR TITLE
rosbag record modes

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -55,6 +55,7 @@
 #include <ros/time.h>
 
 #include <std_msgs/Empty.h>
+#include <std_msgs/String.h>
 #include <topic_tools/shape_shifter.h>
 
 #include "rosbag/bag.h"
@@ -84,6 +85,7 @@ public:
     ros::Time                    time;
 };
 
+enum RecordingMode { CONTINUOUS, SNAPSHOT, STARTSTOP };
 struct ROSBAG_DECL RecorderOptions
 {
     RecorderOptions();
@@ -94,7 +96,7 @@ struct ROSBAG_DECL RecorderOptions
     bool            do_exclude;
     bool            quiet;
     bool            append_date;
-    bool            snapshot;
+    RecordingMode   mode;
     bool            verbose;
     CompressionType compression;
     std::string     prefix;
@@ -139,6 +141,7 @@ private:
     bool checkDisk();
 
     void snapshotTrigger(std_msgs::Empty::ConstPtr trigger);
+    void triggerStartStop(std_msgs::String::ConstPtr trigger);
     //    void doQueue(topic_tools::ShapeShifter::ConstPtr msg, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doRecord();

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -36,6 +36,7 @@
 #include "rosbag/exceptions.h"
 
 #include "boost/program_options.hpp"
+#include <boost/algorithm/string/predicate.hpp>
 #include <string>
 #include <sstream>
 
@@ -49,6 +50,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
 
     desc.add_options()
       ("help,h", "produce help message")
+      ("mode", po::value<std::string>()->implicit_value("continuous"), "Recording mode: continuous, snapshot, or startstop")
       ("all,a", "record all topics")
       ("regex,e", "match topics using regular expressions")
       ("exclude,x", po::value<std::string>(), "exclude topics matching regular expressions")
@@ -88,6 +90,18 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     if (vm.count("help")) {
       std::cout << desc << std::endl;
       exit(0);
+    }
+
+    if (vm.count("mode")) {
+        const std::string &token = vm["mode"].as<std::string>();
+        if (boost::starts_with("continuous", token))
+            opts.mode = rosbag::CONTINUOUS;
+        else if (boost::starts_with("snapshot", token))
+            opts.mode = rosbag::SNAPSHOT;
+        else if (boost::starts_with("startstop", token))
+            opts.mode = rosbag::STARTSTOP;
+        else
+            throw ros::Exception("Unknown recording mode: " + token);
     }
 
     if (vm.count("all"))

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -50,7 +50,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
 
     desc.add_options()
       ("help,h", "produce help message")
-      ("mode", po::value<std::string>()->implicit_value("continuous"), "Recording mode: continuous, snapshot, or startstop")
+      ("mode,m", po::value<std::string>()->implicit_value("continuous"), "Recording mode: continuous, snapshot, or startstop")
       ("all,a", "record all topics")
       ("regex,e", "match topics using regular expressions")
       ("exclude,x", po::value<std::string>(), "exclude topics matching regular expressions")

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -77,6 +77,7 @@ def record_cmd(argv):
                                    description="Record a bag file with the contents of specified topics.",
                                    formatter=optparse.IndentedHelpFormatter())
 
+    parser.add_option("-m", "--mode",          dest="mode",          default="continuous",        action="store", help="Recording mode: continuous, snapshot, or startstop")
     parser.add_option("-a", "--all",           dest="all",           default=False, action="store_true",          help="record all topics")
     parser.add_option("-e", "--regex",         dest="regex",         default=False, action="store_true",          help="match topics using regular expressions")
     parser.add_option("-x", "--exclude",       dest="exclude_regex", default="",    action="store",               help="exclude topics matching the follow regular expression (subtracts from -a or regex)")
@@ -110,6 +111,7 @@ def record_cmd(argv):
     cmd.extend(['--buffsize',  str(options.buffsize)])
     cmd.extend(['--chunksize', str(options.chunksize)])
 
+    if options.mode:          cmd.extend(["--mode", options.mode])
     if options.num != 0:      cmd.extend(['--limit', str(options.num)])
     if options.quiet:         cmd.extend(["--quiet"])
     if options.prefix:        cmd.extend(["-o", options.prefix])


### PR DESCRIPTION
This PR improves `rosbag record` in the following fashion:
- Re-enable `snapshot` mode, which was implemented but not exposed, because `RecorderOptions::snapshot` was always initialized `false`.
- Add new `startstop` mode, which allows to start/stop recording without subscription delay. In this mode, the recorder listens to the topic `start_stop`, which accepts a string as follows:
-- `start` (re)starts recording
-- `start:<filename>` (re)starts recording to new filename
-- `stop` pauses recording
