### PR TITLE
fix sphinx warning

### DIFF
--- a/utilities/message_filters/conf.py
+++ b/utilities/message_filters/conf.py
@@ -23,7 +23,7 @@ import os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.pngmath']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx', 'sphinx.ext.imgmath']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Aiming to fix the sphinx warning from the doc job: http://build.ros.org/job/Mdoc__ros_comm__ubuntu_bionic_amd64/7/console#console-section-14

> WARNING: sphinx.ext.pngmath has been deprecated. Please use sphinx.ext.imgmath instead.