### PR TITLE
Fix rosbag's internal _read_message API

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -1291,12 +1291,12 @@ class Bag(object):
 
         return sum((h.uncompressed_size for h in self._chunk_headers.values()))
 
-    def _read_message(self, position, raw=False):
+    def _read_message(self, position, raw=False, return_connection_header=None):
         """
         Read the message from the given position in the file.
         """
         self.flush()
-        return self._reader.seek_and_read_message_data_record(position, raw)
+        return self._reader.seek_and_read_message_data_record(position, raw, return_connection_header)
 
     # Index accessing
 

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -1291,7 +1291,7 @@ class Bag(object):
 
         return sum((h.uncompressed_size for h in self._chunk_headers.values()))
 
-    def _read_message(self, position, raw=False, return_connection_header=None):
+    def _read_message(self, position, raw=False, return_connection_header=False):
         """
         Read the message from the given position in the file.
         """


### PR DESCRIPTION
This PR fixes the internal rosbag API used by rqt_bag, which was broken with PR https://github.com/ros/ros_comm/pull/1372

This closes https://github.com/ros/ros_comm/issues/1432 and https://github.com/ros-visualization/rqt_bag/issues/27

