### PR TITLE
Reuse xmlrpc connections everywhere

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -636,7 +636,10 @@ def is_topic(param_name):
         return v
     return validator
 
-def xmlrpcapi(uri):
+_xmlrpc_cache = {}
+_xmlrpc_lock = threading.Lock()
+
+def xmlrpcapi(uri, cache=True):
     """
     @return: instance for calling remote server or None if not a valid URI
     @rtype: xmlrpclib.ServerProxy
@@ -646,4 +649,22 @@ def xmlrpcapi(uri):
     uriValidate = urlparse.urlparse(uri)
     if not uriValidate[0] or not uriValidate[1]:
         return None
-    return xmlrpcclient.ServerProxy(uri)
+    if not cache:
+        return xmlrpcclient.ServerProxy(uri)
+    if uri not in _xmlrpc_cache:
+        with _xmlrpc_lock:
+            if uri not in _xmlrpc_cache:  # allows lazy locking
+                _xmlrpc_cache[uri] = _LockedServerProxy(uri)
+    return _xmlrpc_cache[uri]
+
+
+class _LockedServerProxy(xmlrpcclient.ServerProxy):
+
+    def __init__(self, *args, **kwargs):
+        xmlrpcclient.ServerProxy.__init__(self, *args, **kwargs)
+        self._lock = threading.Lock()
+
+    def _ServerProxy__request(self, methodname, params):
+        with self._lock:
+            return xmlrpcclient.ServerProxy._ServerProxy__request(
+                self, methodname, params)

--- a/clients/rospy/src/rospy/impl/masterslave.py
+++ b/clients/rospy/src/rospy/impl/masterslave.py
@@ -447,7 +447,7 @@ class ROSHandler(XmlRpcHandler):
         while not success and not is_shutdown():
             try:
                 code, msg, result = \
-                      xmlrpcapi(pub_uri).requestTopic(caller_id, topic, protocols)
+                      xmlrpcapi(pub_uri, cache=False).requestTopic(caller_id, topic, protocols)
                 success = True
             except Exception as e:
                 if getattr(e, 'errno', None) == errno.ECONNREFUSED:


### PR DESCRIPTION
I noticed that xmlrpc connections are still not always reused since, due to circular import dependencies, the proxy class in rospy.msproxy can't be imported into these modules:
- rospy.impl.registration
- rospy.impl.tcpros_base
- rospy.impl.masterslave
- rospy.impl.simtime

### Current behavior

The current behavior is that a bunch of connections to the master are created and closed when running e.g. rospy.init_node:

(sudo  tshark -i lo -f "dst port 11311 or src port 11311")
```
    1 0.000000000          ::1 → ::1          TCP 94 36840 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65476 SACK_PERM=1 TSval=2354951144 TSecr=0 WS=128
    2 0.000007516          ::1 → ::1          TCP 74 11311 → 36840 [RST, ACK] Seq=1 Ack=1 Win=0 Len=0
    3 0.000094255    127.0.0.1 → 127.0.0.1    TCP 74 36862 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764413847 TSecr=0 WS=128
    4 0.000105717    127.0.0.1 → 127.0.0.1    TCP 74 11311 → 36862 [SYN, ACK] Seq=0 Ack=1 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764413847 TSecr=764413847 WS=128
    5 0.000116362    127.0.0.1 → 127.0.0.1    TCP 66 36862 → 11311 [ACK] Seq=1 Ack=1 Win=43776 Len=0 TSval=764413847 TSecr=764413847
    6 0.000168308    127.0.0.1 → 127.0.0.1    HTTP/XML 606 POST /RPC2 HTTP/1.1
    7 0.000173955    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36862 [ACK] Seq=1 Ack=541 Win=44800 Len=0 TSval=764413847 TSecr=764413847
    8 0.001303588    127.0.0.1 → 127.0.0.1    HTTP/XML 491 HTTP/1.1 200 OK
    9 0.001396096    127.0.0.1 → 127.0.0.1    TCP 66 36862 → 11311 [ACK] Seq=541 Ack=426 Win=44800 Len=0 TSval=764413848 TSecr=764413848
   10 0.001726928    127.0.0.1 → 127.0.0.1    TCP 66 36862 → 11311 [FIN, ACK] Seq=541 Ack=426 Win=44800 Len=0 TSval=764413848 TSecr=764413848
   11 0.001857864    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36862 [FIN, ACK] Seq=426 Ack=542 Win=44800 Len=0 TSval=764413848 TSecr=764413848
   12 0.001867883    127.0.0.1 → 127.0.0.1    TCP 66 36862 → 11311 [ACK] Seq=542 Ack=427 Win=44800 Len=0 TSval=764413849 TSecr=764413848
   13 0.002333755          ::1 → ::1          TCP 94 36844 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65476 SACK_PERM=1 TSval=2354951146 TSecr=0 WS=128
   14 0.002341636          ::1 → ::1          TCP 74 11311 → 36844 [RST, ACK] Seq=1 Ack=1 Win=0 Len=0
   15 0.002424578    127.0.0.1 → 127.0.0.1    TCP 74 36866 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764413849 TSecr=0 WS=128
   16 0.002432337    127.0.0.1 → 127.0.0.1    TCP 74 11311 → 36866 [SYN, ACK] Seq=0 Ack=1 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764413849 TSecr=764413849 WS=128
   17 0.002440512    127.0.0.1 → 127.0.0.1    TCP 66 36866 → 11311 [ACK] Seq=1 Ack=1 Win=43776 Len=0 TSval=764413849 TSecr=764413849
   18 0.002485575    127.0.0.1 → 127.0.0.1    HTTP/XML 456 POST /RPC2 HTTP/1.1
   19 0.002490944    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36866 [ACK] Seq=1 Ack=391 Win=44800 Len=0 TSval=764413849 TSecr=764413849
   20 0.003260067    127.0.0.1 → 127.0.0.1    HTTP/XML 467 HTTP/1.1 200 OK
   21 0.003332324    127.0.0.1 → 127.0.0.1    TCP 66 36866 → 11311 [ACK] Seq=391 Ack=402 Win=44800 Len=0 TSval=764413850 TSecr=764413850
   22 0.003546073    127.0.0.1 → 127.0.0.1    TCP 66 36866 → 11311 [FIN, ACK] Seq=391 Ack=402 Win=44800 Len=0 TSval=764413850 TSecr=764413850
   23 0.003654014    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36866 [FIN, ACK] Seq=402 Ack=392 Win=44800 Len=0 TSval=764413850 TSecr=764413850
   24 0.003663092    127.0.0.1 → 127.0.0.1    TCP 66 36866 → 11311 [ACK] Seq=392 Ack=403 Win=44800 Len=0 TSval=764413850 TSecr=764413850
   25 0.004437313          ::1 → ::1          TCP 94 36848 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65476 SACK_PERM=1 TSval=2354951148 TSecr=0 WS=128
   26 0.004442140          ::1 → ::1          TCP 74 11311 → 36848 [RST, ACK] Seq=1 Ack=1 Win=0 Len=0
   27 0.004500739    127.0.0.1 → 127.0.0.1    TCP 74 36870 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764413851 TSecr=0 WS=128
   28 0.004507852    127.0.0.1 → 127.0.0.1    TCP 74 11311 → 36870 [SYN, ACK] Seq=0 Ack=1 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764413851 TSecr=764413851 WS=128
   29 0.004515114    127.0.0.1 → 127.0.0.1    TCP 66 36870 → 11311 [ACK] Seq=1 Ack=1 Win=43776 Len=0 TSval=764413851 TSecr=764413851
   30 0.004578683    127.0.0.1 → 127.0.0.1    HTTP/XML 628 POST /RPC2 HTTP/1.1
   31 0.004584077    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36870 [ACK] Seq=1 Ack=563 Win=44928 Len=0 TSval=764413851 TSecr=764413851
   32 0.005441083    127.0.0.1 → 127.0.0.1    HTTP/XML 483 HTTP/1.1 200 OK
   33 0.005521379    127.0.0.1 → 127.0.0.1    TCP 66 36870 → 11311 [ACK] Seq=563 Ack=418 Win=44800 Len=0 TSval=764413852 TSecr=764413852
   34 0.005728835    127.0.0.1 → 127.0.0.1    TCP 66 36870 → 11311 [FIN, ACK] Seq=563 Ack=418 Win=44800 Len=0 TSval=764413852 TSecr=764413852
   35 0.005839586    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36870 [FIN, ACK] Seq=418 Ack=564 Win=44928 Len=0 TSval=764413852 TSecr=764413852
   36 0.005848876    127.0.0.1 → 127.0.0.1    TCP 66 36870 → 11311 [ACK] Seq=564 Ack=419 Win=44800 Len=0 TSval=764413852 TSecr=764413852
   37 0.006043120          ::1 → ::1          TCP 94 36852 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65476 SACK_PERM=1 TSval=2354951150 TSecr=0 WS=128
   38 0.006047363          ::1 → ::1          TCP 74 11311 → 36852 [RST, ACK] Seq=1 Ack=1 Win=0 Len=0
   39 0.006104075    127.0.0.1 → 127.0.0.1    TCP 74 36874 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764413853 TSecr=0 WS=128
   40 0.006110591    127.0.0.1 → 127.0.0.1    TCP 74 11311 → 36874 [SYN, ACK] Seq=0 Ack=1 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764413853 TSecr=764413853 WS=128
   41 0.006118103    127.0.0.1 → 127.0.0.1    TCP 66 36874 → 11311 [ACK] Seq=1 Ack=1 Win=43776 Len=0 TSval=764413853 TSecr=764413853
   42 0.006158123    127.0.0.1 → 127.0.0.1    HTTP/XML 633 POST /RPC2 HTTP/1.1
   43 0.006162695    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36874 [ACK] Seq=1 Ack=568 Win=44928 Len=0 TSval=764413853 TSecr=764413853
   44 0.006974897    127.0.0.1 → 127.0.0.1    HTTP/XML 488 HTTP/1.1 200 OK
   45 0.006989306    127.0.0.1 → 127.0.0.1    TCP 66 36874 → 11311 [ACK] Seq=568 Ack=423 Win=44800 Len=0 TSval=764413854 TSecr=764413854
   46 0.007156803    127.0.0.1 → 127.0.0.1    TCP 66 36874 → 11311 [FIN, ACK] Seq=568 Ack=423 Win=44800 Len=0 TSval=764413854 TSecr=764413854
   47 0.007576594    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36874 [FIN, ACK] Seq=423 Ack=569 Win=44928 Len=0 TSval=764413854 TSecr=764413854
   48 0.007638926    127.0.0.1 → 127.0.0.1    TCP 66 36874 → 11311 [ACK] Seq=569 Ack=424 Win=44800 Len=0 TSval=764413854 TSecr=764413854
```

This continues when one creates e.g. a Subscriber:
```
   49 23.805923784          ::1 → ::1          TCP 94 36856 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65476 SACK_PERM=1 TSval=2354974938 TSecr=0 WS=128
   50 23.805930037          ::1 → ::1          TCP 74 11311 → 36856 [RST, ACK] Seq=1 Ack=1 Win=0 Len=0
   51 23.805997684    127.0.0.1 → 127.0.0.1    TCP 74 36878 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764437641 TSecr=0 WS=128
   52 23.806005848    127.0.0.1 → 127.0.0.1    TCP 74 11311 → 36878 [SYN, ACK] Seq=0 Ack=1 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764437641 TSecr=764437641 WS=128
   53 23.806013395    127.0.0.1 → 127.0.0.1    TCP 66 36878 → 11311 [ACK] Seq=1 Ack=1 Win=43776 Len=0 TSval=764437641 TSecr=764437641
   54 23.806057124    127.0.0.1 → 127.0.0.1    HTTP/XML 461 POST /RPC2 HTTP/1.1
   55 23.806061478    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36878 [ACK] Seq=1 Ack=396 Win=44800 Len=0 TSval=764437641 TSecr=764437641
   56 23.807143027    127.0.0.1 → 127.0.0.1    HTTP/XML 472 HTTP/1.1 200 OK
   57 23.807327739    127.0.0.1 → 127.0.0.1    TCP 66 36878 → 11311 [ACK] Seq=396 Ack=407 Win=44800 Len=0 TSval=764437642 TSecr=764437642
   58 23.808404557          ::1 → ::1          TCP 94 36860 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65476 SACK_PERM=1 TSval=2354974940 TSecr=0 WS=128
   59 23.808409059          ::1 → ::1          TCP 74 11311 → 36860 [RST, ACK] Seq=1 Ack=1 Win=0 Len=0
   60 23.808655649    127.0.0.1 → 127.0.0.1    TCP 74 36882 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764437643 TSecr=0 WS=128
   61 23.808662486    127.0.0.1 → 127.0.0.1    TCP 74 11311 → 36882 [SYN, ACK] Seq=0 Ack=1 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764437643 TSecr=764437643 WS=128
   62 23.808669110    127.0.0.1 → 127.0.0.1    TCP 66 36882 → 11311 [ACK] Seq=1 Ack=1 Win=43776 Len=0 TSval=764437643 TSecr=764437643
   63 23.808703062    127.0.0.1 → 127.0.0.1    HTTP/XML 605 POST /RPC2 HTTP/1.1
   64 23.808707011    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36882 [ACK] Seq=1 Ack=540 Win=44800 Len=0 TSval=764437643 TSecr=764437643
   65 23.809377932    127.0.0.1 → 127.0.0.1    HTTP/XML 470 HTTP/1.1 200 OK
   66 23.809440781    127.0.0.1 → 127.0.0.1    TCP 66 36882 → 11311 [ACK] Seq=540 Ack=405 Win=44800 Len=0 TSval=764437644 TSecr=764437644
   67 23.809629372    127.0.0.1 → 127.0.0.1    TCP 66 36882 → 11311 [FIN, ACK] Seq=540 Ack=405 Win=44800 Len=0 TSval=764437644 TSecr=764437644
   68 23.809713615    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36882 [FIN, ACK] Seq=405 Ack=541 Win=44800 Len=0 TSval=764437644 TSecr=764437644
   69 23.809720826    127.0.0.1 → 127.0.0.1    TCP 66 36882 → 11311 [ACK] Seq=541 Ack=406 Win=44800 Len=0 TSval=764437644 TSecr=764437644
```

And a second one:
```
   70 47.352429594    127.0.0.1 → 127.0.0.1    HTTP/XML 461 POST /RPC2 HTTP/1.1
   71 47.352927753    127.0.0.1 → 127.0.0.1    HTTP/XML 472 HTTP/1.1 200 OK
   72 47.352997414    127.0.0.1 → 127.0.0.1    TCP 66 36878 → 11311 [ACK] Seq=791 Ack=813 Win=45952 Len=0 TSval=764461176 TSecr=764461176
   73 47.353824717          ::1 → ::1          TCP 94 36864 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65476 SACK_PERM=1 TSval=2354998474 TSecr=0 WS=128
   74 47.353841293          ::1 → ::1          TCP 74 11311 → 36864 [RST, ACK] Seq=1 Ack=1 Win=0 Len=0
   75 47.354091428    127.0.0.1 → 127.0.0.1    TCP 74 36886 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764461177 TSecr=0 WS=128
   76 47.354100787    127.0.0.1 → 127.0.0.1    TCP 74 11311 → 36886 [SYN, ACK] Seq=0 Ack=1 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764461177 TSecr=764461177 WS=128
   77 47.354119460    127.0.0.1 → 127.0.0.1    TCP 66 36886 → 11311 [ACK] Seq=1 Ack=1 Win=43776 Len=0 TSval=764461177 TSecr=764461177
   78 47.354181906    127.0.0.1 → 127.0.0.1    HTTP/XML 602 POST /RPC2 HTTP/1.1
   79 47.354186263    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36886 [ACK] Seq=1 Ack=537 Win=44800 Len=0 TSval=764461177 TSecr=764461177
   80 47.355441642    127.0.0.1 → 127.0.0.1    HTTP/XML 467 HTTP/1.1 200 OK
   81 47.355573181    127.0.0.1 → 127.0.0.1    TCP 66 36886 → 11311 [ACK] Seq=537 Ack=402 Win=44800 Len=0 TSval=764461179 TSecr=764461178
   82 47.355762291    127.0.0.1 → 127.0.0.1    TCP 66 36886 → 11311 [FIN, ACK] Seq=537 Ack=402 Win=44800 Len=0 TSval=764461179 TSecr=764461178
   83 47.355857007    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36886 [FIN, ACK] Seq=402 Ack=538 Win=44800 Len=0 TSval=764461179 TSecr=764461179
   84 47.355864468    127.0.0.1 → 127.0.0.1    TCP 66 36886 → 11311 [ACK] Seq=538 Ack=403 Win=44800 Len=0 TSval=764461179 TSecr=764461179
```

### Patched version

With the proposed change this behavior changes to:


rospy.init_node
```
    1 0.000000000          ::1 → ::1          TCP 94 36932 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65476 SACK_PERM=1 TSval=2355075628 TSecr=0 WS=128
    2 0.000008367          ::1 → ::1          TCP 74 11311 → 36932 [RST, ACK] Seq=1 Ack=1 Win=0 Len=0
    3 0.000099964    127.0.0.1 → 127.0.0.1    TCP 74 36954 → 11311 [SYN] Seq=0 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764538331 TSecr=0 WS=128
    4 0.000110471    127.0.0.1 → 127.0.0.1    TCP 74 11311 → 36954 [SYN, ACK] Seq=0 Ack=1 Win=43690 Len=0 MSS=65495 SACK_PERM=1 TSval=764538331 TSecr=764538331 WS=128
    5 0.000120775    127.0.0.1 → 127.0.0.1    TCP 66 36954 → 11311 [ACK] Seq=1 Ack=1 Win=43776 Len=0 TSval=764538331 TSecr=764538331
    6 0.000175868    127.0.0.1 → 127.0.0.1    HTTP/XML 606 POST /RPC2 HTTP/1.1
    7 0.000182199    127.0.0.1 → 127.0.0.1    TCP 66 11311 → 36954 [ACK] Seq=1 Ack=541 Win=44800 Len=0 TSval=764538331 TSecr=764538331
    8 0.001266184    127.0.0.1 → 127.0.0.1    HTTP/XML 491 HTTP/1.1 200 OK
    9 0.001355646    127.0.0.1 → 127.0.0.1    TCP 66 36954 → 11311 [ACK] Seq=541 Ack=426 Win=44800 Len=0 TSval=764538332 TSecr=764538332
   10 0.001980446    127.0.0.1 → 127.0.0.1    HTTP/XML 456 POST /RPC2 HTTP/1.1
   11 0.002318695    127.0.0.1 → 127.0.0.1    HTTP/XML 467 HTTP/1.1 200 OK
   12 0.003265115    127.0.0.1 → 127.0.0.1    HTTP/XML 628 POST /RPC2 HTTP/1.1
   13 0.003740236    127.0.0.1 → 127.0.0.1    HTTP/XML 483 HTTP/1.1 200 OK
   14 0.004230398    127.0.0.1 → 127.0.0.1    HTTP/XML 633 POST /RPC2 HTTP/1.1
   15 0.004700802    127.0.0.1 → 127.0.0.1    HTTP/XML 488 HTTP/1.1 200 OK
   16 0.048561980    127.0.0.1 → 127.0.0.1    TCP 66 36954 → 11311 [ACK] Seq=2060 Ack=1666 Win=48000 Len=0 TSval=764538336 TSecr=764538335
```

First Subscriber:
```
   17 21.983918720    127.0.0.1 → 127.0.0.1    HTTP/XML 461 POST /RPC2 HTTP/1.1
   18 21.984347682    127.0.0.1 → 127.0.0.1    HTTP/XML 472 HTTP/1.1 200 OK
   19 21.984431488    127.0.0.1 → 127.0.0.1    TCP 66 36954 → 11311 [ACK] Seq=2455 Ack=2072 Win=49152 Len=0 TSval=764560304 TSecr=764560304
   20 21.984769523    127.0.0.1 → 127.0.0.1    HTTP/XML 602 POST /RPC2 HTTP/1.1
   21 21.985317669    127.0.0.1 → 127.0.0.1    HTTP/XML 467 HTTP/1.1 200 OK
   22 22.031040784    127.0.0.1 → 127.0.0.1    TCP 66 36954 → 11311 [ACK] Seq=2991 Ack=2473 Win=50176 Len=0 TSval=764560305 TSecr=764560305
```

Second Subscriber:
```
   23 38.985236770    127.0.0.1 → 127.0.0.1    HTTP/XML 461 POST /RPC2 HTTP/1.1
   24 38.985925827    127.0.0.1 → 127.0.0.1    HTTP/XML 472 HTTP/1.1 200 OK
   25 38.985993202    127.0.0.1 → 127.0.0.1    TCP 66 36954 → 11311 [ACK] Seq=3386 Ack=2879 Win=51200 Len=0 TSval=764577297 TSecr=764577297
   26 38.986327259    127.0.0.1 → 127.0.0.1    HTTP/XML 605 POST /RPC2 HTTP/1.1
   27 38.986797365    127.0.0.1 → 127.0.0.1    HTTP/XML 470 HTTP/1.1 200 OK
   28 39.027888922    127.0.0.1 → 127.0.0.1    TCP 66 36954 → 11311 [ACK] Seq=3925 Ack=3283 Win=52352 Len=0 TSval=764577298 TSecr=764577298
```

### Implementation:

- The cache dictionary itself is not enough since the ServerProxy is not threadsafe. In order to accomplish that without touching too much code I wrapped the ServerProxy class and made it threadsafe.
- The optional argument cache for xmlrpcapi allows to deactivate the caching. I added this feature to be able to close the xmlrpc connection between a subscriber and a publisher (requestTopic node api) since keeping it open is not really required.