### PR TITLE
Fix check for header first in rosbag play for rate control topic

### DIFF
--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -310,6 +310,7 @@ void Player::updateRateTopicTime(const ros::MessageEvent<topic_tools::ShapeShift
             if (s.find("Header ") == 0) {
                 flag = true;
             }
+            break;
         }
     }
     // If the header is not the first element in the message according to the definition, throw an error.

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -305,7 +305,7 @@ void Player::updateRateTopicTime(const ros::MessageEvent<topic_tools::ShapeShift
     std::string s;
     bool flag = false;
     while(std::getline(f, s, '\n')) {
-        if (s.find("#") != 0) {
+        if (!s.empty() && s.find("#") != 0) {
             // Does not start with #, is not a comment.
             if(s == "Header header") {
                 flag = true;

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -307,7 +307,7 @@ void Player::updateRateTopicTime(const ros::MessageEvent<topic_tools::ShapeShift
     while(std::getline(f, s, '\n')) {
         if (!s.empty() && s.find("#") != 0) {
             // Does not start with #, is not a comment.
-            if(s == "Header header") {
+            if (s.find("Header ") == 0) {
                 flag = true;
             }
         }


### PR DESCRIPTION
The check doesn't work for `sensor_msgs/Image` (see definition [here](http://docs.ros.org/api/sensor_msgs/html/msg/Image.html)). This PR fixes it.

Example code with the new checks for the `sensor_msgs/Image` definition: https://wandbox.org/permlink/1Oin9UytKs9JFf2h