### PR TITLE
Add return_connection_header=False arg

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -2355,7 +2355,7 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
             
         return (topic, topic_index)
 
-    def seek_and_read_message_data_record(self, position, raw):
+    def seek_and_read_message_data_record(self, position, raw, return_connection_header=False):
         f = self.bag._file
 
         # Seek to the message position
@@ -2399,7 +2399,10 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
             msg = msg_type()
             msg.deserialize(data)
         
-        return BagMessage(topic, msg, t)
+        if return_connection_header:
+            return BagMessageWithConnectionHeader(topic, msg, t, header)
+        else:
+            return BagMessage(topic, msg, t)
 
 class _BagReader200(_BagReader):
     """


### PR DESCRIPTION
Add `return_connection_header=False` arg  to `seek_and_read_message_data_record`, for `BagReady102`.

Otherwise we get this error (e.g. using `rqt_bag`):
``` bash
  File ".../lib/python2.7/dist-packages/rosbag/bag.py", line 1299, in _read_message
    return self._reader.seek_and_read_message_data_record(position, raw)
    TypeError: seek_and_read_message_data_record() takes exactly 4 arguments (3 given)
```

This bug was introduced by @ddimarco in https://github.com/ros/ros_comm/commit/752cf1f8bf3a17560f5d496609fadab2ebffd121, that addressed https://github.com/ros/ros_comm/pull/1372

`rqt_bag` is impacted by this. I can't see the contents of any message.

@mikepurvis for review, since he merged it and should know better the context of the original change.