### PR TITLE
Rename python message_filters.Cache.getLastestTime to getLatestTime

### DIFF
--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -156,11 +156,15 @@ class Cache(SimpleFilter):
             return None
         return older[-1]
 
-    def getLastestTime(self):
+    def getLatestTime(self):
         """Return the newest recorded timestamp."""
         if not self.cache_times:
             return None
         return self.cache_times[-1]
+
+    def getLastestTime(self):
+        """Return the newest recorded timestamp (equivalent to `getLatestTime()`, but included for backwards compatibility)."""
+        return self.getLatestTime()
 
     def getOldestTime(self):
         """Return the oldest recorded timestamp."""

--- a/utilities/message_filters/test/test_message_filters_cache.py
+++ b/utilities/message_filters/test/test_message_filters_cache.py
@@ -103,9 +103,11 @@ class TestCache(unittest.TestCase):
         self.assertEqual(s, rospy.Time(3),
                          "invalid msg return by getElemBeforeTime")
 
-        s = cache.getLastestTime()
+        s = cache.getLatestTime()
         self.assertEqual(s, rospy.Time(4),
-                         "invalid stamp return by getLastestTime")
+                         "invalid stamp return by getLatestTime")
+        self.assertEqual(s, cache.getLastestTime(),
+                         "stamps returned by getLatestTime and getLastestTime don't match")
 
         s = cache.getOldestTime()
         self.assertEqual(s, rospy.Time(0),


### PR DESCRIPTION
Per instructions from dirk-thomas on this issue: https://github.com/ros/ros_comm/issues/1449#issuecomment-403118429