### PR TITLE
Topic subscription scalability fix

### DIFF
--- a/clients/roscpp/src/libros/io.cpp
+++ b/clients/roscpp/src/libros/io.cpp
@@ -328,6 +328,12 @@ pollfd_vector_ptr poll_sockets(int epfd, socket_pollfd *fds, nfds_t nfds, int ti
 #else
 	UNUSED(epfd);
 	pollfd_vector_ptr ofds(new std::vector<socket_pollfd>);
+        // Clear the `revents` fields
+        for (nfds_t i = 0; i < nfds; i++)
+        {
+                fds[i].revents = 0;
+        }
+
 	// use an existing poll implementation
 	int result = poll(fds, nfds, timeout);
 	if ( result < 0 )

--- a/clients/roscpp/src/libros/poll_set.cpp
+++ b/clients/roscpp/src/libros/poll_set.cpp
@@ -279,6 +279,7 @@ void PollSet::createNativePollset()
     pfd.events = info.events_;
     pfd.revents = 0;
   }
+  sockets_changed_ = false;
 }
 
 void PollSet::onLocalPipeEvents(int events)


### PR DESCRIPTION
Address a long standing issue where the `sockets_changed_` flag would never be reset causing the native poll set to be re-created everytime doing a poll.