### PR TITLE
Fix integer overflow for oneshot timers.

### DIFF
--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -584,7 +584,7 @@ void TimerManager<T, D, E>::threadFunc()
       {
         // On system time we can simply sleep for the rest of the wait time, since anything else requiring processing will
         // signal the condition variable
-        int64_t remaining_time = static_cast<int64_t>(std::max((sleep_end - current).toSec() * 1000.0f, 1.0));
+        int64_t remaining_time = std::max<int64_t>((sleep_end - current).toSec() * 1000.0f, 1);
         timers_cond_.timed_wait(lock, boost::posix_time::milliseconds(remaining_time));
       }
     }

--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -584,7 +584,7 @@ void TimerManager<T, D, E>::threadFunc()
       {
         // On system time we can simply sleep for the rest of the wait time, since anything else requiring processing will
         // signal the condition variable
-        int32_t remaining_time = std::max((int32_t)((sleep_end - current).toSec() * 1000.0f), 1);
+        int64_t remaining_time = std::max((int64_t)((sleep_end - current).toSec() * 1000.0f), (int64_t)1);
         timers_cond_.timed_wait(lock, boost::posix_time::milliseconds(remaining_time));
       }
     }

--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -584,7 +584,7 @@ void TimerManager<T, D, E>::threadFunc()
       {
         // On system time we can simply sleep for the rest of the wait time, since anything else requiring processing will
         // signal the condition variable
-        int64_t remaining_time = std::max((int64_t)((sleep_end - current).toSec() * 1000.0f), (int64_t)1);
+        int64_t remaining_time = static_cast<int64_t>(std::max((sleep_end - current).toSec() * 1000.0f, 1.0));
         timers_cond_.timed_wait(lock, boost::posix_time::milliseconds(remaining_time));
       }
     }


### PR DESCRIPTION
I noticed that the `robot_state_publisher` node takes a significant of cpu time although it's basically doing nothing (urdf with only fixed joints). After debugging a bit, I noticed that the cpu consumption stems from a `ros::Timer` with `oneshot = true`:

Interestingly, when stopping the oneshot timer after its callback has been called, almost no cpu is consumed. This I could verify by creating two simple nodes, one that stops the timer and one that doesn't, and comparing their consumed cpu time:

Timer is stopped:
```cpp
// Stops the oneshot timer after callback execution. No significant cpu usage.
ros::Timer timer;
timer = nh.createTimer(ros::Duration(0.1), [&timer](const ros::TimerEvent&) {
  timer.stop();
}, true /* oneshot */);
```

Timer is not stopped:
```cpp
// Oneshot timer not stopped, significant higher cpu usage (~10times as much).
ros::Timer timer;
timer = nh.createTimer(ros::Duration(0.1), [&timer](const ros::TimerEvent&) {
  ;  // no op
}, true /* oneshot */);
```

Long story short: The reason for the higher cpu usage was an integer overflow for oneshot timers in https://github.com/ros/ros_comm/blob/e96c407c64e1c17b0dd2bb85b67f388380527097/clients/roscpp/include/ros/timer_manager.h#L579-L580

with my debug values:
```cpp
ros::Time sleep_end(2147483647, 999999999);
ros::Time current(1525190218, 443312022);

std::max((int32_t)((sleep_end - current).toSec() * 1000.0f), 1); /*
+                 +|                           |          +    +
|                 +-----    622293429.55    ---+          |    |
|                 |                                       |    |
|                 +-----    -476828920 (overflow)     ----+    |
|                                                              |
+--------------------------   1     ---------------------------+
*/
```

So it was always sleeping for 1ms, although it could have slept much longer.
