### PR TITLE
Take XmlRpcValue by *const* ref. in operator<<

### DIFF
--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
@@ -189,7 +189,7 @@ namespace XmlRpc {
 } // namespace XmlRpc
 
 
-std::ostream& operator<<(std::ostream& os, XmlRpc::XmlRpcValue& v);
+std::ostream& operator<<(std::ostream& os, const XmlRpc::XmlRpcValue& v);
 
 
 #endif // _XMLRPCVALUE_H_

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -653,10 +653,10 @@ namespace XmlRpc {
 
 
 // ostream
-std::ostream& operator<<(std::ostream& os, XmlRpc::XmlRpcValue& v) 
-{ 
+std::ostream& operator<<(std::ostream& os, const XmlRpc::XmlRpcValue& v)
+{
   // If you want to output in xml format:
-  //return os << v.toXml(); 
+  //return os << v.toXml();
   return v.write(os);
 }
 


### PR DESCRIPTION
This allows to use the `operator<<` also with const references to `XmlRpcValue` objects, not only non-const ones.