### PR TITLE
fix "pass_all_args" for roslaunch-check

### DIFF
--- a/tools/roslaunch/resources/example-args.launch
+++ b/tools/roslaunch/resources/example-args.launch
@@ -1,0 +1,3 @@
+<launch>
+  <arg name="test_foo" />
+</launch>

--- a/tools/roslaunch/resources/example-pass_all_args.launch
+++ b/tools/roslaunch/resources/example-pass_all_args.launch
@@ -1,0 +1,4 @@
+<launch>
+  <arg name="test_foo" default="value_foo" />
+  <include file="$(find roslaunch)/resources/example-args.launch" pass_all_args="true" />
+</launch>

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -170,6 +170,12 @@ def _parse_launch(tags, launch_file, file_deps, verbose, context):
                 else:
                     launch_tag = dom[0]
                     sub_context = _parse_subcontext(tag.childNodes, context)
+                    try:
+                        if tag.attributes['pass_all_args']:
+                            sub_context["arg"] = context["arg"]
+                            sub_context["arg"].update(_parse_subcontext(tag.childNodes, context)["arg"])
+                    except KeyError as e:
+                        pass
                     _parse_launch(launch_tag.childNodes, sub_launch_file, file_deps, verbose, sub_context)
             except IOError as e:
                 raise RoslaunchDepsException("Cannot load roslaunch include '%s' in '%s'"%(sub_launch_file, launch_file))

--- a/tools/roslaunch/test/unit/test_roslaunch_rlutil.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_rlutil.py
@@ -84,4 +84,8 @@ class TestRoslaunchRlutil(unittest.TestCase):
                 self.fail("should have failed")
             except roslaunch.RLException:
                 pass
-            
+
+    def test_roslaunch_check_pass_all_args(self):
+        filename = os.path.join(get_example_path(), 'example-pass_all_args.launch')
+        error_msg = roslaunch.rlutil.check_roslaunch(filename)
+        assert error_msg is None


### PR DESCRIPTION
the option "pass_all_args" was not recognized by roslaunch checks. This works as expected on "our" launch files which create a mixed tree using the "pass_all_args" option as well as explicit argument forwarding