### PR TITLE
Fix Issue 1346 - Make a copy of the topic list

### DIFF
--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -95,7 +95,7 @@ def _rosout(level, msg, fname, line, func):
                         disable_topics_ = False
 
                     if not disable_topics_:
-                        topics = get_topic_manager().get_topics()
+                        topics = get_topic_manager().get_topics().copy()
                     else:
                         topics = ""
 

--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -95,7 +95,7 @@ def _rosout(level, msg, fname, line, func):
                         disable_topics_ = False
 
                     if not disable_topics_:
-                        topics = get_topic_manager().get_topics().copy()
+                        topics = get_topic_manager().get_topics()
                     else:
                         topics = ""
 

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -1348,7 +1348,7 @@ class _TopicManager(object):
         @return: list of topic names this node subscribes to/publishes
         @rtype: [str]
         """                
-        return self.topics
+        return self.topics.copy()
     
     def _get_list(self, rmap):
         return [[k, v.type] for k, v in rmap.items()]


### PR DESCRIPTION
Proposed fix from https://github.com/ros/ros_comm/issues/1346

#### Description
get_topics() returns a set, which is iterated by the Log constructor.  Make a copy of the set (atomic in cpython!) so nobody adds or removes something while the Log constructor iterates over it

A more optimized fix might be to use an immutable data structure inside the topic manager.  I imagine that in the general case the topic list changes a lot less often than than calls are made to _rosout.  It might be better to eat the overhead on topic add/remove instead of adding a copy operation to every _rosout call.