### PR TITLE
import socket, threading in udpros.py

### DIFF
--- a/clients/rospy/src/rospy/impl/udpros.py
+++ b/clients/rospy/src/rospy/impl/udpros.py
@@ -42,6 +42,7 @@ UDPROS connection protocol.
 # 
 
 import socket
+import threading
 import rosgraph.network
 
 import rospy.impl.registration

--- a/clients/rospy/src/rospy/impl/udpros.py
+++ b/clients/rospy/src/rospy/impl/udpros.py
@@ -41,6 +41,7 @@ UDPROS connection protocol.
 #  http://ros.org/wiki/ROS/UDPROS
 # 
 
+import socket
 import rosgraph.network
 
 import rospy.impl.registration


### PR DESCRIPTION
Avoids seven undefined names:

[flake8](http://flake8.pycqa.org) testing of https://github.com/ros/ros_comm on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./clients/rospy/src/rospy/impl/udpros.py:72:17: F821 undefined name 'socket'
            s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
                ^
./clients/rospy/src/rospy/impl/udpros.py:72:31: F821 undefined name 'socket'
            s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
                              ^
./clients/rospy/src/rospy/impl/udpros.py:72:48: F821 undefined name 'socket'
            s = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
                                               ^
./clients/rospy/src/rospy/impl/udpros.py:74:17: F821 undefined name 'socket'
            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
                ^
./clients/rospy/src/rospy/impl/udpros.py:74:31: F821 undefined name 'socket'
            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
                              ^
./clients/rospy/src/rospy/impl/udpros.py:74:47: F821 undefined name 'socket'
            s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM) 
                                              ^
./clients/rospy/src/rospy/impl/udpros.py:79:9: F821 undefined name 'threading'
        threading.start_new_thread(self.run, ())
        ^
```