### PR TITLE
roslaunch: Allow passing _TIMEOUT_SIGINT and _TIMEOUT_SIGTERM as parameters

### DIFF
--- a/tools/roslaunch/resources/timeouts.launch
+++ b/tools/roslaunch/resources/timeouts.launch
@@ -1,0 +1,5 @@
+<launch>
+
+  <node name="signals" pkg="roslaunch" type="signal_logger.py" />
+
+</launch>

--- a/tools/roslaunch/scripts/roscore
+++ b/tools/roslaunch/scripts/roscore
@@ -59,6 +59,16 @@ def _get_optparse():
     parser.add_option("--master-logger-level",
                       dest="master_logger_level", default=False, type=str,
                       help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
+    parser.add_option("--sigint-timeout",
+                      dest="sigint_timeout",
+                      default=15, type=int,
+                      help="the SIGINT timeout used when killing the core (in seconds).",
+                      metavar="SIGINT_TIMEOUT")
+    parser.add_option("--sigterm-timeout",
+                      dest="sigterm_timeout",
+                      default=2, type=int,
+                      help="the SIGTERM timeout used when killing core if SIGINT does not stop the core (in seconds).",
+                      metavar="SIGTERM_TIMEOUT")
     return parser
 
 

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -187,6 +187,16 @@ def _get_optparse():
     parser.add_option("--master-logger-level",
                       dest="master_logger_level", default=False, type=str,
                       help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
+    parser.add_option("--sigint-timeout",
+                      dest="sigint_timeout",
+                      default=15, type=int,
+                      help="the SIGINT timeout used when killing nodes (in seconds).",
+                      metavar="SIGINT_TIMEOUT")
+    parser.add_option("--sigterm-timeout",
+                      dest="sigterm_timeout",
+                      default=2, type=int,
+                      help="the SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).",
+                      metavar="SIGTERM_TIMEOUT")
 
     return parser
     
@@ -318,7 +328,8 @@ def main(argv=sys.argv):
                     verbose=options.verbose, force_screen=options.force_screen,
                     force_log=options.force_log,
                     num_workers=options.num_workers, timeout=options.timeout,
-                    master_logger_level=options.master_logger_level)
+                    master_logger_level=options.master_logger_level,
+                    sigint_timeout=options.sigint_timeout, sigterm_timeout=options.sigterm_timeout)
             p.start()
             p.spin()
 

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -300,7 +300,9 @@ def main(argv=sys.argv):
             # client spins up an XML-RPC server that waits for
             # commands and configuration from the server.
             from . import child as roslaunch_child
-            c = roslaunch_child.ROSLaunchChild(uuid, options.child_name, options.server_uri)
+            c = roslaunch_child.ROSLaunchChild(uuid, options.child_name, options.server_uri,
+                                               sigint_timeout=options.sigint_timeout,
+                                               sigterm_timeout=options.sigterm_timeout)
             c.run()
         else:
             logger.info('starting in server mode')

--- a/tools/roslaunch/src/roslaunch/child.py
+++ b/tools/roslaunch/src/roslaunch/child.py
@@ -57,7 +57,7 @@ class ROSLaunchChild(object):
     This must be called from the Python Main thread due to signal registration.
     """
 
-    def __init__(self, run_id, name, server_uri):
+    def __init__(self, run_id, name, server_uri, sigint_timeout=15, sigterm_timeout=2):
         """
         Startup roslaunch remote client XML-RPC services. Blocks until shutdown
         @param run_id: UUID of roslaunch session
@@ -66,6 +66,11 @@ class ROSLaunchChild(object):
         @type  name: str
         @param server_uri: XML-RPC URI of roslaunch server
         @type  server_uri: str
+        @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        @type  sigint_timeout: int
+        @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (
+                                in seconds).
+        @type  sigterm_timeout: int
         @return: XML-RPC URI
         @rtype:  str
         """
@@ -77,6 +82,8 @@ class ROSLaunchChild(object):
         self.server_uri = server_uri
         self.child_server = None
         self.pm = None
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
 
         roslaunch.pmon._init_signal_handlers()
 
@@ -102,7 +109,9 @@ class ROSLaunchChild(object):
             try:
                 self.logger.info("starting roslaunch child process [%s], server URI is [%s]", self.name, self.server_uri)
                 self._start_pm()
-                self.child_server = roslaunch.server.ROSLaunchChildNode(self.run_id, self.name, self.server_uri, self.pm)
+                self.child_server = roslaunch.server.ROSLaunchChildNode(self.run_id, self.name, self.server_uri,
+                                                                        self.pm, sigint_timeout=self.sigint_timeout,
+                                                                        sigterm_timeout=self.sigterm_timeout)
                 self.logger.info("... creating XMLRPC server for child")
                 self.child_server.start()
                 self.logger.info("... started XMLRPC server for child")

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -197,6 +197,13 @@ class LocalProcess(Process):
         """    
         super(LocalProcess, self).__init__(package, name, args, env,
                 respawn, respawn_delay, required)
+
+        if sigint_timeout <= 0:
+            raise RLException("sigint_timeout must be a positive number, received %f" % sigint_timeout)
+
+        if sigterm_timeout <= 0:
+            raise RLException("sigterm_timeout must be a positive number, received %f" % sigterm_timeout)
+
         self.run_id = run_id
         self.popen = None
         self.log_output = log_output

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -55,16 +55,13 @@ from rosmaster.master_api import NUM_WORKERS
 import logging
 _logger = logging.getLogger("roslaunch")
 
-_TIMEOUT_SIGINT  = 15.0 #seconds
-_TIMEOUT_SIGTERM = 2.0 #seconds
-
 _counter = 0
 def _next_counter():
     global _counter
     _counter += 1
     return _counter
 
-def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
+def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False, sigint_timeout=15, sigterm_timeout=2):
     """
     Launch a master
     @param type_: name of master executable (currently just Master.ZENMASTER)
@@ -77,10 +74,14 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
     @type  num_workers: int
     @param timeout: socket timeout for connections.
     @type  timeout: float
-    @raise RLException: if type_ or port is invalid
     @param master_logger_level: rosmaster.master logger debug level
     @type  master_logger_level=: str or False
-    """    
+    @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+    @type sigint_timeout: int
+    @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+    @type sigterm_timeout: int
+    @raise RLException: if type_ or port is invalid
+    """
     if port < 1 or port > 65535:
         raise RLException("invalid port assignment: %s"%port)
 
@@ -100,9 +101,9 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
 
     _logger.info("process[master]: launching with args [%s]"%args)
     log_output = False
-    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, None, required=True)
+    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, None, required=True, sigint_timeout=sigint_timeout, sigterm_timeout=sigterm_timeout)
 
-def create_node_process(run_id, node, master_uri):
+def create_node_process(run_id, node, master_uri, sigint_timeout=15, sigterm_timeout=2):
     """
     Factory for generating processes for launching local ROS
     nodes. Also registers the process with the L{ProcessMonitor} so that
@@ -114,6 +115,10 @@ def create_node_process(run_id, node, master_uri):
     @type  node: L{Node}
     @param master_uri: API URI for master node
     @type  master_uri: str
+    @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+    @type sigint_timeout: int
+    @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+    @type sigterm_timeout: int
     @return: local process instance
     @rtype: L{LocalProcess}
     @raise NodeParamsException: If the node's parameters are improperly specific
@@ -150,7 +155,8 @@ def create_node_process(run_id, node, master_uri):
     _logger.debug('process[%s]: returning LocalProcess wrapper')
     return LocalProcess(run_id, node.package, name, args, env, log_output, \
             respawn=node.respawn, respawn_delay=node.respawn_delay, \
-            required=node.required, cwd=node.cwd)
+            required=node.required, cwd=node.cwd, \
+            sigint_timeout=sigint_timeout, sigterm_timeout=sigterm_timeout)
 
 
 class LocalProcess(Process):
@@ -160,7 +166,7 @@ class LocalProcess(Process):
     
     def __init__(self, run_id, package, name, args, env, log_output,
             respawn=False, respawn_delay=0.0, required=False, cwd=None,
-            is_node=True):
+            is_node=True, sigint_timeout=15, sigterm_timeout=2):
         """
         @param run_id: unique run ID for this roslaunch. Used to
           generate log directory location. run_id may be None if this
@@ -184,6 +190,10 @@ class LocalProcess(Process):
         @type  cwd: str
         @param is_node: (optional) if True, process is ROS node and accepts ROS node command-line arguments. Default: True
         @type  is_node: False
+        @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        @type sigint_timeout: int
+        @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+        @type sigterm_timeout: int
         """    
         super(LocalProcess, self).__init__(package, name, args, env,
                 respawn, respawn_delay, required)
@@ -196,6 +206,9 @@ class LocalProcess(Process):
         self.log_dir = None
         self.pid = -1
         self.is_node = is_node
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
+
 
     # NOTE: in the future, info() is going to have to be sufficient for relaunching a process
     def get_info(self):
@@ -406,7 +419,7 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
             _logger.info("[%s] sending SIGINT to pgid [%s]", self.name, pgid)                                    
             os.killpg(pgid, signal.SIGINT)
             _logger.info("[%s] sent SIGINT to pgid [%s]", self.name, pgid)
-            timeout_t = time.time() + _TIMEOUT_SIGINT
+            timeout_t = time.time() + self.sigint_timeout
             retcode = self.popen.poll()                
             while time.time() < timeout_t and retcode is None:
                 time.sleep(0.1)
@@ -414,7 +427,7 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
             # Escalate non-responsive process
             if retcode is None:
                 printerrlog("[%s] escalating to SIGTERM"%self.name)
-                timeout_t = time.time() + _TIMEOUT_SIGTERM
+                timeout_t = time.time() + self.sigterm_timeout
                 os.killpg(pgid, signal.SIGTERM)                
                 _logger.info("[%s] sent SIGTERM to pgid [%s]"%(self.name, pgid))
                 retcode = self.popen.poll()
@@ -474,7 +487,7 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
             _logger.info("[%s] sending SIGINT to pgid [%s]", self.name, pid)
             os.kill(pid, signal.SIGINT)
             _logger.info("[%s] sent SIGINT to pgid [%s]", self.name, pid)
-            timeout_t = time.time() + _TIMEOUT_SIGINT
+            timeout_t = time.time() + self.sigint_timeout
             retcode = self.popen.poll()
             while time.time() < timeout_t and retcode is None:
                 time.sleep(0.1)
@@ -482,7 +495,7 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
             # Escalate non-responsive process
             if retcode is None:
                 printerrlog("[%s] escalating to SIGTERM"%self.name)
-                timeout_t = time.time() + _TIMEOUT_SIGTERM
+                timeout_t = time.time() + self.sigterm_timeout
                 os.killpg(pid, signal.SIGTERM)
                 _logger.info("[%s] sent SIGTERM to pid [%s]"%(self.name, pid))
                 retcode = self.popen.poll()

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -211,7 +211,9 @@ class ROSLaunchParent(object):
         if not self.local_only and self.config.has_remote_nodes():
             # keep the remote package lazy-imported
             import roslaunch.remote
-            self.remote_runner = roslaunch.remote.ROSRemoteRunner(self.run_id, self.config, self.pm, self.server)
+            self.remote_runner = roslaunch.remote.ROSRemoteRunner(self.run_id, self.config, self.pm, self.server,
+                                                                  sigint_timeout=self.sigint_timeout,
+                                                                  sigterm_timeout=self.sigterm_timeout)
         elif self.local_only:
             printlog_bold("LOCAL\nlocal only launch specified, will not launch remote nodes\nLOCAL\n")
 

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -73,7 +73,8 @@ class ROSLaunchParent(object):
     """
 
     def __init__(self, run_id, roslaunch_files, is_core=False, port=None, local_only=False, process_listeners=None,
-            verbose=False, force_screen=False, force_log=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
+            verbose=False, force_screen=False, force_log=False, is_rostest=False, roslaunch_strs=None, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False,
+                 sigint_timeout=15, sigterm_timeout=2):
         """
         @param run_id: UUID of roslaunch session
         @type  run_id: str
@@ -105,12 +106,16 @@ class ROSLaunchParent(object):
         @throws RLException
         @param master_logger_level: Specify roscore's rosmaster.master logger level, use default if it is False.
         @type master_logger_level: str or False
+        @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        @type sigint_timeout: int
+        @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+        @type sigterm_timeout: int
         """
-        
+
         self.logger = logging.getLogger('roslaunch.parent')
         self.run_id = run_id
         self.process_listeners = process_listeners
-        
+
         self.roslaunch_files = roslaunch_files
         self.roslaunch_strs = roslaunch_strs
         self.is_core = is_core
@@ -121,6 +126,8 @@ class ROSLaunchParent(object):
         self.num_workers = num_workers
         self.timeout = timeout
         self.master_logger_level = master_logger_level
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
 
         # I don't think we should have to pass in so many options from
         # the outside into the roslaunch parent. One possibility is to
@@ -161,7 +168,8 @@ class ROSLaunchParent(object):
             raise RLException("pm is not initialized")
         if self.server is None:
             raise RLException("server is not initialized")
-        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout, master_logger_level=self.master_logger_level)
+        self.runner = roslaunch.launch.ROSLaunchRunner(self.run_id, self.config, server_uri=self.server.uri, pmon=self.pm, is_core=self.is_core, remote_runner=self.remote_runner, is_rostest=self.is_rostest, num_workers=self.num_workers, timeout=self.timeout, master_logger_level=self.master_logger_level,
+                                                       sigint_timeout=self.sigint_timeout, sigterm_timeout=self.sigterm_timeout)
 
         # print runner info to user, put errors last to make the more visible
         if self.is_core:

--- a/tools/roslaunch/src/roslaunch/remote.py
+++ b/tools/roslaunch/src/roslaunch/remote.py
@@ -56,17 +56,23 @@ class ROSRemoteRunner(roslaunch.launch.ROSRemoteRunnerIF):
     Manages the running of remote roslaunch children
     """
     
-    def __init__(self, run_id, rosconfig, pm, server):
+    def __init__(self, run_id, rosconfig, pm, server, sigint_timeout=15, sigterm_timeout=2):
         """
         :param run_id: roslaunch run_id of this runner, ``str``
         :param config: launch configuration, ``ROSConfig``
         :param pm process monitor, ``ProcessMonitor``
         :param server: roslaunch parent server, ``ROSLaunchParentNode``
+        :param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        :type sigint_timeout: int
+        :param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+        :type sigterm_timeout: int
         """
         self.run_id = run_id
         self.rosconfig = rosconfig
         self.server = server
         self.pm = pm
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
         self.logger = logging.getLogger('roslaunch.remote')
         self.listeners = []
         

--- a/tools/roslaunch/src/roslaunch/remote.py
+++ b/tools/roslaunch/src/roslaunch/remote.py
@@ -96,7 +96,8 @@ class ROSRemoteRunner(roslaunch.launch.ROSRemoteRunnerIF):
         self.logger.info("remote[%s] starting roslaunch", name)
         printlog("remote[%s] starting roslaunch"%name)
             
-        p = SSHChildROSLaunchProcess(self.run_id, name, server_node_uri, machine, self.rosconfig.master.uri)
+        p = SSHChildROSLaunchProcess(self.run_id, name, server_node_uri, machine, self.rosconfig.master.uri,
+                                     sigint_timeout=self.sigint_timeout, sigterm_timeout=self.sigterm_timeout)
         success = p.start()
         self.pm.register(p)
         if not success: #treat as fatal

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -137,7 +137,8 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         """
         if not machine.env_loader:
             raise ValueError("machine.env_loader must have been assigned before creating ssh child instance")
-        args = [machine.env_loader, 'roslaunch', '-c', name, '-u', server_uri, '--run_id', run_id, '--sigint-timeout', sigint_timeout, '--sigterm-timeout', sigterm_timeout]
+        args = [machine.env_loader, 'roslaunch', '-c', name, '-u', server_uri, '--run_id', run_id,
+                '--sigint-timeout', str(sigint_timeout), '--sigterm-timeout', str(sigterm_timeout)]
         # env is always empty dict because we only use env_loader
         super(SSHChildROSLaunchProcess, self).__init__(name, args, {})
         self.machine = machine

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -126,18 +126,24 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
     """
     Process wrapper for launching and monitoring a child roslaunch process over SSH
     """
-    def __init__(self, run_id, name, server_uri, machine, master_uri=None):
+    def __init__(self, run_id, name, server_uri, machine, master_uri=None, sigint_timeout=15, sigterm_timeout=2):
         """
         :param machine: Machine instance. Must be fully configured.
             machine.env_loader is required to be set.
+        :param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        :type sigint_timeout: int
+        :param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+        :type sigterm_timeout: int
         """
         if not machine.env_loader:
             raise ValueError("machine.env_loader must have been assigned before creating ssh child instance")
-        args = [machine.env_loader, 'roslaunch', '-c', name, '-u', server_uri, '--run_id', run_id]
+        args = [machine.env_loader, 'roslaunch', '-c', name, '-u', server_uri, '--run_id', run_id, '--sigint-timeout', sigint_timeout, '--sigterm-timeout', sigterm_timeout]
         # env is always empty dict because we only use env_loader
         super(SSHChildROSLaunchProcess, self).__init__(name, args, {})
         self.machine = machine
         self.master_uri = master_uri
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
         self.ssh = self.sshin = self.sshout = self.ssherr = None
         self.started = False
         self.uri = None

--- a/tools/roslaunch/test/manual-test-remote-timeouts.sh
+++ b/tools/roslaunch/test/manual-test-remote-timeouts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+if [ $# -lt 5 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
+    echo "Usage: manual-test-remote-timeouts.sh sigint_timeout sigterm_timeout address env_loader user [roslaunch_timeout]"
+    echo "Run this script set up to connect to a remote machine (or your own one, if you have self-ssh enabled), and after a while, break the program with Ctrl-C."
+    echo "Observe, if SIGINT and SIGTERM are issued approximately after the time you have given in sigint_timeout and sigterm_timeout"
+    echo "Make sure the remote machine also has the same version of ros_comm as this one!"
+    exit 1
+fi
+
+sigint=$1
+sigterm=$2
+address=$3
+env_loader=$4
+user=$5
+if [ $# -gt 6 ]; then
+    timeout=$6
+else
+    timeout=10.0
+fi
+
+bold="\033[1m"
+normal="\033[0m"
+echo -e "${bold}A while after you see '... done launching nodes', break the program with Ctrl-C."
+echo -e "Observe, if SIGINT and SIGTERM are issued approximately after ${sigint} and ${sigterm} seconds"
+echo -e "Make sure the remote machine also has the same version of ros_comm as this one!${normal}"
+
+sleep 5
+
+"${THIS_DIR}/../scripts/roslaunch" --sigint-timeout ${sigint} --sigterm-timeout ${sigterm} \
+    "${THIS_DIR}/xml/manual-test-remote-timeouts.launch" \
+    address:=${address} env_loader:=${env_loader} user:=${user} timeout:=${timeout}

--- a/tools/roslaunch/test/signal_logger.py
+++ b/tools/roslaunch/test/signal_logger.py
@@ -22,4 +22,4 @@ signal.signal(signal.SIGINT, handler)
 signal.signal(signal.SIGTERM, handler)
 
 while True:
-    pass
+    time.sleep(10)

--- a/tools/roslaunch/test/signal_logger.py
+++ b/tools/roslaunch/test/signal_logger.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import os
+import signal
+import tempfile
+import time
+
+
+LOG_FILE = os.path.join(tempfile.gettempdir(), "signal.log")
+log_stream = open(LOG_FILE, 'w')
+
+
+def handler(signum, frame):
+    log_stream.write("%i %s\n" % (signum, str(time.time())))
+    log_stream.flush()
+
+    if signum == signal.SIGTERM:
+        log_stream.close()
+
+
+signal.signal(signal.SIGINT, handler)
+signal.signal(signal.SIGTERM, handler)
+
+while True:
+    pass

--- a/tools/roslaunch/test/xml/manual-test-remote-timeouts.launch
+++ b/tools/roslaunch/test/xml/manual-test-remote-timeouts.launch
@@ -1,0 +1,14 @@
+<launch>
+
+    <!-- To be used with roslaunch/test/manual-test-remote-timeouts.sh -->
+
+    <arg name="address" />
+    <arg name="env_loader" />
+    <arg name="user" />
+    <arg name="timeout" default="10.0" />
+
+    <machine name="remote" address="$(arg address)" user="$(arg user)" env-loader="$(arg env_loader)" timeout="$(arg timeout)" />
+
+    <node name="signal_logger" pkg="roslaunch" type="signal_logger.py" machine="remote" output="screen" />
+
+</launch>


### PR DESCRIPTION
Fixes #1493 by adding roslaunch CLI options `--sigint-timeout` and `--sigterm-timeout`. The timeouts are common to all nodes launched by this command. It would be possible to customize them per-node, but that would require changing the XML tags, and I'm not sure if it'd be useful at all.

It needed an unexpectedly big change to the codebase, but mainly it was just adding and passing keyword arguments of methods, so the API should be backwards compatible (every added kw argument has a default value).

I added unit tests for the local nodes, however, I haven't figured out any other way of testing this than really launching and stopping nodes, so the newly added tests need about 20 seconds to run... I hope it's not a big problem...

I also haven't figured out how to do automatic testing of the remote launch, but it seems that it's not tested at all. So I at least added a script you can run manually in case you have a second machine set up for remote launching. This test passed on my machine.

Theoretically, it should work also on Windows, but I haven't tested that.