### PR TITLE
[roslaunch-deps] Print warning for package.xml, not manifest.xml.

### DIFF
--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -365,7 +365,7 @@ def roslaunch_deps_main(argv=sys.argv):
         print('\nMissing declarations:')
         for pkg, miss in missing.items():
             if miss:
-                print("%s/manifest.xml:"%pkg)
+                print("%s/package.xml:"%pkg)
                 for m in miss:
                     print('  <depend package="%s" />'%m)
     


### PR DESCRIPTION
Mentioning about manifest.xml could be just confusing with little benefit these days.

```
$ apt-cache policy ros-kinetic-roslaunch
ros-kinetic-roslaunch:
  Installed: 1.12.12-0xenial-20171116-224009-0800
  Candidate: 1.12.12-0xenial-20171116-224009-0800

$ roslaunch-deps -w app.launch
Dependencies:
rviz robot_state_publisher joint_state_publisher tf rgbd_launch openni2_launch nodelet

Missing declarations:
pkg_AA/manifest.xml:
  <depend package="rviz" />
  <depend package="robot_state_publisher" />
  <depend package="joint_state_publisher" />
  <depend package="tf" />
  <depend package="openni2_launch" />
```