### PR TITLE
[roswtf] Better msg replacement for 'No package or stack in context'.

### DIFF
--- a/utilities/roswtf/src/roswtf/__init__.py
+++ b/utilities/roswtf/src/roswtf/__init__.py
@@ -162,7 +162,7 @@ def _roswtf_main():
             print("Stack:", curr_stack)
             ctx = WtfContext.from_stack(curr_stack)
         else:
-            print("No package or stack in context")
+            print("No package or stack in the current directory")
             ctx = WtfContext.from_env()
         if options.all_packages:
             print("roswtf will run against all packages")


### PR DESCRIPTION
When there's no ROS pkg is found on the current directory when `roswtf` is run, a message `No package or stack in context` appears. This message is not useful IMO because what "context" means is unclear and is not something clearly explained anywhere in ROS documents.

This PR suggests clearer message.

**How to reproduce the behavior**
```
$ cd ~
$ roswtf
:
No package or stack in context
:

$ rosversion roswtf
1.12.14
```