### PR TITLE
Support respawning for machine tag and add some logic to correctly re…

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -332,10 +332,11 @@ class Machine(object):
     specification.
     """
     __slots__ = ['name', 'address', 'ssh_port', 'user', 'password', 'assignable',
-                 'env_loader', 'timeout']
+                 'env_loader', 'timeout', 'respawn', 'respawn_delay']
     def __init__(self, name, address,
                  env_loader=None, ssh_port=22, user=None, password=None, 
-                 assignable=True, env_args=[], timeout=None):
+                 assignable=True, env_args=[], timeout=None, respawn=None,
+                 respawn_delay=None):
         """
         :param name: machine name, ``str``
         :param address: network address of machine, ``str``
@@ -343,6 +344,8 @@ class Machine(object):
         :param ssh_port: SSH port number, ``int``
         :param user: SSH username, ``str``
         :param password: SSH password. Not recommended for use. Use SSH keys instead., ``str``
+        :param respawn: should the roslaunch client on this machine be respawned when it is lost on the remote machine
+        :param respawn_delay: time before respawn
         """
         self.name = name
         self.env_loader = env_loader
@@ -351,10 +354,12 @@ class Machine(object):
         self.address = address
         self.ssh_port = ssh_port
         self.assignable = assignable
+        self.respawn = respawn
+        self.respawn_delay = respawn_delay
         self.timeout = timeout or _DEFAULT_REGISTER_TIMEOUT
         
     def __str__(self):
-        return "Machine(name[%s] env_loader[%s] address[%s] ssh_port[%s] user[%s] assignable[%s] timeout[%s])"%(self.name, self.env_loader, self.address, self.ssh_port, self.user, self.assignable, self.timeout)
+        return "Machine(name[%s] env_loader[%s] address[%s] ssh_port[%s] user[%s] assignable[%s] timeout[%s] respawn[%s] respawn_delay[%s])"%(self.name, self.env_loader, self.address, self.ssh_port, self.user, self.assignable, self.timeout, self.respawn, self.respawn_delay)
     def __eq__(self, m2):
         if not isinstance(m2, Machine):
             return False

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -52,7 +52,7 @@ from roslaunch.core import printlog_bold, printerrlog, RLException
 import roslaunch.launch
 import roslaunch.pmon
 import roslaunch.server
-import roslaunch.xmlloader 
+import roslaunch.xmlloader
 
 from rosmaster.master_api import NUM_WORKERS
 

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -614,6 +614,10 @@ class ProcessMonitor(Thread):
                         # stop process, don't accumulate errors
                         r.stop([])
                         r.start()
+                        if r.__class__.__name__ == "SSHChildROSLaunchProcess":
+                            time.sleep(3)
+                            printlog("Remote child Roslaunch respawned. Respawning its remote nodes.")
+                            r.relaunch_nodes()
                     else:
                         # not ready yet, keep it around
                         _respawn.append(r)

--- a/tools/roslaunch/src/roslaunch/remote.py
+++ b/tools/roslaunch/src/roslaunch/remote.py
@@ -190,9 +190,9 @@ in your launch"""%'\n'.join([" * %s (timeout %ss)"%(m.name, m.timeout) for m in 
         for child in self.remote_processes:
             nodes = self.remote_nodes[child.machine.config_key()]
             body = '\n'.join([n.to_remote_xml() for n in nodes])
-            # #3799: force utf-8 encoding 
-            xml = '<?xml version="1.0" encoding="utf-8"?>\n<launch>\n%s</launch>'%body 
-                
+            # #3799: force utf-8 encoding
+            xml = '<?xml version="1.0" encoding="utf-8"?>\n<launch>\n%s</launch>'%body
+            child.nodes_xml = xml
             api = child.getapi()
             # TODO: timeouts
             try:
@@ -212,7 +212,7 @@ in your launch"""%'\n'.join([" * %s (timeout %ss)"%(m.name, m.timeout) for m in 
 
             except socket.gaierror as e:
                 errno, msg = e
-                # usually errno == -2. See #815. 
+                # usually errno == -2. See #815.
                 child_host, _ = network.parse_http_host_and_port(child.uri)
                 printerrlog("Unable to contact remote roslaunch at [%s]. This is most likely due to a network misconfiguration with host lookups. Please make sure that you can contact '%s' from this machine"%(child.uri, child_host))
                 self._assume_failed(nodes, failed)

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -39,6 +39,7 @@ Process handler for launching ssh-based roslaunch child processes.
 import os
 import socket
 import traceback
+import time
 try:
     from xmlrpc.client import ServerProxy
 except ImportError:
@@ -48,12 +49,14 @@ import rosgraph
 from roslaunch.core import printlog, printerrlog
 import roslaunch.pmon
 import roslaunch.server
-
+import rosgraph.network as network
 import logging
 _logger = logging.getLogger("roslaunch.remoteprocess")
 
 # #1975 timeout for creating ssh connections
-TIMEOUT_SSH_CONNECT = 30.
+TIMEOUT_SSH_CONNECT = 10.
+TIMEOUT_SSH_REBOOT = 30.
+
 
 def ssh_check_known_hosts(ssh, address, port, username=None, logger=None):
     """
@@ -138,9 +141,13 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         super(SSHChildROSLaunchProcess, self).__init__(name, args, {})
         self.machine = machine
         self.master_uri = master_uri
+        self.respawn = machine.respawn
+        self.respawn_delay = machine.respawn_delay or 0.0
+        self.time_of_death = None
         self.ssh = self.sshin = self.sshout = self.ssherr = None
         self.started = False
         self.uri = None
+        self.nodes_xml = None
         # self.is_dead is a flag set by is_alive that affects whether or not we
         # log errors during a stop(). 
         self.is_dead = False
@@ -185,28 +192,37 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         
         if not err_msg:
             username_str = '%s@'%username if username else ''
-            try:
-                if not password: #use SSH agent
-                    ssh.connect(address, port, username, timeout=TIMEOUT_SSH_CONNECT, key_filename=identity_file)
-                else: #use SSH with login/pass
-                    ssh.connect(address, port, username, password, timeout=TIMEOUT_SSH_CONNECT)
-            except paramiko.BadHostKeyException:
-                _logger.error(traceback.format_exc())
-                err_msg =  "Unable to verify host key for remote computer[%s:%s]"%(address, port)
-            except paramiko.AuthenticationException:
-                _logger.error(traceback.format_exc())
-                err_msg = "Authentication to remote computer[%s%s:%s] failed.\nA common cause of this error is a missing key in your authorized_keys file."%(username_str, address, port)
-            except paramiko.SSHException as e:
-                _logger.error(traceback.format_exc())
-                if str(e).startswith("Unknown server"):
-                    pass
-                err_msg = "Unable to establish ssh connection to [%s%s:%s]: %s"%(username_str, address, port, e)
-            except socket.error as e:
-                # #1824
-                if e.args[0] == 111:
-                    err_msg = "network connection refused by [%s:%s]"%(address, port)
-                else:
-                    err_msg = "network error connecting to [%s:%s]: %s"%(address, port, str(e))
+            start_time = time.time()
+            while 1:
+                err_msg = None
+                try:
+                    if not password: #use SSH agent
+                        ssh.connect(address, port, username, timeout=TIMEOUT_SSH_CONNECT, key_filename=identity_file)
+                    else: #use SSH with login/pass
+                        ssh.connect(address, port, username, password, timeout=TIMEOUT_SSH_CONNECT)
+                except paramiko.BadHostKeyException:
+                    _logger.error(traceback.format_exc())
+                    err_msg =  "Unable to verify host key for remote computer[%s:%s]"%(address, port)
+                except paramiko.AuthenticationException:
+                    _logger.error(traceback.format_exc())
+                    err_msg = "Authentication to remote computer[%s%s:%s] failed.\nA common cause of this error is a missing key in your authorized_keys file."%(username_str, address, port)
+                except paramiko.SSHException as e:
+                    _logger.error(traceback.format_exc())
+                    if str(e).startswith("Unknown server"):
+                        pass
+                    err_msg = "Unable to establish ssh connection to [%s%s:%s]: %s"%(username_str, address, port, e)
+                except socket.error as e:
+                    # #1824
+                    if e[0] == 111:
+                        err_msg = "network connection refused by [%s:%s]"%(address, port)
+                    else:
+                        err_msg = "network error connecting to [%s:%s]: %s"%(address, port, str(e))
+                    if time.time() - start_time < TIMEOUT_SSH_REBOOT:
+                        printlog(err_msg)
+                        time.sleep(1)
+                        printlog("Retrying to connect.")
+                        continue
+                break
         if err_msg:
             return None, err_msg
         else:
@@ -238,6 +254,36 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
             self.started = True            
             return True
 
+    def relaunch_nodes(self):
+        succeeded = []
+        failed = []
+        api = self.getapi()
+        if self.nodes_xml is not None:
+            try:
+                _logger.debug("sending [%s] XML [\n%s\n]" % (self.uri, self.nodes_xml))
+                code, msg, val = api.launch(self.nodes_xml)
+                if code == 1:
+                    c_succ, c_fail = val
+                    succeeded.extend(c_succ)
+                    failed.extend(c_fail)
+                else:
+                    printerrlog('error launching on [%s, uri %s]: %s' % (
+                    self.name, self.uri, msg))
+            except socket.error as e:
+                errno, msg = e
+                printerrlog('error launching on [%s, uri %s]: %s' % (
+                self.name, self.uri, str(msg)))
+            except socket.gaierror as e:
+                errno, msg = e
+                # usually errno == -2. See #815.
+                child_host, _ = network.parse_http_host_and_port(self.uri)
+                printerrlog("Unable to contact remote roslaunch at [%s]. This is most likely due to a network misconfiguration with host lookups. Please make sure that you can contact '%s' from this machine"%(child.uri, child_host))
+
+            except Exception as e:
+                printerrlog('error launching on [%s, uri %s]: %s'%(self.name, self.uri, str(e)))
+        else:
+            _logger.error("xml provided is not defined")
+
     def getapi(self):
         """
         :returns: ServerProxy to remote client XMLRPC server, `ServerProxy`
@@ -263,6 +309,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
             data = s.read(2048)
             if not len(data):
                 self.is_dead = True
+                self.time_of_death = time.time()
                 return False
             # #2012 il8n: ssh *should* be UTF-8, but often isn't
             # (e.g. Japan)

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -448,7 +448,8 @@ class XmlLoader(loader.Loader):
                 "Invalid <node> tag: %s. \n\nNode xml is %s"%(e, tag.toxml()))
 
     MACHINE_ATTRS = ('name', 'address', 'env-loader', 
-                     'ssh-port', 'user', 'password', 'default', 'timeout')
+                     'ssh-port', 'user', 'password',
+                     'default', 'timeout', 'respawn', 'respawn_delay')
     @ifunless
     def _machine_tag(self, tag, context, ros_config, verbose=True):
         try:
@@ -468,8 +469,8 @@ class XmlLoader(loader.Loader):
             # optional attributes
             attrs = self.opt_attrs(tag, context,
                                    ('env-loader', 
-                                    'ssh-port', 'user', 'password', 'default', 'timeout'))
-            env_loader, ssh_port, user, password, default, timeout = attrs
+                                    'ssh-port', 'user', 'password', 'default', 'timeout', 'respawn', 'respawn_delay'))
+            env_loader, ssh_port, user, password, default, timeout, respawn, respawn_delay = attrs
 
             ssh_port = int(ssh_port or '22')
 
@@ -500,7 +501,8 @@ class XmlLoader(loader.Loader):
 
             m = Machine(name, address, env_loader=env_loader,
                         ssh_port=ssh_port, user=user, password=password, 
-                        assignable=assignable, env_args=context.env_args, timeout=timeout)
+                        assignable=assignable, env_args=context.env_args,
+                        timeout=timeout, respawn=respawn, respawn_delay=respawn_delay)
             return (m, is_default)
         except KeyError as e:
             raise XmlParseException("<machine> tag is missing required attribute: %s"%e)


### PR DESCRIPTION
I had a use case not yet supported by roslaunch, using the machine tag to launch nodes on a remote machine (additional Rpi or Odroid gathering sensor data on a robot).

Unfortunately it happens from time to time that the remote machine loses power and reboots, this can only be recovered by restarting the whole robot's bringup in the current implementation. I added a respawn an respawn_delay attributes the the Machine class in order to first respawn the child roslaunch process on the remote machine, then a function "relaunch_nodes" to the SSHChildROSLaunchProcess class that does basically the same as launch_remote_nodes from ROSRemoteRunner.

There are two points I still want to discuss though:

1. Rebooting takes some time, so I added a while loop in _ssh_exec that keeps retrying to connect whenever a socket.error is thrown (remote machine still not rebooted yet). It will fail after TIMEOUT_SSH_REBOOT = 30 has elapsed. A simpler approach would be to just increase the newly introduced respawn_delay in the machine tag to a time after which the remote machine should have already rebooted, but that is rather heuristic.

2. In my actual pull request, relaunch_nodes and launch_remote_nodes are redundant, I could just move launch_remote_nodes to SSHChildROSLaunchProcess.

Some feedback would be helpful.