### PR TITLE
Add a default __hash__ function for the Edge class

### DIFF
--- a/tools/rosgraph/src/rosgraph/impl/graph.py
+++ b/tools/rosgraph/src/rosgraph/impl/graph.py
@@ -213,6 +213,7 @@ class Edge(object):
         return "%s->%s"%(self.start, self.end)
     def __eq__(self, other):
         return self.start == other.start and self.end == other.end
+    __hash__ = object.__hash__
 
 def edge_args(start, dest, direction, label):
     """


### PR DESCRIPTION
In Python3, using rqt_graph with some compressed image topics present gave the following error:
```python
PluginHandlerDirect._restore_settings() plugin "rqt_graph/RosGraph#0" raised an exception:
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python3.6/site-packages/qt_gui/plugin_handler_direct.py", line 116, in _restore_settings
    self._plugin.restore_settings(plugin_settings_plugin, instance_settings_plugin)
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/ros_graph.py", line 217, in restore_settings
    self._refresh_rosgraph()
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/ros_graph.py", line 246, in _refresh_rosgraph
    self._update_graph_view(self._generate_dotcode())
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/ros_graph.py", line 280, in _generate_dotcode
    hide_dynamic_reconfigure=hide_dynamic_reconfigure)
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/dotcode.py", line 876, in generate_dotcode
    hide_dynamic_reconfigure=hide_dynamic_reconfigure)
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/dotcode.py", line 698, in generate_dotgraph
    nt_nodes, edges, image_nodes = self._accumulate_image_topics(nt_nodes, edges, node_connections)
  File "/opt/ros/melodic/lib/python3.6/site-packages/rqt_graph/dotcode.py", line 553, in _accumulate_image_topics
    image_topic_edges_in.update(node_connections[n2].incoming)
TypeError: unhashable type: 'Edge'
```