### PR TITLE
Fix for issue 1441

### DIFF
--- a/clients/rospy/src/rospy/impl/rosout.py
+++ b/clients/rospy/src/rospy/impl/rosout.py
@@ -121,7 +121,7 @@ _logging_to_rospy_levels = {
 
 class RosOutHandler(logging.Handler):
    def emit(self, record):
-      _rosout(_logging_to_rospy_levels[record.levelno], record.getMessage(),
+      _rosout(_logging_to_rospy_levels[record.levelno], self.format(record),
             record.filename, record.lineno, record.funcName)
 
 ## Load loggers for publishing to /rosout


### PR DESCRIPTION
Suggested fix for https://github.com/ros/ros_comm/issues/1441

Use the logger.Handler's format method so that by default stack traces
are included in the log message if exc_info is set on the LogRecord