### PR TITLE
Fix memory error due to missing rosout_disable_topics_generation para…

### DIFF
--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -107,10 +107,7 @@ void ROSOutAppender::log(::ros::console::Level level, const char* str, const cha
   
   // check parameter server/cache for omit_topics flag
   // the same parameter is checked in rosout.py for the same purpose
-  if (!ros::param::getCached("/rosout_disable_topics_generation", disable_topics_))
-  {
-    disable_topics_ = false;
-  }
+  ros::param::getCached("/rosout_disable_topics_generation", disable_topics_);
 
   if (!disable_topics_){
     this_node::getAdvertisedTopics(msg->topics);

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -106,7 +106,8 @@ void ROSOutAppender::log(::ros::console::Level level, const char* str, const cha
   
   // check parameter server/cache for omit_topics flag
   // the same parameter is checked in rosout.py for the same purpose
-  ros::param::getCached("/rosout_disable_topics_generation", disable_topics_);
+  if (!ros::param::getCached("/rosout_disable_topics_generation", disable_topics_))
+      disable_topics_ = false;
 
   if (!disable_topics_){
     this_node::getAdvertisedTopics(msg->topics);

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -47,6 +47,7 @@ namespace ros
 
 ROSOutAppender::ROSOutAppender()
 : shutting_down_(false)
+, disable_topics_(false)
 , publish_thread_(boost::bind(&ROSOutAppender::logThread, this))
 {
   AdvertiseOptions ops;
@@ -107,7 +108,9 @@ void ROSOutAppender::log(::ros::console::Level level, const char* str, const cha
   // check parameter server/cache for omit_topics flag
   // the same parameter is checked in rosout.py for the same purpose
   if (!ros::param::getCached("/rosout_disable_topics_generation", disable_topics_))
-      disable_topics_ = false;
+  {
+    disable_topics_ = false;
+  }
 
   if (!disable_topics_){
     this_node::getAdvertisedTopics(msg->topics);


### PR DESCRIPTION
Getting the parameter `rosout_disable_topics_generation` was not secured by a default value and thus could cause a memory error if it is not set (cf. [https://lists.debian.org/debian-science/2018/09/msg00046.html](https://lists.debian.org/debian-science/2018/09/msg00046.html).