### PR TITLE
add option to hide summary from roslaunch output.

### DIFF
--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -161,6 +161,9 @@ def _get_optparse():
     parser.add_option("-v", action="store_true",
                       dest="verbose", default=False,
                       help="verbose printing")
+    parser.add_option("--no-summary", action="store_true",
+                      dest="no_summary", default=None,
+                      help="hide summary printing")
     # 2685 - Dump parameters of launch files
     parser.add_option("--dump-params", default=False, action="store_true",
                       dest="dump_params",
@@ -301,7 +304,7 @@ def main(argv=sys.argv):
                 options.port = options.port or DEFAULT_MASTER_PORT
             p = roslaunch_parent.ROSLaunchParent(uuid, args, roslaunch_strs=roslaunch_strs,
                     is_core=options.core, port=options.port, local_only=options.local_only,
-                    verbose=options.verbose, force_screen=options.force_screen,
+                    verbose=options.verbose, no_summary=options.no_summary, force_screen=options.force_screen,
                     num_workers=options.num_workers, timeout=options.timeout)
             p.start()
             p.spin()

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -73,7 +73,7 @@ class ROSLaunchParent(object):
     """
 
     def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,
-            verbose=False, force_screen=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None):
+            verbose=False, no_summary=None, force_screen=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None):
         """
         @param run_id: UUID of roslaunch session
         @type  run_id: str
@@ -91,6 +91,8 @@ class ROSLaunchParent(object):
         @type  port: int
         @param verbose: (optional) print verbose output
         @type  verbose: boolean
+        @param no_summary: (optional) hide summary output
+        @type  no_summary: boolean
         @param force_screen: (optional) force output of all nodes to screen
         @type  force_screen: boolean
         @param is_rostest bool: if True, this launch is a rostest
@@ -114,6 +116,7 @@ class ROSLaunchParent(object):
         self.port = port
         self.local_only = local_only
         self.verbose = verbose
+        self.no_summary = no_summary
         self.num_workers = num_workers
         self.timeout = timeout
 
@@ -157,8 +160,8 @@ class ROSLaunchParent(object):
         # print runner info to user, put errors last to make the more visible
         if self.is_core:
             print("ros_comm version %s" % (self.config.params['/rosversion'].value))
-            
-        print(self.config.summary(local=self.remote_runner is None))
+        if self.no_summary is None:    
+            print(self.config.summary(local=self.remote_runner is None))
         if self.config:
             for err in self.config.config_errors:
                 printerrlog("WARNING: %s"%err)


### PR DESCRIPTION
On large projects the summary output can slow down the launch of a system. The --no-summary option hides the summary to get things running faster. 