### PR TITLE
Add in -D_FILE_OFFSET_BITS=64 on machines less than 64-bits.

### DIFF
--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -12,6 +12,7 @@ find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options rege
 find_package(BZip2 REQUIRED)
 
 catkin_package(
+  CFG_EXTRAS rosbag_storage-extras.cmake
   INCLUDE_DIRS include
   LIBRARIES rosbag_storage
   CATKIN_DEPENDS pluginlib roslz4

--- a/tools/rosbag_storage/cmake/rosbag_storage-extras.cmake
+++ b/tools/rosbag_storage/cmake/rosbag_storage-extras.cmake
@@ -1,0 +1,10 @@
+# PR https://github.com/ros/ros_comm/pull/1206 added support for encryption
+# and decryption of rosbags by utilizing libgpgme-dev.  On armhf, libgpgme-dev
+# is compiled with -D_FILE_OFF_BITS=64, which means that all downstream
+# consumers of it must also be compiled with that
+# (https://www.gnupg.org/documentation/manuals/gpgme/Largefile-Support-_0028LFS_0029.html
+# has some more information).  Add that flag to the CMAKE_CXX_FLAGS for all
+# architectures where the size of the pointer is less than 8 bytes.
+if(CMAKE_SIZEOF_VOID_P LESS 8)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_FILE_OFFSET_BITS=64")
+endif()


### PR DESCRIPTION
This should fix the error alluded to https://github.com/ros/ros_comm/pull/1206#issuecomment-390806896, and seen in several buildfarm jobs (e.g. http://build.ros.org/job/Mbin_ubhf_uBhf__swri_console__ubuntu_bionic_armhf__binary/2/console)

I tested this in a local amd64 devel job, and the flag was not added.  I also tested on a local armhf devel job, where the flag was added and allowed the failing `swri_console` to build.

Signed-off-by: Chris Lalancette <clalancette@gmail.com>