### PR TITLE
Strip quotes around strings before putting onto parameter server

### DIFF
--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -814,7 +814,7 @@ void init(const M_string& remappings)
   for (; it != end; ++it)
   {
     const std::string& name = it->first;
-    const std::string& param = it->second;
+    std::string param = it->second;
 
     if (name.size() < 2)
     {
@@ -857,6 +857,18 @@ void init(const M_string& remappings)
       if (success)
       {
         continue;
+      }
+
+      // Eliminate double or single quotes around text, which will
+      // save numerical strings like "'583'" as "583"
+      // (while "583" will have been turned into an int above.)
+      // This should be identical behavior to doing the same in python.
+      if ((param.length() > 1) &&
+          (((param[0] == '\'') && (param[param.length() - 1] == '\'')) ||
+           ((param[0] == '"') && (param[param.length() - 1] == '"'))))
+      {
+        param.erase(0, 1);
+        param.erase(param.length() - 1, 1);
       }
 
       if (param == "true" || param == "True" || param == "TRUE")

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -76,6 +76,24 @@ TEST(Params, setThenGetString)
   XmlRpc::XmlRpcValue v;
   param::get("test_set_param", v);
   ASSERT_EQ(v.getType(), XmlRpc::XmlRpcValue::TypeString);
+
+  // numerical string
+  param::set( "test_set_param_string", std::string("1234") );
+  param = "";
+  ASSERT_TRUE( param::get( "test_set_param_string", param ) );
+  ASSERT_STREQ( "1234", param.c_str() );
+
+  param::get("test_set_param_string", v);
+  ASSERT_EQ(v.getType(), XmlRpc::XmlRpcValue::TypeString);
+
+  // float string
+  param::set( "test_set_param_string", std::string("57.34") );
+  param = "";
+  ASSERT_TRUE( param::get( "test_set_param_string", param ) );
+  ASSERT_STREQ( "57.34", param.c_str() );
+
+  param::get("test_set_param_string", v);
+  ASSERT_EQ(v.getType(), XmlRpc::XmlRpcValue::TypeString);
 }
 
 TEST(Params, setThenGetStringCached)

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -51,6 +51,14 @@ class LoadException(RLException):
     """Error loading data as specified (e.g. cannot find included files, etc...)"""
     pass
 
+# strip one layer of quotes
+def strip_quotes(value):
+    if len(value) > 1:
+        if ((value[0] == "'" and value[-1] == "'") or
+            (value[0] == '"' and value[-1] == '"')):
+            value = value[1:-1]
+    return value
+
 #TODO: lists, maps(?)
 def convert_value(value, type_):
     """
@@ -80,9 +88,10 @@ def convert_value(value, type_):
         if lval == 'true' or lval == 'false':
             return convert_value(value, 'bool')
         #string
-        return value
+        # strip quotes like rosparam set
+        return strip_quotes(value)
     elif type_ == 'str' or type_ == 'string':
-        return value
+        return strip_quotes(value)
     elif type_ == 'int':
         return int(value)
     elif type_ == 'double':


### PR DESCRIPTION
The behavior of setting strings through rosparam set and rospy node command line args should all be the same, this allows setting numerical strings through the command line e.g. _foo:="'43'" which gets stored as string 43.

For #1339 

Consider stripping the quotes from roslaunch params for additional consistency.