### PR TITLE
fix topic_tools environment hook

### DIFF
--- a/tools/topic_tools/env-hooks/20.transform.bash
+++ b/tools/topic_tools/env-hooks/20.transform.bash
@@ -20,7 +20,7 @@ function _roscomplete_node_transform
     fi
 }
 
-_sav_transform_roscomplete_rosrun=$(complete | grep -w rosrun | awk '{print $3}')
+_sav_transform_roscomplete_rosrun=$(complete | { grep -w rosrun || test $? = 1; } | awk '{print $3}')
 
 function is_transform_node
 {


### PR DESCRIPTION
Without this commit, `source /opt/ros/$ROS_DISTRO/setup.bash` fails under the following conditions:

1. topic_tools is installed
2. rosbash is not installed
3. the bash shell has the following options set (which is the default in GitLab CI):

    set -o errexit
    set -o pipefail

What happens is that since rosbash is not installed, `$(complete | grep -w rosrun)` finds no match, and grep exits with status 1. Since `pipefail` is enabled, this error code is propagated to the return value of the pipe. Since `errexit` is enabled, the script exits immediately.

This commit catches grep exit status 1 (= "no match") and passes everything else through.

Supersedes #1484.