### PR TITLE
fix compiler warnings about unused variables

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -604,8 +604,6 @@ void shutdown()
     XMLRPCManager::instance()->shutdown();
   }
 
-  WallTime end = WallTime::now();
-
   g_started = false;
   g_ok = false;
   Time::shutdown();

--- a/test/test_rosbag/test/test_bag.cpp.in
+++ b/test/test_rosbag/test/test_bag.cpp.in
@@ -379,6 +379,7 @@ TEST(rosbag, bad_topic_query_works) {
 
     rosbag::View view(bag, rosbag::TopicQuery(t));
     foreach(rosbag::MessageInstance const m, view) {
+      (void)m;
       FAIL();
     }
 


### PR DESCRIPTION
Which appeared in the recent devel job build: http://build.ros.org/view/Mdev/job/Mdev__ros_comm__ubuntu_bionic_amd64/42/