### PR TITLE
[roslaunch] Better exception handling when resource is not found.

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -47,6 +47,7 @@ from xml.dom.minidom import parse, parseString
 from xml.dom import Node as DomNode #avoid aliasing
 
 from rosgraph.names import make_global_ns, ns_join, is_private, is_legal_name, get_ros_namespace
+from rospkg import ResourceNotFound
 
 from .core import Param, Node, Test, Machine, RLException
 from . import loader
@@ -301,6 +302,9 @@ class XmlLoader(loader.Loader):
         except substitution_args.ArgException as e:
             raise XmlParseException(
                 "arg '%s' is not defined. \n\nArg xml is %s"%(e, tag.toxml()))
+        except ResourceNotFound as e:
+            raise XmlParseException(
+                "Invalid <arg> tag: Make sure the following is found in ROS_PACKAGE_PATH: %s \n\nArg xml is %s"%(e, tag.toxml()))
         except Exception as e:
             raise XmlParseException(
                 "Invalid <arg> tag: %s. \n\nArg xml is %s"%(e, tag.toxml()))

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -303,7 +303,8 @@ class XmlLoader(loader.Loader):
             raise XmlParseException(
                 "arg '%s' is not defined. \n\nArg xml is %s"%(e, tag.toxml()))
         except ResourceNotFound as e:
-            raise type(e)("Tag the exception occurred at {}\nPackage not found in ROS_PACKAGE_PATH: {}\nMake sure the package is found in ROS_PACKAGE_PATH.".format(tag.toxml(), e))
+            raise ResourceNotFound(
+                "The following package was not found in {}: {}".format(tag.toxml(), e))
         except Exception as e:
             raise XmlParseException(
                 "Invalid <arg> tag: %s. \n\nArg xml is %s"%(e, tag.toxml()))

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -303,8 +303,7 @@ class XmlLoader(loader.Loader):
             raise XmlParseException(
                 "arg '%s' is not defined. \n\nArg xml is %s"%(e, tag.toxml()))
         except ResourceNotFound as e:
-            raise XmlParseException(
-                "Invalid <arg> tag: Make sure the following is found in ROS_PACKAGE_PATH: %s \n\nArg xml is %s"%(e, tag.toxml()))
+            raise type(e)("Tag the exception occurred at {}\nPackage not found in ROS_PACKAGE_PATH: {}\nMake sure the package is found in ROS_PACKAGE_PATH.".format(tag.toxml(), e))
         except Exception as e:
             raise XmlParseException(
                 "Invalid <arg> tag: %s. \n\nArg xml is %s"%(e, tag.toxml()))


### PR DESCRIPTION
When `$(find pkg)` fail to return a resource in `arg` tag, `roslaunch` fails without printing useful output. With this PR it provides better explanation.

Though I haven't looked into whether there's a test that covers this yet, I'm happy to add one if needed.

Without this PR:
```
$ roslaunch /tmp/invalid_arg.launch
:
Invalid <arg> tag: foo
ROS path [0]=/opt/ros/kinetic/share/ros
ROS path [1]=/home/n130s/ROS/indigo_trusty/cws_rosdt/src/ros/ros_comm/tools/roslaunch
ROS path [2]=/opt/ros/kinetic/share

Arg xml is <arg default="$(find foo)/.config" name="foo"/>
The traceback for the exception was written to the log file
```

With this PR:
```
$ roslaunch /tmp/invalid_arg.launch
:
Invalid <arg> tag: Make sure the following is found in ROS_PACKAGE_PATH: foo
ROS path [0]=/opt/ros/kinetic/share/ros
ROS path [1]=/home/n130s/ROS/indigo_trusty/cws_rosdt/src/ros/ros_comm/tools/roslaunch
ROS path [2]=/opt/ros/kinetic/share

Arg xml is <arg default="$(find foo)/.config" name="foo"/>
The traceback for the exception was written to the log file
```

```
$ more /tmp/invalid_arg.launch
<?xml version="1.0"?>
<launch>
  <arg name="foo" default="$(find foo)/.config" />
  <arg name="baa" default="$(arg foo)/hoge.yaml" />
</launch>
```