### PR TITLE
message_filters: call Subscriber::unsubscribe() in destructor

### DIFF
--- a/utilities/message_filters/include/message_filters/subscriber.h
+++ b/utilities/message_filters/include/message_filters/subscriber.h
@@ -123,7 +123,7 @@ public:
 
   ~Subscriber()
   {
-    unsubscribe();
+    Subscriber::unsubscribe();
   }
 
   /**


### PR DESCRIPTION
This makes it obvious, which function is actually called.

In Addition, this fix a clang stytic analyser warning.