### PR TITLE
Throw BagException when disk is full and return from run() with error…

### DIFF
--- a/tools/rosbag/scripts/trim.py
+++ b/tools/rosbag/scripts/trim.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2018, Victor Lamoine - Institut Maupertuis
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import print_function
+
+import argparse
+import datetime
+import os
+import rospy
+import rosbag
+
+if __name__ == '__main__':
+    import sys
+    parser = argparse.ArgumentParser(description='Trim bag files.')
+    parser.add_argument('inbag_filename', type=str, help='the input bag file')
+    parser.add_argument('outbag_filename', type=str, help='the output bag file')
+    parser.add_argument('begin_trim_time', type=float, help='the begin trim time (in seconds, relative to the start of the bag file)')
+    parser.add_argument('end_trim_time', type=float, help='the begin trim time (in seconds, relative to the start of the bag file)')
+    args = parser.parse_args()
+
+    inbag_filename = args.inbag_filename
+    outbag_filename = args.outbag_filename
+    begin_trim = args.begin_trim_time
+    end_trim = args.end_trim_time
+
+    if begin_trim >= end_trim:
+        print("Begin trim time cannot be >= to end trim time", file=sys.stderr)
+        sys.exit(1)
+
+    if os.path.realpath(inbag_filename) == os.path.realpath(outbag_filename):
+        print('Cannot use same file as input and output [%s]' % inbag_filename, file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        inbag = rosbag.Bag(inbag_filename, 'r')
+    except (ROSBagEncryptNotSupportedException, ROSBagEncryptException) as ex:
+        print('ERROR: %s' % str(ex), file=sys.stderr)
+        sys.exit(3)
+    except ROSBagUnindexedException as ex:
+        print('ERROR bag unindexed: %s.  Run rosbag reindex.' % inbag_filename, file=sys.stderr)
+        sys.exit(3)
+
+    start = inbag._get_yaml_info("start")
+    if start is None:
+        print ("Could not get start time of bag file", file=sys.stderr)
+        sys.exit(4)
+    start = float(start)
+    print("Start time", start, "which was", datetime.datetime.fromtimestamp(start))
+
+    end = inbag._get_yaml_info("end")
+    if start is None:
+        print("Could not get end time of bag file", file=sys.stderr)
+        sys.exit(4)
+    end = float(end)
+    print("End time  ", end, "which was", datetime.datetime.fromtimestamp(end))
+
+    print("Data before", begin_trim, "seconds and after", end_trim, "seconds will be trimmed")
+    #rosbag.filter_cmd()
+
+    outbag = rosbag.Bag(outbag_filename, 'w')
+    # FIXME Trim bag file...
+    # https://github.com/ros/ros_comm/blob/melodic-devel/tools/rosbag/src/rosbag/rosbag_main.py#L301-L387
+
+    inbag.close()
+    outbag.close()

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -476,7 +476,7 @@ void Recorder::doRecord() {
     {
         checkDisk();
     }
-    catch (rosbag::BagException ex)
+    catch (rosbag::BagException &ex)
     {
         ROS_ERROR_STREAM(ex.what());
         exit_code_ = 1;
@@ -534,7 +534,7 @@ void Recorder::doRecord() {
             if (scheduledCheckDisk() && checkLogging())
                 bag_.write(out.topic, out.time, *out.msg, out.connection_header);
         }
-        catch (rosbag::BagException ex)
+        catch (rosbag::BagException &ex)
         {
             ROS_ERROR_STREAM(ex.what());
             exit_code_ = 1;

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -196,13 +196,11 @@ int Recorder::run() {
         check_master_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&Recorder::doCheckMaster, this, _1, boost::ref(nh)));
     }
 
-    ros::MultiThreadedSpinner s(10);
-    ros::spin(s);
-
-    queue_condition_.notify_all();
+    ros::AsyncSpinner s(10);
+    s.start();
 
     record_thread.join();
-
+    queue_condition_.notify_all();
     delete queue_;
 
     return exit_code_;
@@ -473,7 +471,19 @@ void Recorder::doRecord() {
 
     // Schedule the disk space check
     warn_next_ = ros::WallTime();
-    checkDisk();
+
+    try
+    {
+        checkDisk();
+    }
+    catch (rosbag::BagException ex)
+    {
+        ROS_ERROR_STREAM(ex.what());
+        exit_code_ = 1;
+        stopWriting();
+        return;
+    }
+
     check_disk_next_ = ros::WallTime::now() + ros::WallDuration().fromSec(20.0);
 
     // Technically the queue_mutex_ should be locked while checking empty.
@@ -519,8 +529,17 @@ void Recorder::doRecord() {
         if (checkDuration(out.time))
             break;
 
-        if (scheduledCheckDisk() && checkLogging())
-            bag_.write(out.topic, out.time, *out.msg, out.connection_header);
+        try
+        {
+            if (scheduledCheckDisk() && checkLogging())
+                bag_.write(out.topic, out.time, *out.msg, out.connection_header);
+        }
+        catch (rosbag::BagException ex)
+        {
+            ROS_ERROR_STREAM(ex.what());
+            exit_code_ = 1;
+            break;
+        }
     }
 
     stopWriting();
@@ -674,9 +693,8 @@ bool Recorder::checkDisk() {
     }
     if ( info.available < options_.min_space)
     {
-        ROS_ERROR("Less than %s of space free on disk with %s.  Disabling recording.", options_.min_space_str.c_str(), bag_.getFileName().c_str());
         writing_enabled_ = false;
-        return false;
+        throw BagException("Less than " + options_.min_space_str + " of space free on disk with " + bag_.getFileName() + ". Disabling recording.");
     }
     else if (info.available < 5 * options_.min_space)
     {

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -2355,7 +2355,7 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
             
         return (topic, topic_index)
 
-    def seek_and_read_message_data_record(self, position, raw):
+    def seek_and_read_message_data_record(self, position, raw, return_connection_header=False):
         f = self.bag._file
 
         # Seek to the message position
@@ -2399,7 +2399,10 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
             msg = msg_type()
             msg.deserialize(data)
         
-        return BagMessage(topic, msg, t)
+        if return_connection_header:
+            return BagMessageWithConnectionHeader(topic, msg, t, header)
+        else:
+            return BagMessage(topic, msg, t)
 
 class _BagReader200(_BagReader):
     """


### PR DESCRIPTION
Currently when the disk is full a `ROS_ERROR` message is sent, writing is disabled (see https://github.com/ros/ros_comm/blob/melodic-devel/tools/rosbag/src/recorder.cpp#L649-L651). The problem is that the recording thread does not exit in that case.

This changes the behavior:
- If disk is below the minimum an exception is thrown
- The exception is catched in the recording thread
- The recording thread exits with an error code (`1`)
- The  `run` member functions joins the recording thread and return the exit code

From a user perspective now you can run:
```bash
if (!recorder->run())
  // Handle the fact that we cannot record anymore
```

Note: in `doRecordSnapshotter` no disk space checking is done, I did not add it.