### PR TITLE
Enable statistics by default, with lazy publishing

### DIFF
--- a/clients/rospy/src/rospy/impl/statistics.py
+++ b/clients/rospy/src/rospy/impl/statistics.py
@@ -54,7 +54,7 @@ class SubscriberStatisticsLogger():
         # disable statistics if node can't talk to parameter server
         # which is the case in unit tests
         try:
-            return rospy.get_param("/enable_statistics", False)
+            return rospy.get_param("/enable_statistics", True)
         except Exception:
             return False
 
@@ -103,7 +103,9 @@ class SubscriberStatisticsLogger():
             if logger is None:
                 logger = ConnectionStatisticsLogger(self.subscriber_name, rospy.get_name(), publisher)
                 self.connections[publisher] = logger
-
+            if logger.pub.get_num_connections() == 0:
+                return
+                
             # delegate stuff to that instance
             logger.callback(self, msg, stat_bytes)
         except Exception as e:

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -617,9 +617,7 @@ class _SubscriberImpl(_TopicImpl):
         self.queue_size = None
         self.buff_size = DEFAULT_BUFF_SIZE
         self.tcp_nodelay = False
-        self.statistics_logger = SubscriberStatisticsLogger(self) \
-            if SubscriberStatisticsLogger.is_enabled() \
-            else None
+        self.statistics_logger = SubscriberStatisticsLogger(self)
 
     def close(self):
         """close I/O and release resources"""


### PR DESCRIPTION
statistics are now enabled by default in roscpp and rospy nodes. Statistics publishing is now lazy publishing, meaning that no statistics will be computed and published to /statistics until there is a subscriber on the topic.