### PR TITLE
keep connection header information in rosbag operations (#679, #685)

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -104,6 +104,7 @@ class Compression:
     LZ4  = 'lz4'
 
 BagMessage = collections.namedtuple('BagMessage', 'topic message timestamp')
+BagMessageWithConnectionHeader = collections.namedtuple('BagMessageWithConnectionHeader', 'topic message timestamp connection_header')
 
 class Bag(object):
     """
@@ -250,7 +251,7 @@ class Bag(object):
         
     chunk_threshold = property(_get_chunk_threshold, _set_chunk_threshold)
 
-    def read_messages(self, topics=None, start_time=None, end_time=None, connection_filter=None, raw=False):
+    def read_messages(self, topics=None, start_time=None, end_time=None, connection_filter=None, raw=False, return_connection_header=False):
         """
         Read messages from the bag, optionally filtered by topic, timestamp and connection details.
         @param topics: list of topics or a single topic. if an empty list is given all topics will be read [optional]
@@ -271,7 +272,7 @@ class Bag(object):
         if topics and type(topics) is str:
             topics = [topics]
         
-        return self._reader.read_messages(topics, start_time, end_time, connection_filter, raw)
+        return self._reader.read_messages(topics, start_time, end_time, connection_filter, raw, return_connection_header)
 
     def flush(self):
         """
@@ -284,7 +285,7 @@ class Bag(object):
         if self._chunk_open:
             self._stop_writing_chunk()
 
-    def write(self, topic, msg, t=None, raw=False):
+    def write(self, topic, msg, t=None, raw=False, connection_header=None):
         """
         Write a message to the bag.
         @param topic: name of topic
@@ -343,10 +344,20 @@ class Bag(object):
                 if pytype._md5sum != md5sum:
                     print('WARNING: md5sum of loaded type [%s] does not match that specified' % msg_type, file=sys.stderr)
                     #raise ROSBagException('md5sum of loaded type does not match that of data being recorded')
-            
-                header = { 'topic' : topic, 'type' : msg_type, 'md5sum' : md5sum, 'message_definition' : pytype._full_text }
+
+                header = connection_header if connection_header is not None else {
+                    'topic': topic,
+                    'type': msg_type,
+                    'md5sum': md5sum,
+                    'message_definition': pytype._full_text
+                }
             else:
-                header = { 'topic' : topic, 'type' : msg.__class__._type, 'md5sum' : msg.__class__._md5sum, 'message_definition' : msg._full_text }
+                header = connection_header if connection_header is not None else {
+                    'topic': topic,
+                    'type': msg.__class__._type,
+                    'md5sum': msg.__class__._md5sum,
+                    'message_definition': msg._full_text
+                }
 
             connection_info = _ConnectionInfo(conn_id, topic, header)
 
@@ -1725,7 +1736,7 @@ class _BagReader(object):
     def start_reading(self):
         raise NotImplementedError()
 
-    def read_messages(self, topics, start_time, end_time, connection_filter, raw):
+    def read_messages(self, topics, start_time, end_time, connection_filter, raw, return_connection_header):
         raise NotImplementedError()
 
     def reindex(self):
@@ -1790,7 +1801,7 @@ class _BagReader102_Unindexed(_BagReader):
             
             offset = f.tell()
 
-    def read_messages(self, topics, start_time, end_time, topic_filter, raw):
+    def read_messages(self, topics, start_time, end_time, topic_filter, raw, return_connection_header):
         f = self.bag._file
 
         f.seek(self.bag._file_header_pos)
@@ -1850,7 +1861,10 @@ class _BagReader102_Unindexed(_BagReader):
                 msg = msg_type()
                 msg.deserialize(data)
 
-            yield BagMessage(topic, msg, t)
+            if return_connection_header:
+                yield BagMessageWithConnectionHeader(topic, msg, t, info.header)
+            else:
+                yield BagMessage(topic, msg, t)
 
         self.bag._connection_indexes_read = True
 
@@ -2331,10 +2345,10 @@ class _BagReader200(_BagReader):
 
         self.bag._connection_indexes_read = True
 
-    def read_messages(self, topics, start_time, end_time, connection_filter, raw):
+    def read_messages(self, topics, start_time, end_time, connection_filter, raw, return_connection_header):
         connections = self.bag._get_connections(topics, connection_filter)
         for entry in self.bag._get_entries(connections, start_time, end_time):
-            yield self.seek_and_read_message_data_record((entry.chunk_pos, entry.offset), raw)
+            yield self.seek_and_read_message_data_record((entry.chunk_pos, entry.offset), raw, return_connection_header)
 
     ###
 
@@ -2422,7 +2436,7 @@ class _BagReader200(_BagReader):
 
         return (connection_id, index)
 
-    def seek_and_read_message_data_record(self, position, raw):
+    def seek_and_read_message_data_record(self, position, raw, return_connection_header):
         chunk_pos, offset = position
 
         chunk_header = self.bag._chunk_headers.get(chunk_pos)
@@ -2485,8 +2499,11 @@ class _BagReader200(_BagReader):
         else:
             msg = msg_type()
             msg.deserialize(data)
-        
-        return BagMessage(connection_info.topic, msg, t)
+
+        if return_connection_header:
+            return BagMessageWithConnectionHeader(connection_info.topic, msg, t, connection_info.header)
+        else:
+            return BagMessage(connection_info.topic, msg, t)
 
 def _time_to_str(secs):
     secs_frac = secs - int(secs) 


### PR DESCRIPTION
This PR provides a fix for the issue that `rosbag filter` & `rosbag compress` removes latching information from topic connection headers.
See #679 for a nice description. This PR is based on that discussion, but follows a slightly different implementation.


You can see the difference by using [this script](https://gist.github.com/ddimarco/f3e22b27d16f7d3d8f2b9c5dece3a78c) (the script needs the patched code to access the bag headers):
```
# using current kinetic-devel branch
$ rosbag compress test_rosbag.bag --output-dir /tmp/
$ show_bag_headers.py /tmp/test_rosbag.bag           
/chatter_no_latch: {u'topic': '/chatter_no_latch', u'message_definition': 'string data\n', u'md5sum': '992ce8a1687cec8c8bd883ec73ca41d1', u'type': 'std_msgs/String'}
/chatter_latch: {u'topic': '/chatter_latch', u'message_definition': 'string data\n', u'md5sum': '992ce8a1687cec8c8bd883ec73ca41d1', u'type': 'std_msgs/String'}

# this PR
$ rosbag compress test_rosbag.bag --output-dir /tmp/
$ show_bag_headers.py /tmp/test_rosbag.bag           
/chatter_no_latch: {u'message_definition': 'string data\n', u'callerid': '/talker', u'latching': '0', u'md5sum': '992ce8a1687cec8c8bd883ec73ca41d1', u'topic': '/chatter_no_latch', u'type': 'std_msgs/String'}
/chatter_latch: {u'message_definition': 'string data\n', u'callerid': '/talker', u'latching': '1', u'md5sum': '992ce8a1687cec8c8bd883ec73ca41d1', u'topic': '/chatter_latch', u'type': 'std_msgs/String'}
```