### PR TITLE
roslaunch: add --log option

### DIFF
--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -140,6 +140,9 @@ def _get_optparse():
     parser.add_option("--screen",
                       dest="force_screen", default=False, action="store_true",
                       help="Force output of all local nodes to screen")
+    parser.add_option("--log",
+                      dest="force_log", default=False, action="store_true",
+                      help="Force output of all local nodes to log")
     parser.add_option("-u", "--server_uri",
                       dest="server_uri", default=None,
                       help="URI of server. Required with -c", metavar="URI")
@@ -313,6 +316,7 @@ def main(argv=sys.argv):
             p = roslaunch_parent.ROSLaunchParent(uuid, args, roslaunch_strs=roslaunch_strs,
                     is_core=options.core, port=options.port, local_only=options.local_only,
                     verbose=options.verbose, force_screen=options.force_screen,
+                    force_log=options.force_log,
                     num_workers=options.num_workers, timeout=options.timeout,
                     master_logger_level=options.master_logger_level)
             p.start()

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -73,7 +73,7 @@ class ROSLaunchParent(object):
     """
 
     def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,
-            verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
+            verbose=False, force_screen=False, force_log=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
         """
         @param run_id: UUID of roslaunch session
         @type  run_id: str
@@ -93,6 +93,8 @@ class ROSLaunchParent(object):
         @type  verbose: boolean
         @param force_screen: (optional) force output of all nodes to screen
         @type  force_screen: boolean
+        @param force_log: (optional) force output of all nodes to log
+        @type  force_log: boolean
         @param is_rostest bool: if True, this launch is a rostest
             instance. This affects validation checks.
         @type  is_rostest: bool
@@ -124,6 +126,7 @@ class ROSLaunchParent(object):
         # the outside into the roslaunch parent. One possibility is to
         # allow alternate config loaders to be passed in.
         self.force_screen = force_screen
+        self.force_log = force_log
         
         # flag to prevent multiple shutdown attempts
         self._shutting_down = False
@@ -138,6 +141,9 @@ class ROSLaunchParent(object):
         if self.force_screen:
             for n in self.config.nodes:
                 n.output = 'screen'
+        if self.force_log:
+            for n in self.config.nodes:
+                n.output = 'log'
 
     def _start_pm(self):
         """


### PR DESCRIPTION
add --log option which force all node output to log, Useful when you store all information in log file