### PR TITLE
[roswtf] 1) Switch from OptParse to ArgParse. 2) arg parsing portion as an option, not a requirement

### DIFF
--- a/utilities/roswtf/src/roswtf/__init__.py
+++ b/utilities/roswtf/src/roswtf/__init__.py
@@ -93,7 +93,7 @@ def roswtf_main():
 def _roswtf_main():
     # performance optimization
     rospack = rospkg.RosPack()
-    all_pkgs = rospack.list()
+    all_packages = rospack.list()
 
     import argparse
     parser = argparse.ArgumentParser(usage="usage: roswtf [launch file]", description="roswtf is a tool for verifying a ROS installation and running system. Checks provided launchfile if provided, else current stack or package.")
@@ -117,16 +117,19 @@ def _roswtf_main():
                         help="launch files to check. 0...n files can be passed")
     #TODO: --all-pkgs option
     args = parser.parse_args()
-    roswtf_node(args)
+    roswtf_node(args.all_packages, args.disable_plugins, args.launch_files, args.offline)
 
 
-def roswtf_node(args):
+def roswtf_node(all_packages=False, disable_plugins=False, launch_files=[], offline=False):
     """
-    @type args: argparse.Namespace
+    @type all_packages: 
+    @type disable_plugins:
+    @type launch_files: 
+    @type offline: 
     """
     launch_files = names = None
-    if args.launch_files:
-        launch_files = args.launch_files
+    if launch_files:
+        launch_files = launch_files
         if 0:
             # disable names for now as don't have any rules yet
             launch_files = [a for a in args if os.path.isfile(a)]
@@ -143,7 +146,7 @@ def roswtf_node(args):
     import roswtf.roslaunchwtf
     import roswtf.stacks    
     import roswtf.plugins
-    if not args.disable_plugins:
+    if not disable_plugins:
         static_plugins, online_plugins = roswtf.plugins.load_plugins()
     else:
         static_plugins, online_plugins = [], []
@@ -173,9 +176,9 @@ def roswtf_node(args):
         else:
             print("No package or stack in the current directory")
             ctx = WtfContext.from_env()
-        if args.all_packages:
+        if all_packages:
             print("roswtf will run against all packages")
-            ctx.pkgs = all_pkgs
+            ctx.pkgs = all_packages
 
     # static checks
     wtf_check_environment(ctx)
@@ -203,7 +206,7 @@ def roswtf_node(args):
 
     try:
 
-        if args.offline or not ctx.ros_master_uri or invalid_url(ctx.ros_master_uri) or not rosgraph.is_master_online():
+        if offline or not ctx.ros_master_uri or invalid_url(ctx.ros_master_uri) or not rosgraph.is_master_online():
             online_checks = False
         else:
             online_checks = True

--- a/utilities/roswtf/src/roswtf/__init__.py
+++ b/utilities/roswtf/src/roswtf/__init__.py
@@ -96,28 +96,30 @@ def _roswtf_main():
     rospack = rospkg.RosPack()
     all_pkgs = rospack.list()
 
-    import optparse
-    parser = optparse.OptionParser(usage="usage: roswtf [launch file]", description="roswtf is a tool for verifying a ROS installation and running system. Checks provided launchfile if provided, else current stack or package.")
+    import argparse
+    parser = argparse.ArgumentParser(usage="usage: roswtf [launch file]", description="roswtf is a tool for verifying a ROS installation and running system. Checks provided launchfile if provided, else current stack or package.")
     # #2268
-    parser.add_option("--all", 
+    parser.add_argument("--all", 
                       dest="all_packages", default=False,
                       action="store_true",
                       help="run roswtf against all packages")
     # #2270
-    parser.add_option("--no-plugins", 
+    parser.add_argument("--no-plugins", 
                       dest="disable_plugins", default=False,
                       action="store_true",
                       help="disable roswtf plugins")
 
-    parser.add_option("--offline", 
+    parser.add_argument("--offline", 
                       dest="offline", default=False,
                       action="store_true",
                       help="only run offline tests")
 
+    parser.add_argument("launch_files",  nargs='*',
+                        help="launch files to check. 0...n files can be passed")
     #TODO: --all-pkgs option
-    options, args = parser.parse_args()
-    if args:
-        launch_files = args
+    args = parser.parse_args()
+    if args.launch_files:
+        launch_files = args.launch_files
         if 0:
             # disable names for now as don't have any rules yet
             launch_files = [a for a in args if os.path.isfile(a)]
@@ -134,7 +136,7 @@ def _roswtf_main():
     import roswtf.roslaunchwtf
     import roswtf.stacks    
     import roswtf.plugins
-    if not options.disable_plugins:
+    if not args.disable_plugins:
         static_plugins, online_plugins = roswtf.plugins.load_plugins()
     else:
         static_plugins, online_plugins = [], []
@@ -164,7 +166,7 @@ def _roswtf_main():
         else:
             print("No package or stack in the current directory")
             ctx = WtfContext.from_env()
-        if options.all_packages:
+        if args.all_packages:
             print("roswtf will run against all packages")
             ctx.pkgs = all_pkgs
 
@@ -194,7 +196,7 @@ def _roswtf_main():
 
     try:
 
-        if options.offline or not ctx.ros_master_uri or invalid_url(ctx.ros_master_uri) or not rosgraph.is_master_online():
+        if args.offline or not ctx.ros_master_uri or invalid_url(ctx.ros_master_uri) or not rosgraph.is_master_online():
             online_checks = False
         else:
             online_checks = True

--- a/utilities/roswtf/src/roswtf/__init__.py
+++ b/utilities/roswtf/src/roswtf/__init__.py
@@ -91,7 +91,6 @@ def roswtf_main():
         print(str(e), file=sys.stderr)
         
 def _roswtf_main():
-    launch_files = names = None
     # performance optimization
     rospack = rospkg.RosPack()
     all_pkgs = rospack.list()
@@ -118,6 +117,14 @@ def _roswtf_main():
                         help="launch files to check. 0...n files can be passed")
     #TODO: --all-pkgs option
     args = parser.parse_args()
+    roswtf_node(args)
+
+
+def roswtf_node(args):
+    """
+    @type args: argparse.Namespace
+    """
+    launch_files = names = None
     if args.launch_files:
         launch_files = args.launch_files
         if 0:

--- a/utilities/roswtf/test/check_roswtf_command_line_online.py
+++ b/utilities/roswtf/test/check_roswtf_command_line_online.py
@@ -65,7 +65,7 @@ class TestRostopicOnline(unittest.TestCase):
     def test_cmd_help(self):
         cmd = 'roswtf'
         output = Popen([cmd, '-h'], stdout=PIPE).communicate()[0].decode()
-        self.assert_('Options' in output)
+        self.assert_('optional arguments' in output)
             
     def test_offline(self):
         # this test is disabled for now; now that test_roswtf is part

--- a/utilities/roswtf/test/test_roswtf_command_line_offline.py
+++ b/utilities/roswtf/test/test_roswtf_command_line_offline.py
@@ -55,7 +55,7 @@ class TestRoswtfOffline(unittest.TestCase):
         cmd = 'roswtf'
         output = Popen([cmd, '-h'], stdout=PIPE).communicate()[0]
         output = output.decode()
-        self.assert_('Options' in output)
+        self.assert_('optional arguments' in output)
             
     def test_offline(self):
         cmd = 'roswtf'


### PR DESCRIPTION
2 changes committed separately.

- Replace with `argparse` - `OptParse` is deprecated since Python 2.7 (ref: https://docs.python.org/2.7/library/optparse.html).
- In Python API there's no equivalent to sh' `roswtf` command that serves as a single point of triggering `roswtf` via API, not via executable.

  sh script `roswtf` calls `roswtf_main()` that internally calls [_roswtf_main()](https://github.com/ros/ros_comm/blob/24e45419bdd4b0d588321e3b376650c7a51bf11c/utilities/roswtf/src/roswtf/__init__.py#L93), which takes in stdin. This still works ok when you have a control over the arguments to pass to roswtf, but doesn't work when you don't. E.g. `catkin run_tests` seems to pass some args while internally running `nosetests`, which the parse module takes in and thus passed to roswtf and ends up causing an error.