### PR TITLE
[roswtf] Add an alias script.

### DIFF
--- a/utilities/roswtf/scripts/rosfaq
+++ b/utilities/roswtf/scripts/rosfaq
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2018, Open Source Robotics Foundation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Open Source Robotics Foundation. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import roswtf
+roswtf.roswtf_main()

--- a/utilities/roswtf/setup.py
+++ b/utilities/roswtf/setup.py
@@ -6,7 +6,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 d = generate_distutils_setup(
     packages=['roswtf'],
     package_dir={'': 'src'},
-    scripts=['scripts/roswtf'],
+    scripts=['scripts/roswtf', 'scripts/rosfaq'],
     requires=['genmsg', 'genpy', 'roslib', 'rospkg']
 )
 


### PR DESCRIPTION
`roswtf` provides federated FAQ analysis. Its plugin mechanism allows customization. In product setting we found it convenient to implement system checkup that the users, not just developers, can run with a fewer steps.

I hate to say but its script name is often concerning when asking customers to run checkup command. Here I'm suggesting to add an "alias" script.

I simply duplicated `roswtf` script and renamed it, so it's not really an alias, but I did not know how I can alias a Python script.

I named it `rosfaq` but I'm all ears for the naming as well.