### PR TITLE
suppress sequential identical messages

### DIFF
--- a/clients/rospy/src/rospy/__init__.py
+++ b/clients/rospy/src/rospy/__init__.py
@@ -58,6 +58,7 @@ from .core import is_shutdown, signal_shutdown, \
     get_node_uri, get_ros_root, \
     logdebug, logwarn, loginfo, logout, logerr, logfatal, \
     logdebug_throttle, logwarn_throttle, loginfo_throttle, logerr_throttle, logfatal_throttle, \
+    logdebug_throttle_identical, logwarn_throttle_identical, loginfo_throttle_identical, logerr_throttle_identical, logfatal_throttle_identical, \
     logdebug_once, logwarn_once, loginfo_once, logerr_once, logfatal_once, \
     parse_rosrpc_uri
 from .exceptions import *

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -43,7 +43,7 @@ except ImportError:
     import pickle
 import inspect
 import logging
-from md5 import md5
+from hashlib import md5
 import os
 import signal
 import sys

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -43,6 +43,7 @@ except ImportError:
     import pickle
 import inspect
 import logging
+from md5 import md5
 import os
 import signal
 import sys
@@ -151,6 +152,7 @@ def _base_logger(msg, *args, **kwargs):
     throttle = kwargs.pop('logger_throttle', None)
     level = kwargs.pop('logger_level', None)
     once = kwargs.pop('logger_once', False)
+    throttle_identical = kwargs.pop('logger_throttle_identical', False)
 
     rospy_logger = logging.getLogger('rosout')
     if name:
@@ -160,6 +162,13 @@ def _base_logger(msg, *args, **kwargs):
     if once:
         caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
         if _logging_once(caller_id):
+            logfunc(msg, *args)
+    elif throttle_identical:
+        caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
+        throttle_elapsed = False
+        if throttle is not None:
+            throttle_elapsed = _logging_throttle(caller_id, throttle)
+        if _logging_identical(caller_id, msg) or throttle_elapsed:
             logfunc(msg, *args)
     elif throttle:
         caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
@@ -213,6 +222,27 @@ class LoggingThrottle(object):
 
 
 _logging_throttle = LoggingThrottle()
+
+
+class LoggingIdentical(object):
+
+    last_logging_msg_table = {}
+
+    def __call__(self, caller_id, msg):
+        """Do logging specified message only if distinct from last message.
+
+        - caller_id (str): Id to identify the caller
+        - msg (str): Contents of message to log
+        """
+        msg_hash = md5(msg).hexdigest()
+
+        if msg_hash != self.last_logging_msg_table.get(caller_id):
+            self.last_logging_msg_table[caller_id] = msg_hash
+            return True
+        return False
+
+
+_logging_identical = LoggingIdentical()
 
 
 def _frame_to_caller_id(frame):
@@ -595,4 +625,3 @@ def xmlrpcapi(uri):
     if not uriValidate[0] or not uriValidate[1]:
         return None
     return xmlrpcclient.ServerProxy(uri)
-

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -144,7 +144,16 @@ def rospyerr(msg, *args):
 def rospywarn(msg, *args):
     """Internal rospy client library warn logging"""
     _rospy_logger.warn(msg, *args)
-    
+
+
+def _frame_to_caller_id(frame):
+    caller_id = (
+        inspect.getabsfile(frame),
+        frame.f_lineno,
+        frame.f_lasti,
+    )
+    return pickle.dumps(caller_id)
+
 
 def _base_logger(msg, *args, **kwargs):
 
@@ -224,6 +233,22 @@ class LoggingThrottle(object):
 _logging_throttle = LoggingThrottle()
 
 
+def logdebug_throttle(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_level='debug')
+
+def loginfo_throttle(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_level='info')
+
+def logwarn_throttle(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_level='warn')
+
+def logerr_throttle(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_level='error')
+
+def logfatal_throttle(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_level='critical')
+
+
 class LoggingIdentical(object):
 
     last_logging_msg_table = {}
@@ -245,29 +270,26 @@ class LoggingIdentical(object):
 _logging_identical = LoggingIdentical()
 
 
-def _frame_to_caller_id(frame):
-    caller_id = (
-        inspect.getabsfile(frame),
-        frame.f_lineno,
-        frame.f_lasti,
-    )
-    return pickle.dumps(caller_id)
+def logdebug_throttle_identical(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_throttle_identical=True,
+                 logger_level='debug')
 
+def loginfo_throttle_identical(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_throttle_identical=True,
+                 logger_level='info')
 
-def logdebug_throttle(period, msg):
-    _base_logger(msg, logger_throttle=period, logger_level='debug')
+def logwarn_throttle_identical(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_throttle_identical=True,
+                 logger_level='warn')
 
-def loginfo_throttle(period, msg):
-    _base_logger(msg, logger_throttle=period, logger_level='info')
+def logerr_throttle_identical(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_throttle_identical=True,
+                 logger_level='error')
 
-def logwarn_throttle(period, msg):
-    _base_logger(msg, logger_throttle=period, logger_level='warn')
+def logfatal_throttle_identical(period, msg):
+    _base_logger(msg, logger_throttle=period, logger_throttle_identical=True,
+                 logger_level='critical')
 
-def logerr_throttle(period, msg):
-    _base_logger(msg, logger_throttle=period, logger_level='error')
-
-def logfatal_throttle(period, msg):
-    _base_logger(msg, logger_throttle=period, logger_level='critical')
 
 class LoggingOnce(object):
 

--- a/test/test_rospy/test/rostest/test_rospy_client_online.py
+++ b/test/test_rospy/test/rostest/test_rospy_client_online.py
@@ -164,7 +164,7 @@ class TestRospyClientOnline(unittest.TestCase):
                     self.assert_("test 1" in lout_last)
                     lout_len = len(lout.getvalue())
                     rospy.sleep(rospy.Duration(1))
-                elif i == 1:  # making sure the length of lerr doesnt change
+                elif i == 1:  # making sure the length of lout doesnt change
                     self.assert_(lout_len == len(lout.getvalue()))
                     rospy.sleep(rospy.Duration(2))
                 else:
@@ -211,7 +211,96 @@ class TestRospyClientOnline(unittest.TestCase):
                     rospy.sleep(rospy.Duration(2))
                 else:
                     self.assert_("test 4" in lerr_last)
-            
+
+            # logXXX_throttle_identical
+            lout_len = -1
+            for i in range(5):
+                if i < 2:
+                    test_text = "test 1"
+                else:
+                    test_text = "test 1a"
+                rospy.loginfo_throttle_identical(2, test_text)
+                lout_last = lout.getvalue().splitlines()[-1]
+                if i == 0:  # Confirm test text was logged
+                    self.assert_(test_text in lout_last)
+                    lout_len = len(lout.getvalue())
+                elif i == 1:  # Confirm the length of lout hasn't changed
+                    self.assert_(lout_len == len(lout.getvalue()))
+                elif i == 2:  # Confirm the new message was logged correctly
+                    self.assert_(test_text in lout_last)
+                    lout_len = len(lout.getvalue())
+                    rospy.sleep(rospy.Duration(2))
+                elif i == 3:  # Confirm the length of lout has changed
+                    self.assert_(lout_len != len(lout.getvalue()))
+                else:  # Confirm new test text is in last log
+                    self.assert_(test_text in lout_last)
+
+            lerr_len = -1
+            for i in range(5):
+                if i < 2:
+                    test_text = "test 2"
+                else:
+                    test_text = "test 2a"
+                rospy.logwarn_throttle_identical(2, test_text)
+                lerr_last = lerr.getvalue().splitlines()[-1]
+                if i == 0:  # Confirm test text was logged
+                    self.assert_(test_text in lerr_last)
+                    lerr_len = len(lerr.getvalue())
+                elif i == 1:  # Confirm the length of lerr hasn't changed
+                    self.assert_(lerr_len == len(lerr.getvalue()))
+                elif i == 2:  # Confirm the new message was logged correctly
+                    self.assert_(test_text in lerr_last)
+                    lerr_len = len(lerr.getvalue())
+                    rospy.sleep(rospy.Duration(2))
+                elif i == 3:  # Confirm the length of lerr has incremented
+                    self.assert_(lerr_len != len(lerr.getvalue()))
+                else:  # Confirm new test text is in last log
+                    self.assert_(test_text in lerr_last)
+
+            lerr_len = -1
+            for i in range(5):
+                if i < 2:
+                    test_text = "test 3"
+                else:
+                    test_text = "test 3a"
+                rospy.logerr_throttle_identical(2, test_text)
+                lerr_last = lerr.getvalue().splitlines()[-1]
+                if i == 0:  # Confirm test text was logged
+                    self.assert_(test_text in lerr_last)
+                    lerr_len = len(lerr.getvalue())
+                elif i == 1:  # Confirm the length of lerr hasn't changed
+                    self.assert_(lerr_len == len(lerr.getvalue()))
+                elif i == 2:  # Confirm the new message was logged correctly
+                    self.assert_(test_text in lerr_last)
+                    lerr_len = len(lerr.getvalue())
+                    rospy.sleep(rospy.Duration(2))
+                elif i == 3:  # Confirm the length of lerr has incremented
+                    self.assert_(lerr_len != len(lerr.getvalue()))
+                else:  # Confirm new test text is in last log
+                    self.assert_(test_text in lerr_last)
+
+            lerr_len = -1
+            for i in range(5):
+                if i < 2:
+                    test_text = "test 4"
+                else:
+                    test_text = "test 4a"
+                rospy.logfatal_throttle_identical(2, test_text)
+                lerr_last = lerr.getvalue().splitlines()[-1]
+                if i == 0:  # Confirm test text was logged
+                    self.assert_(test_text in lerr_last)
+                    lerr_len = len(lerr.getvalue())
+                elif i == 1:  # Confirm the length of lerr hasn't changed
+                    self.assert_(lerr_len == len(lerr.getvalue()))
+                elif i == 2:  # Confirm the new message was logged correctly
+                    self.assert_(test_text in lerr_last)
+                    lerr_len = len(lerr.getvalue())
+                    rospy.sleep(rospy.Duration(2))
+                elif i == 3:  # Confirm the length of lerr has incremented
+                    self.assert_(lerr_len != len(lerr.getvalue()))
+                else:  # Confirm new test text is in last log
+                    self.assert_(test_text in lerr_last)
+
             rospy.loginfo("test child logger 1", logger_name="log1")
             lout_last = lout.getvalue().splitlines()[-1]
             self.assert_("test child logger 1" in lout_last)


### PR DESCRIPTION
Frequently nodes will spam messages that unhelpfully fill up logs. recently throttling by period was added to python to help reduce this spam, but sometimes simply throttling by period will suppress new information when your log is not static. I am proposing the inclusion of a throttler that will filter out identical sequential messages to help reduce log spam when desired.

the LoggingIdentical class is set up similarly to existing LoggingThrottle class and plays nicely with throttling by period. Filtering out sequential identical logs is triggered by setting kwarg `logger_throttle_identical` to true. When this flag is set a given log will publish if
a) the new message is not identical to previous message
or
b) throttle by period is set and throttle period has elapsed.

