### PR TITLE
remove messages that are newer than the newly added message

### DIFF
--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -57,7 +57,7 @@ class SimpleFilter(object):
             cb(*(msg + args))
 
 class Subscriber(SimpleFilter):
-
+    
     """
     ROS subscription filter.  Identical arguments as :class:`rospy.Subscriber`.
 
@@ -167,7 +167,7 @@ class Cache(SimpleFilter):
         if not self.cache_times:
             return None
         return self.cache_times[0]
-
+        
     def getLast(self):
         if self.getLastestTime() is None:
             return None
@@ -258,7 +258,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
         # clear all buffers if jump backwards in time is detected
         now = rospy.Time.now()
         if now < self.last_added:
-            rospy.loginfo("ApproximateTimeSynchronizer: Detected jump back in time. Clearing  buffer.")
+            rospy.loginfo("ApproximateTimeSynchronizer: Detected jump back in time. Clearing buffer.")
             for q in self.queues:
                 q.clear()
         self.last_added = now

--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -253,6 +253,9 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
 
         self.lock.acquire()
         my_queue[stamp] = msg
+        # remove messages that jump backwards in time
+        while msg.header.stamp.to_time() - max(my_queue.keys()).to_time() < 0:
+            del my_queue[max(my_queue)]
         while len(my_queue) > self.queue_size:
             del my_queue[min(my_queue)]
         # self.queues = [topic_0 {stamp: msg}, topic_1 {stamp: msg}, ...]

--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -258,6 +258,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
         # clear all buffers if jump backwards in time is detected
         now = rospy.Time.now()
         if now < self.last_added:
+            rospy.loginfo("ApproximateTimeSynchronizer: Detected jump back in time. Clearing  buffer.")
             for q in self.queues:
                 q.clear()
         self.last_added = now

--- a/utilities/message_filters/test/test_approxsync.py
+++ b/utilities/message_filters/test/test_approxsync.py
@@ -65,6 +65,7 @@ class TestApproxSync(unittest.TestCase):
         m0 = MockFilter()
         m1 = MockFilter()
         ts = ApproximateTimeSynchronizer([m0, m1], 1, 0.1)
+        rospy.rostime.set_rostime_initialized(True)
         ts.registerCallback(self.cb_collector_2msg)
 
         if 0:
@@ -98,7 +99,6 @@ class TestApproxSync(unittest.TestCase):
 
         # Scramble sequences of length N of headerless and header-having messages.
         # Make sure that TimeSequencer recombines them.
-        rospy.rostime.set_rostime_initialized(True)
         random.seed(0)
         for N in range(1, 10):
             m0 = MockFilter()


### PR DESCRIPTION
In some circumstances, when replaying a log in loop mode (-l) the synchronisation blocks because messages jump back in time when restarting the log. This commit removes messages that are newer than the newly added message, enabling to synchronise looped log files. This could optionally enabled via a parameter that gives the maximum tolerated backward jump in time.