### PR TITLE
add test case for #1408

### DIFF
--- a/clients/roscpp/include/ros/rosout_appender.h
+++ b/clients/roscpp/include/ros/rosout_appender.h
@@ -75,7 +75,6 @@ protected:
   boost::mutex queue_mutex_;
   boost::condition_variable queue_condition_;
   bool shutting_down_;
-  bool disable_topics_;
 
   boost::thread publish_thread_;
 };

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -38,7 +38,6 @@
 #include "ros/topic_manager.h"
 #include "ros/advertise_options.h"
 #include "ros/names.h"
-#include "ros/param.h"
 
 #include <rosgraph_msgs/Log.h>
 
@@ -103,14 +102,7 @@ void ROSOutAppender::log(::ros::console::Level level, const char* str, const cha
   msg->file = file;
   msg->function = function;
   msg->line = line;
-  
-  // check parameter server/cache for omit_topics flag
-  // the same parameter is checked in rosout.py for the same purpose
-  ros::param::getCached("/rosout_disable_topics_generation", disable_topics_);
-
-  if (!disable_topics_){
-    this_node::getAdvertisedTopics(msg->topics);
-  }
+  this_node::getAdvertisedTopics(msg->topics);
 
   if (level == ::ros::console::levels::Fatal || level == ::ros::console::levels::Error)
   {

--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -85,20 +85,7 @@ def _rosout(level, msg, fname, line, func):
                 try:
                     _in_rosout = True
                     msg = str(msg)
-
-                    # check parameter server/cache for omit_topics flag
-                    # the same parameter is checked in rosout_appender.cpp for the same purpose
-                    # parameter accesses are cached automatically in python
-                    if rospy.has_param("/rosout_disable_topics_generation"):
-                        disable_topics_ = rospy.get_param("/rosout_disable_topics_generation")
-                    else:
-                        disable_topics_ = False
-
-                    if not disable_topics_:
-                        topics = get_topic_manager().get_topics()
-                    else:
-                        topics = ""
-
+                    topics = get_topic_manager().get_topics()
                     l = Log(level=level, name=str(rospy.names.get_caller_id()), msg=str(msg), topics=topics, file=fname, line=line, function=func)
                     l.header.stamp = Time.now()
                     _rosout_pub.publish(l)

--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -147,5 +147,7 @@ add_rostest(launch/search_param.xml)
 
 add_rostest(launch/stamped_topic_statistics_with_empty_timestamp.xml)
 
+add_rostest(launch/test_1408.xml)
+
 # Test spinners
 add_rostest(launch/spinners.xml)

--- a/test/test_roscpp/test/launch/test_1408.xml
+++ b/test/test_roscpp/test/launch/test_1408.xml
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_1408" pkg="test_roscpp" type="test_roscpp-test_1408"/>
+</launch>

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -216,6 +216,10 @@ add_executable(${PROJECT_NAME}-subscriber EXCLUDE_FROM_ALL subscriber.cpp)
 target_link_libraries(${PROJECT_NAME}-subscriber ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME}-subscriber ${std_msgs_EXPORTED_TARGETS})
 
+add_executable(${PROJECT_NAME}-test_1408 EXCLUDE_FROM_ALL test_1408.cpp)
+target_link_libraries(${PROJECT_NAME}-test_1408 ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+add_dependencies(${PROJECT_NAME}-test_1408 ${std_msgs_EXPORTED_TARGETS})
+
 if(TARGET tests)
   add_dependencies(tests
     ${PROJECT_NAME}-handles
@@ -281,6 +285,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-publisher
     ${PROJECT_NAME}-subscriber
     ${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp
+    ${PROJECT_NAME}-test_1408
   )
 endif()
 
@@ -344,5 +349,5 @@ add_dependencies(${PROJECT_NAME}-test_ns_node_remapping ${${PROJECT_NAME}_EXPORT
 add_dependencies(${PROJECT_NAME}-test_search_param ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-left_right ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-string_msg_expect ${${PROJECT_NAME}_EXPORTED_TARGETS})
-add_dependencies(${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp
- ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}-test_1408 ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/test/test_roscpp/test/src/test_1408.cpp
+++ b/test/test_roscpp/test/src/test_1408.cpp
@@ -1,0 +1,43 @@
+#include <std_msgs/Empty.h>
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+void assign(std_msgs::Empty::ConstPtr &dest, std_msgs::Empty::ConstPtr src) { dest = src; }
+
+TEST(Test1408, Disturber)
+{
+  ros::NodeHandle nh;
+
+  ROS_INFO("Started"); // can be moved down
+
+  std_msgs::Empty::ConstPtr received;
+  ros::Subscriber subscriber = nh.subscribe<std_msgs::Empty>("empty", 1, boost::bind(assign, boost::ref(received), _1));
+
+  ros::Publisher publisher_ = nh.advertise<std_msgs::Empty>("empty", 1); // must come after subscriber
+}
+
+TEST(Test1408, Disturbed)
+{
+  ros::NodeHandle nh;
+
+  ros::Publisher publisher_ = nh.advertise<std_msgs::Empty>("empty", 1);
+
+  std_msgs::Empty::ConstPtr received;
+  ros::Subscriber subscriber = nh.subscribe<std_msgs::Empty>("empty", 1, boost::bind(assign, boost::ref(received), _1));
+
+  std_msgs::Empty msg;
+  publisher_.publish(msg);
+
+  ros::WallDuration(1.0).sleep();
+  EXPECT_FALSE(received);
+  ros::spinOnce();
+  EXPECT_TRUE(received);
+}
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "test_to_topic");
+  ros::WallDuration(1.0).sleep();
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This is a down-stripped test case for #1408.
Until now I don't have a better name for it.

This test case passes for ros_comm <=1.13.6, but fails for 1.14.1.

If any of `ROS_INFO` , `publisher` or `subscriber` gets removed from the `Disturber` case, the `Disturbed` case passes.
