### PR TITLE
adding decompress to free(state) before return (targeting Lunar)

### DIFF
--- a/utilities/roslz4/src/lz4s.c
+++ b/utilities/roslz4/src/lz4s.c
@@ -584,7 +584,7 @@ int roslz4_buffToBuffCompress(char *input, unsigned int input_size,
   int ret;
   ret = roslz4_compressStart(&stream, block_size_id);
   if (ret != ROSLZ4_OK) {
-    roslz4_decompressEnd(&stream);
+    roslz4_compressEnd(&stream);
     return ret;
   }
 

--- a/utilities/roslz4/src/lz4s.c
+++ b/utilities/roslz4/src/lz4s.c
@@ -616,10 +616,7 @@ int roslz4_buffToBuffDecompress(char *input, unsigned int input_size,
 
   int ret;
   ret = roslz4_decompressStart(&stream);
-  if (ret != ROSLZ4_OK) {
-    roslz4_decompressEnd(&stream);
-    return ret;
-  }
+  if (ret != ROSLZ4_OK) { return ret; }
 
   while (stream.input_left > 0 && ret != ROSLZ4_STREAM_END) {
     ret = roslz4_decompress(&stream);

--- a/utilities/roslz4/src/lz4s.c
+++ b/utilities/roslz4/src/lz4s.c
@@ -583,7 +583,10 @@ int roslz4_buffToBuffCompress(char *input, unsigned int input_size,
 
   int ret;
   ret = roslz4_compressStart(&stream, block_size_id);
-  if (ret != ROSLZ4_OK) { return ret; }
+  if (ret != ROSLZ4_OK) {
+    roslz4_decompressEnd(&stream);
+    return ret;
+  }
 
   while (stream.input_left > 0 && ret != ROSLZ4_STREAM_END) {
     ret = roslz4_compress(&stream, ROSLZ4_FINISH);
@@ -613,7 +616,10 @@ int roslz4_buffToBuffDecompress(char *input, unsigned int input_size,
 
   int ret;
   ret = roslz4_decompressStart(&stream);
-  if (ret != ROSLZ4_OK) { return ret; }
+  if (ret != ROSLZ4_OK) {
+    roslz4_decompressEnd(&stream);
+    return ret;
+  }
 
   while (stream.input_left > 0 && ret != ROSLZ4_STREAM_END) {
     ret = roslz4_decompress(&stream);


### PR DESCRIPTION
Replaces #1293 targeting the latest development branch.