### PR TITLE
Respawn nodes on remote machine correctly after reboot

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -331,10 +331,11 @@ class Machine(object):
     specification.
     """
     __slots__ = ['name', 'address', 'ssh_port', 'user', 'password', 'assignable',
-                 'env_loader', 'timeout']
+                 'env_loader', 'timeout', 'respawn', 'respawn_delay']
     def __init__(self, name, address,
                  env_loader=None, ssh_port=22, user=None, password=None, 
-                 assignable=True, env_args=[], timeout=None):
+                 assignable=True, env_args=[], timeout=None, respawn=None,
+                 respawn_delay=None):
         """
         :param name: machine name, ``str``
         :param address: network address of machine, ``str``
@@ -342,6 +343,8 @@ class Machine(object):
         :param ssh_port: SSH port number, ``int``
         :param user: SSH username, ``str``
         :param password: SSH password. Not recommended for use. Use SSH keys instead., ``str``
+        :param respawn: should the roslaunch client on this machine be respawned when it is lost on the remote machine
+        :param respawn_delay: time before respawn
         """
         self.name = name
         self.env_loader = env_loader
@@ -350,10 +353,12 @@ class Machine(object):
         self.address = address
         self.ssh_port = ssh_port
         self.assignable = assignable
+        self.respawn = respawn
+        self.respawn_delay = respawn_delay
         self.timeout = timeout or _DEFAULT_REGISTER_TIMEOUT
         
     def __str__(self):
-        return "Machine(name[%s] env_loader[%s] address[%s] ssh_port[%s] user[%s] assignable[%s] timeout[%s])"%(self.name, self.env_loader, self.address, self.ssh_port, self.user, self.assignable, self.timeout)
+        return "Machine(name[%s] env_loader[%s] address[%s] ssh_port[%s] user[%s] assignable[%s] timeout[%s] respawn[%s] respawn_delay[%s])"%(self.name, self.env_loader, self.address, self.ssh_port, self.user, self.assignable, self.timeout, self.respawn, self.respawn_delay)
     def __eq__(self, m2):
         if not isinstance(m2, Machine):
             return False

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -52,7 +52,7 @@ from roslaunch.core import printlog_bold, printerrlog, RLException
 import roslaunch.launch
 import roslaunch.pmon
 import roslaunch.server
-import roslaunch.xmlloader 
+import roslaunch.xmlloader
 
 from rosmaster.master_api import NUM_WORKERS
 

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -614,6 +614,10 @@ class ProcessMonitor(Thread):
                         # stop process, don't accumulate errors
                         r.stop([])
                         r.start()
+                        if r.__class__.__name__ == "SSHChildROSLaunchProcess":
+                            time.sleep(3)
+                            printlog("Remote child Roslaunch respawned. Respawning its remote nodes.")
+                            r.relaunch_nodes()
                     else:
                         # not ready yet, keep it around
                         _respawn.append(r)

--- a/tools/roslaunch/src/roslaunch/remote.py
+++ b/tools/roslaunch/src/roslaunch/remote.py
@@ -190,9 +190,9 @@ in your launch"""%'\n'.join([" * %s (timeout %ss)"%(m.name, m.timeout) for m in 
         for child in self.remote_processes:
             nodes = self.remote_nodes[child.machine.config_key()]
             body = '\n'.join([n.to_remote_xml() for n in nodes])
-            # #3799: force utf-8 encoding 
-            xml = '<?xml version="1.0" encoding="utf-8"?>\n<launch>\n%s</launch>'%body 
-                
+            # #3799: force utf-8 encoding
+            xml = '<?xml version="1.0" encoding="utf-8"?>\n<launch>\n%s</launch>'%body
+            child.nodes_xml = xml
             api = child.getapi()
             # TODO: timeouts
             try:
@@ -212,7 +212,7 @@ in your launch"""%'\n'.join([" * %s (timeout %ss)"%(m.name, m.timeout) for m in 
 
             except socket.gaierror as e:
                 errno, msg = e
-                # usually errno == -2. See #815. 
+                # usually errno == -2. See #815.
                 child_host, _ = network.parse_http_host_and_port(child.uri)
                 printerrlog("Unable to contact remote roslaunch at [%s]. This is most likely due to a network misconfiguration with host lookups. Please make sure that you can contact '%s' from this machine"%(child.uri, child_host))
                 self._assume_failed(nodes, failed)

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -446,7 +446,8 @@ class XmlLoader(loader.Loader):
                 "Invalid <node> tag: %s. \n\nNode xml is %s"%(e, tag.toxml()))
 
     MACHINE_ATTRS = ('name', 'address', 'env-loader', 
-                     'ssh-port', 'user', 'password', 'default', 'timeout')
+                     'ssh-port', 'user', 'password',
+                     'default', 'timeout', 'respawn', 'respawn_delay')
     @ifunless
     def _machine_tag(self, tag, context, ros_config, verbose=True):
         try:
@@ -466,8 +467,8 @@ class XmlLoader(loader.Loader):
             # optional attributes
             attrs = self.opt_attrs(tag, context,
                                    ('env-loader', 
-                                    'ssh-port', 'user', 'password', 'default', 'timeout'))
-            env_loader, ssh_port, user, password, default, timeout = attrs
+                                    'ssh-port', 'user', 'password', 'default', 'timeout', 'respawn', 'respawn_delay'))
+            env_loader, ssh_port, user, password, default, timeout, respawn, respawn_delay = attrs
 
             ssh_port = int(ssh_port or '22')
 
@@ -498,7 +499,8 @@ class XmlLoader(loader.Loader):
 
             m = Machine(name, address, env_loader=env_loader,
                         ssh_port=ssh_port, user=user, password=password, 
-                        assignable=assignable, env_args=context.env_args, timeout=timeout)
+                        assignable=assignable, env_args=context.env_args,
+                        timeout=timeout, respawn=respawn, respawn_delay=respawn_delay)
             return (m, is_default)
         except KeyError as e:
             raise XmlParseException("<machine> tag is missing required attribute: %s"%e)


### PR DESCRIPTION
I had a use case not yet supported by roslaunch, using the machine tag to launch nodes on a remote machine (additional Rpi or Odroid gathering sensor data on a robot).

Unfortunately it happens from time to time that the remote machine loses power and reboots, this can only be recovered by restarting the whole robot's bringup in the current implementation. I added a respawn an respawn_delay attributes the the Machine class in order to first respawn the child roslaunch process on the remote machine, then a function "relaunch_nodes" to the SSHChildROSLaunchProcess class that does basically the same as launch_remote_nodes from ROSRemoteRunner.

There are two points I still want to discuss though:

1. Rebooting takes some time, so I added a while loop in _ssh_exec that keeps retrying to connect whenever a socket.error is thrown (remote machine still not rebooted yet). It will fail after  TIMEOUT_SSH_REBOOT = 30 has elapsed. A simpler approach would be to just increase the newly introduced respawn_delay in the machine tag to a time after which the remote machine should have already rebooted, but that is rather heuristic.

2. In my actual pull request, relaunch_nodes and launch_remote_nodes are redundant, I could just move launch_remote_nodes to SSHChildROSLaunchProcess.

Some feedback would be helpful.