### PR TITLE
Show connection info in rosnode info

### DIFF
--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -45,6 +45,7 @@ import errno
 import sys
 import socket
 import time
+import re
 try:
     from xmlrpc.client import ServerProxy
 except ImportError:
@@ -62,6 +63,7 @@ import rostopic
 
 NAME='rosnode'
 ID = '/rosnode'
+CONNECTION_PATTERN = re.compile(r'\w+ connection on port (\d+) to \[(.*) on socket (\d+)\]')
 
 class ROSNodeException(Exception):
     """
@@ -543,11 +545,16 @@ def get_node_connection_info_description(node_api, master):
                     # older ros publisher implementations don't report a URI
                     buff += "    * to: %s\n"%lookup_uri(master, system_state, topic, dest_id)
                     if direction == 'i':
-                        buff += "    * direction: inbound\n"
+                        buff += "    * direction: inbound"
                     elif direction == 'o':
-                        buff += "    * direction: outbound\n"
+                        buff += "    * direction: outbound"
                     else:
-                        buff += "    * direction: unknown\n"
+                        buff += "    * direction: unknown"
+                    if len(info) > 6:
+                        match = CONNECTION_PATTERN.match(info[6])
+                        if match is not None:
+                            buff += " (%s - %s) [%s]" % match.groups()
+                    buff += "\n"
                     buff += "    * transport: %s\n"%transport
     except socket.error:
         raise ROSNodeIOException("Communication with node[%s] failed!"%(node_api))


### PR DESCRIPTION
This shows the **port**, **URI** (of the other side of the socket) and the **socket** file descriptor for each connection next to the `direction`.

This is useful for debugging the traffic on the port/s of the socket use by a topic, b/c it shows the matching between topic and those ports, which can by used in `tcpdump`.

# Example

Before: `    * direction: inbound`
With this PR: `    * direction: inbound (48768 - 123.0.0.1:41908) [28]`

FYI @mikepurvis @dirk-thomas 

I target `melodic-devel` in this PR, but if possible I'd like to get this in `lunar-devel` as well.