### PR TITLE
Raise the correct exception from AnyMsg.serialize

### DIFF
--- a/clients/rospy/src/rospy/msg.py
+++ b/clients/rospy/src/rospy/msg.py
@@ -69,7 +69,7 @@ class AnyMsg(genpy.Message):
     def serialize(self, buff):
         """AnyMsg provides an implementation so that a node can forward messages w/o (de)serialization"""
         if self._buff is None:
-            raise rospy.exceptions("AnyMsg is not initialized")
+            raise rospy.exceptions.ROSException("AnyMsg is not initialized")
         else:
             buff.write(self._buff)
             

--- a/test/test_rospy/test/unit/test_rospy_api.py
+++ b/test/test_rospy/test/unit/test_rospy_api.py
@@ -66,12 +66,13 @@ class TestRospyApi(unittest.TestCase):
         except ImportError:
             from io import StringIO
         import rospy
+        import rospy.exceptions
         #trip wires against AnyMsg API
         m = rospy.AnyMsg()
         try:
             m.serialize(StringIO())
             self.fail("AnyMsg should not allow serialization")
-        except:
+        except rospy.exceptions.ROSException:
             pass
 
         teststr = 'foostr-%s'%time.time()


### PR DESCRIPTION
Previously, this was causing `TypeError: 'module' object is not
callable`, which was not noticed due to the bare `except:` in the test.

I wasn't able to run the tests, so I'm relying on CI to test that part of the change. I tried running them within a `ros:lunar` docker container with:
```
catkin_make --pkg ros_comm
catkin_make run_tests_test_rospy_rostest
```
but got lots of errors like:
```
  File "/catkin_ws/src/ros_comm/clients/rospy/src/rospy/client.py", line 68, in <module>
    from roscpp.srv import GetLoggers, GetLoggersResponse, SetLoggerLevel, SetLoggerLevelResponse
ImportError: No module named srv
```