### PR TITLE
add dependency on rosbash to topic_tools

### DIFF
--- a/tools/topic_tools/package.xml
+++ b/tools/topic_tools/package.xml
@@ -19,6 +19,7 @@
 
   <build_depend>cpp_common</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>rosbash</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rostest</build_depend>
@@ -28,6 +29,7 @@
   <build_depend>xmlrpcpp</build_depend>
 
   <run_depend>message_runtime</run_depend>
+  <run_depend>rosbash</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rostime</run_depend>


### PR DESCRIPTION
Without this, `source /opt/ros/$ROS_DISTRO/setup.bash` fails when `topic_tools` is installed (and `rosbash` is not) because the following variable is empty in `20.transform.bash`:

    _sav_transform_roscomplete_rosrun=

This problem is demonstrated by the following `.gitlab-ci.yml`:

https://gitlab.com/mintar/debug_topic_tools_rosbash/blob/master/.gitlab-ci.yml

The failure is shown in the log here:

https://gitlab.com/mintar/debug_topic_tools_rosbash/-/jobs/88877496

Without rosbash installed, the command `$(complete | grep -w rosrun | awk '{print $3}')` returns nothing, so the `source` command fails.

Installing `rosbash` fixes the problem, which is why I believe `topic_tools` should have a dependency on `rosbash`.