### PR TITLE
make roslaunch-check respect arg remappings with command line argument (:=)

### DIFF
--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -26,6 +26,7 @@
   <run_depend>rosclean</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
   <run_depend>roslib</run_depend>
+  <run_depend>rospy</run_depend>
   <run_depend version_gte="1.11.16">rosmaster</run_depend>
   <run_depend>rosout</run_depend>
   <run_depend>rosparam</run_depend>

--- a/tools/roslaunch/resources/example.launch
+++ b/tools/roslaunch/resources/example.launch
@@ -70,4 +70,10 @@
     <include file="does/not/exist.launch" />
     <node pkg="doesnt_exist" type="nope" name="nope" />
   </group>
+
+  <!-- Pass over argument from commandline. Set to false should fail -->
+  <arg name="commandline_true_arg" default="true" />
+  <group unless="$(arg commandline_true_arg)">
+    <node pkg="doesnt_exist" type="nope" name="nope" />
+  </group>
 </launch>

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -45,7 +45,7 @@ from xml.dom import Node as DomNode
 
 import rospkg
 
-from .loader import convert_value
+from .loader import convert_value, load_mappings
 from .substitution_args import resolve_args
 
 NAME="roslaunch-deps"
@@ -205,7 +205,7 @@ def parse_launch(launch_file, file_deps, verbose):
 
     file_deps[launch_file] = RoslaunchDeps()
     launch_tag = dom[0]
-    context = { 'arg': {}}
+    context = { 'arg': load_mappings(sys.argv) }
     _parse_launch(launch_tag.childNodes, launch_file, file_deps, verbose, context)
 
 def rl_file_deps(file_deps, launch_file, verbose=False):


### PR DESCRIPTION
the example
```
  <arg name="commandline_true_arg" default="true" />
  <group unless="$(arg commandline_true_arg)">
    <node pkg="doesnt_exist" type="nope" name="nope" />
  </group>
```
want to fail  `roslauch-check` script with
```
$ scripts/roslaunch-check resources/example.launch commandline_true_arg:=false
```

this PR added 
```
    context = { 'arg': load_mappings(sys.argv) }
```
to respect remappings with command line argument.

I'm not sure if we need to change 'subcontext', for now, 
```
    subcontext = {'arg': {}}

```
https://github.com/k-okada/ros_comm/blob/d206841691f45d3fd972149afdd9d5eb133e157e/tools/roslaunch/src/roslaunch/depends.py#L109-L111

For now, I could not find example which need to set 'load_remapping(sys.argv)' to 'subcontext'
```
$ cat hoge.launch 
<launch>
  <arg name="hoge" default="true" />
  <include file="./fuga.launch" >
    <arg name="hoge2" value="$(arg hoge)" />
  </include>
  <group if="$(arg hoge)">
    <node pkg="hoge" name="fuga" type="fuga" />
  </group>
</launch>
$ cat fuga.launch 
<launch>
  <arg name="hoge2" default="true" />
  <group if="$(arg hoge2)">
    <node pkg="hoge2" name="fuga2" type="fuga2" />
  </group>
</launch>
```