### PR TITLE
arg within group is not exposed to include tag

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -655,6 +655,7 @@ class XmlLoader(loader.Loader):
                     default_machine = \
                         self._recurse_load(ros_config, tag.childNodes, child_ns, \
                                                default_machine, is_core, verbose)
+                    context.arg_names.extend(child_ns.arg_names) # copy is need to extend args within group
             elif name == 'node':
                 n = self._node_tag(tag, context, ros_config, default_machine, verbose=verbose)
                 if n is not None:


### PR DESCRIPTION
Running the following roslaunch file
```
k-okada@p51s:~/catkin_ws/ws_ros_comm$ cat include-group-arg-2.launch 
<launch>
  <include file="include-group-arg-included-2.launch" >
    <arg name="foo" default="foo" />
    <arg name="hoge" default="hoge" />        
  </include>
</launch>
k-okada@p51s:~/catkin_ws/ws_ros_comm$ cat include-group-arg-included-2.launch 
<launch>
  <group ns="ns">
    <arg name="foo" />
    <arg name="hoge" default="hoge-included"/>
    <param name="foo" value="$(arg foo)" />
    <param name="hoge" value="$(arg hoge)" />        
  </group>
</launch>

```
I get an error saying. 
```
k-okada@p51s:~/catkin_ws/ws_ros_comm$ roslaunch include-group-arg-2.launch 
... logging to /home/k-okada/.ros/log/f77b10e8-720a-11e8-aaa2-1c4d70ae9421/roslaunch-p51s-26641.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
WARNING: disk usage in log directory [/home/k-okada/.ros/log] is over 1GB.
It's recommended that you use the 'rosclean' command.

unused args [foo, hoge] for include of [include-group-arg-included-2.launch]
The traceback for the exception was written to the log file
```
This appears that `arg` defined in `group` only seems to be valid within that `group` only.

On the other hand, if you execute the following roslaunch file
```
k-okada@p51s:~/catkin_ws/ws_ros_comm$ cat include-group-arg-1.launch 
<launch>
  <include file="include-group-arg-included-1.launch" >
    <arg name="foo" default="foo" />
    <arg name="bar" default="bar" />
    <arg name="hoge" default="hoge" />        
  </include>
</launch>
k-okada@p51s:~/catkin_ws/ws_ros_comm$ cat include-group-arg-included-1.launch 
<launch>
  <group ns="ns">
    <arg name="foo" />
    <arg name="bar" value="bar"/>
    <arg name="hoge" default="hoge"/>    
    <param name="foo" value="$(arg foo)" />
    <param name="bar" value="$(arg bar)" />
    <param name="hoge" value="$(arg hoge)" />        
  </group>
</launch>
```
It will be displayed as. 
```
k-okada@p51s:~/catkin_ws/ws_ros_comm$ roslaunch include-group-arg-1.launch 
... logging to /home/k-okada/.ros/log/8b2f5ace-720b-11e8-aaa2-1c4d70ae9421/roslaunch-p51s-27106.log
Checking log directory for disk usage. This may take awhile.
Press Ctrl-C to interrupt
WARNING: disk usage in log directory [/home/k-okada/.ros/log] is over 1GB.
It's recommended that you use the 'rosclean' command.

while processing include-group-arg-included-1.launch:
Invalid <arg> tag: cannot override arg 'bar', which has already been set. 

Arg xml is <arg name="bar" value="bar"/>
The traceback for the exception was written to the log file
```

This looks the same behavior whether `arg` defined in `group` or `arg` defined outside of `group`.

With this patch, the first example will not cause an error.