### PR TITLE
Use boost::shared_ptr to fix memory leak in BagPlayer

### DIFF
--- a/tools/rosbag_storage/include/rosbag/bag_player.h
+++ b/tools/rosbag_storage/include/rosbag/bag_player.h
@@ -116,7 +116,7 @@ public:
 private:
     ros::Time real_time(const ros::Time &msg_time);
 
-    std::map<std::string, BagCallback *> cbs_;
+    std::map<std::string, boost::shared_ptr<BagCallback> > cbs_;
     ros::Time bag_start_;
     ros::Time bag_end_;
     ros::Time last_message_time_;
@@ -127,7 +127,7 @@ private:
 template<class T>
 void BagPlayer::register_callback(const std::string &topic,
         typename BagCallbackT<T>::Callback cb) {
-    cbs_[topic] = new BagCallbackT<T>(cb);
+    cbs_[topic] = boost::make_shared<BagCallbackT<T> >(cb);
 }
 
 }

--- a/tools/rosbag_storage/src/bag_player.cpp
+++ b/tools/rosbag_storage/src/bag_player.cpp
@@ -43,7 +43,7 @@ ros::Time BagPlayer::real_time(const ros::Time &msg_time) {
 void BagPlayer::start_play() {
 
     std::vector<std::string> topics;
-    std::pair<std::string, BagCallback *> cb;
+    std::pair<std::string, boost::shared_ptr<BagCallback> > cb;
     foreach(cb, cbs_)
         topics.push_back(cb.first);
 
@@ -63,7 +63,6 @@ void BagPlayer::start_play() {
 }
 
 void BagPlayer::unregister_callback(const std::string &topic) {
-    delete cbs_[topic];
     cbs_.erase(topic);
 }
 


### PR DESCRIPTION
This fixes two memory leaks in `BagPlayer` by changing the `std::map` of RAW pointers to `BagCallback` to smart pointers `boost::shared_ptr<BagCallback>`"

1. On destruction, b/c the destructor doesn't `delete` the RAW pointers in the `std::map`.
2. In `register_callback` is called with the same `topic` name more than once w/o calling `unregister_callback` for that topic name.

This should also work now if we call `unregister_callback` for a topic not previously registered. Before that would `delete` a null pointer.