### PR TITLE
Add hasStarted() const to Timer API

### DIFF
--- a/clients/roscpp/include/ros/timer.h
+++ b/clients/roscpp/include/ros/timer.h
@@ -71,6 +71,7 @@ public:
    */
   void setPeriod(const Duration& period, bool reset=true);
 
+  bool hasStarted() const { return impl_->hasStarted(); }
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void*)1 : (void*)0; }
 
@@ -98,6 +99,7 @@ private:
     Impl();
     ~Impl();
 
+    bool hasStarted() const;
     bool isValid();
     bool hasPending();
     void setPeriod(const Duration& period, bool reset=true);

--- a/clients/roscpp/src/libros/timer.cpp
+++ b/clients/roscpp/src/libros/timer.cpp
@@ -42,6 +42,11 @@ Timer::Impl::~Impl()
   stop();
 }
 
+bool Timer::Impl::hasStarted() const
+{
+  return started_;
+}
+
 bool Timer::Impl::isValid()
 {
   return !period_.isZero();


### PR DESCRIPTION
To assert if a timer is running at the moment, one can hack their way around by using `isValid` and `setDuration` to invalid ones.

I'm proposing the addition of a simple const accessor to the internal `started_` field. 

Should I add a simple test file as well?
Can this be cherry-picked to kinetic-devel too?