### PR TITLE
roslaunch: add command to not override params already defined

### DIFF
--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -291,7 +291,7 @@ class ROSLaunchConfig(object):
         """
         self.clear_params.append(param)
 
-    def add_param(self, p, filename=None, verbose=True):
+    def add_param(self, p, filename=None, verbose=True, override_params=True):
         """
         Declare a parameter to be set on the param server before launching nodes
         @param p: parameter instance
@@ -305,6 +305,8 @@ class ROSLaunchConfig(object):
                 self.logger.debug("[%s] overriding parameter [%s]"%(filename, p.key))
             else:
                 self.logger.debug("overriding parameter [%s]"%p.key)
+            if not override_params:
+                return
         # check for parent conflicts
         for parent_key in [pk for pk in namespaces_of(key) if pk in self.params]:
             self.add_config_error("parameter [%s] conflicts with parent parameter [%s]"%(key, parent_key))

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -175,7 +175,7 @@ class LoaderContext(object):
         # when this context was created via include, was pass_all_args set?
         self.pass_all_args = False
 
-    def add_param(self, p):
+    def add_param(self, p, override_params=True):
         """
         Add a ~param to the context. ~params are evaluated by any node
         declarations that occur later in the same context.

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -78,7 +78,7 @@ class RosLaunchMock(object):
     def add_executable(self, t):
         self.executables.append(t)        
 
-    def add_param(self, p, filename=None, verbose=True):
+    def add_param(self, p, filename=None, verbose=True, override_params=True):
         matches = [x for x in self.params if x.key == p.key]
         for m in matches:
             self.params.remove(m)


### PR DESCRIPTION
Allow to decide if we want to override already defined params with new value or not (in launch file).
```<rosparam command="load_no_override" file="xxx" />```