### PR TITLE
reduce test threshold to avoid flakiness

### DIFF
--- a/test/test_roscpp/test/launch/pingpong.xml
+++ b/test/test_roscpp/test/launch/pingpong.xml
@@ -1,5 +1,5 @@
 <launch>
   <node name="pub_sub" pkg="test_roscpp" type="test_roscpp-pub_sub" args="1"/>
-  <test test-name="pingpong" pkg="test_roscpp" type="test_roscpp-sub_pub" args="5000 10.0"/>
+  <test test-name="pingpong" pkg="test_roscpp" type="test_roscpp-sub_pub" args="500 10.0"/>
 </launch>
 

--- a/test/test_roscpp/test/src/sub_pub.cpp
+++ b/test/test_roscpp/test/src/sub_pub.cpp
@@ -120,10 +120,13 @@ TEST_F(Subscriptions, subPub)
     ros::getGlobalCallbackQueue()->callAvailable(ros::WallDuration(0.1));
   }
 
-  if(success)
+  if(success) {
     SUCCEED();
-  else
-    FAIL();
+  } else if (ros::Time::now() >= t1) {
+    FAIL() << "timed out after receiving " << msg_i << " of " << g_msg_count << " messages";
+  } else {
+    FAIL() << "message counter did not match";
+  }
 }
 
 #define USAGE "USAGE: sub_pub <count> <time>"


### PR DESCRIPTION
Increase the verbosity of the test as well as lower the threshold to avoid flakiness:
* http://build.ros.org/job/Mpr__ros_comm__ubuntu_bionic_amd64/248/testReport/junit/(root)/Subscriptions/subPub/
  > timed out after receiving 877 of 5000 messages
* http://build.ros.org/job/Mpr_ds__ros_comm__debian_stretch_amd64/234/testReport/junit/(root)/Subscriptions/subPub/
  > timed out after receiving 3178 of 5000 messages