### PR TITLE
Add rosconsole echo

### DIFF
--- a/clients/rospy/src/rospy/rosconsole.py
+++ b/clients/rospy/src/rospy/rosconsole.py
@@ -154,6 +154,8 @@ class RosConsoleEcho(object):
         'FATAL': 95,  # Light magenta
     }
 
+    LEVEL_MAX_LENGTH = max([len(level) for level in LEVEL_COLOR.keys()])
+
     def __init__(self, options):
         self._filter = re.compile(options.filter)
         self._level = getattr(Log, options.level.upper())
@@ -166,9 +168,10 @@ class RosConsoleEcho(object):
         rospy.Subscriber(options.topic, Log, callback)
 
     def _stringify(self, level):
-        string = level.ljust(5)
+        string = level.ljust(RosConsoleEcho.LEVEL_MAX_LENGTH)
 
-        return string if self._nocolor else '\033[{}m{}\033[0m'.format(self.LEVEL_COLOR[level], string)
+        return string if self._nocolor else \
+               '\033[{}m{}\033[0m'.format(self.LEVEL_COLOR[level], string)
 
     @staticmethod
     def get_levels():

--- a/clients/rospy/src/rospy/rosconsole.py
+++ b/clients/rospy/src/rospy/rosconsole.py
@@ -201,7 +201,8 @@ def _get_cmd_echo_argparse(prog):
     parser.add_argument('filter', metavar='FILTER', type=str, nargs='?', default='.*',
                         help='regular expression to filter the logger name (default: %(default)s)')
 
-    parser.add_argument('level', metavar='LEVEL', type=str, nargs='?', default='warn',
+    parser.add_argument('-l', '--level', action='store', metavar='LEVEL',
+                        type=str, default='warn', dest='level',
                         choices=[level.lower() for level in RosConsoleEcho.get_levels()],
                         help='minimum logger level to print (default: %(default)s)')
 

--- a/clients/rospy/src/rospy/rosconsole.py
+++ b/clients/rospy/src/rospy/rosconsole.py
@@ -174,7 +174,7 @@ class RosConsoleEcho(object):
 
         self._filter = re.compile(options.filter)
         self._level = self.STRING_LEVEL[options.level.lower()]
-        self._detail = options.detail
+        self._verbose = options.verbose
 
         callback = self._once_callback if options.once else self._callback
         rospy.Subscriber(options.topic, Log, callback)
@@ -183,7 +183,7 @@ class RosConsoleEcho(object):
         print('[ {} ] [\033[1m{}\033[21m]: {}'.format(
             self._level_string_map[msg.level], msg.name, msg.msg))
 
-        if self._detail:
+        if self._verbose:
             stamp_sec = msg.header.stamp.to_sec()
             stamp_tz = datetime.fromtimestamp(stamp_sec, tzlocal())
 
@@ -218,7 +218,7 @@ def _get_cmd_echo_argparse(prog):
 
     parser.add_argument('--nocolor', action='store_true', help='output without color')
 
-    parser.add_argument('-d', '--detail', action='store_true', help='print full logger details')
+    parser.add_argument('-v', '--verbose', action='store_true', help='print full logger details')
 
     return parser
 

--- a/clients/rospy/src/rospy/rosconsole.py
+++ b/clients/rospy/src/rospy/rosconsole.py
@@ -160,20 +160,12 @@ class RosConsoleEcho(object):
         Log.FATAL: '\033[95mFATAL\033[0m',
     }
 
-    STRING_LEVEL = {
-        'debug': Log.DEBUG,
-        'info' : Log.INFO,
-        'warn' : Log.WARN,
-        'error': Log.ERROR,
-        'fatal': Log.FATAL,
-    }
-
     def __init__(self, options):
         self._level_string_map = self.LEVEL_STRING_NO_COLOR if options.nocolor else \
                                  self.LEVEL_STRING_COLOR
 
         self._filter = re.compile(options.filter)
-        self._level = self.STRING_LEVEL[options.level.lower()]
+        self._level = getattr(Log, options.level.upper())
         self._verbose = options.verbose
 
         callback = self._once_callback if options.once else self._callback

--- a/clients/rospy/src/rospy/rosconsole.py
+++ b/clients/rospy/src/rospy/rosconsole.py
@@ -233,8 +233,6 @@ def _rosconsole_cmd_echo(argv):
 
     rospy.spin()
 
-    del rosconsole
-
 
 def _fullusage():
     print("""rosconsole is a command-line tool for configuring the logger level of ROS nodes.


### PR DESCRIPTION
This PR adds a new command to `rosconsole` that allows to print the logger messages from the `/rosout` or `/rosout_agg` topic using only the CLI.

This new command is `echo`, so we can simply call `rosconsole echo` to see all the logger messages. The command takes multiple optional arguments that modify its behaviour, as shown below:
```bash
$ rosconsole echo -h
usage: rosconsole echo [-h] [-1] [--topic TOPIC] [--nocolor] [-d]
                       [FILTER] [LEVEL]

Print logger messages

positional arguments:
  FILTER         regular expression to filter the logger name (default: .*)
  LEVEL          minimum logger level to print (default: warn)

optional arguments:
  -h, --help     show this help message and exit
  -1, --once     prints one logger message and exits
  --topic TOPIC  topic to read the logger messages from (default: /rosout)
  --nocolor      output without color
  -d, --detail   print full logger details
```

This video shows how it works using two test nodes from https://github.com/efernandez/rosconsole_echo_test:
[![https://youtu.be/Bn7f26OKBD8](http://img.youtube.com/vi/Bn7f26OKBD8/0.jpg)](http://www.youtube.com/watch?v=Bn7f26OKBD8)

The two positional arguments supports auto-complete hints thanks to https://github.com/ros/ros/pull/168.

This is slightly inspired on @guillaumeautran 's [`rosdiagnostic` tool](https://github.com/ros/diagnostics/blob/indigo-devel/rosdiagnostic/src/rosdiagnostic/rosdiagnostic.py). I tried to make it closer to how the other `rosconsole` commands are though, and also auto-complete friendly.