### PR TITLE
Add "param" substitution in tags

### DIFF
--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -306,11 +306,11 @@ def _param(resolved, a, args, context):
         raise SubstitutionException("$(param var) must specify a variable name [%s]"%(a))
     elif len(args) > 1:
         raise SubstitutionException("$(param var) may only specify one arg [%s]"%(a))
-    
+
     resolve_arg = '/'+args[0]
     for param in context['param']:
         if param.key==resolve_arg:
-            return resolved.replace("$(%s)" % a, str(param.value.value)) # +2 for equals sign
+            return resolved.replace("$(%s)" % a, str(param.value)) # +2 for equals sign
 
 # Create a dictionary of global symbols that will be available in the eval
 # context.  We disable all the builtins, then add back True and False, and also
@@ -411,7 +411,7 @@ def resolve_args(arg_str, context=None, resolve_anon=True, filename=None):
     return resolved
 
 def _resolve_args(arg_str, context, resolve_anon, commands):
-    valid = ['find', 'env', 'optenv', 'dirname', 'anon', 'arg','param']
+    valid = ['find', 'env', 'optenv', 'dirname', 'anon', 'arg', 'param']
     resolved = arg_str
     for a in _collect_args(arg_str):
         splits = [s for s in a.split(' ') if s]

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -259,7 +259,8 @@ class XmlLoader(loader.Loader):
     def _rosparam_tag(self, tag, context, ros_config, verbose=True):
         try:
             self._check_attrs(tag, context, ros_config, XmlLoader.ROSPARAM_OPT_ATTRS)
-            cmd, ns, file, param, subst_value = self.opt_attrs(tag, context, (XmlLoader.ROSPARAM_OPT_ATTRS))
+            opt_attrs_fn = lambda ctx: self.opt_attrs(tag, ctx, (XmlLoader.ROSPARAM_OPT_ATTRS))
+            cmd, ns, file, param, subst_value = self._exec_fn_with_tmp_ctx(context, ros_config, opt_attrs_fn)
             subst_value = _bool_attr(subst_value, False, 'subst_value')
             # ns atribute is a bit out-moded and is only left in for backwards compatibility
             param = ns_join(ns or '', param or '')
@@ -270,7 +271,7 @@ class XmlLoader(loader.Loader):
             subst_function = None
             if subst_value:
                 subst_function = lambda x: self.resolve_args(x, context)
-            load_rosparam_fn = lambda x: self.load_rosparam(x, ros_config, cmd, param, file, value, verbose=verbose,
+            load_rosparam_fn = lambda ctx: self.load_rosparam(ctx, ros_config, cmd, param, file, value, verbose=verbose,
                 subst_function=subst_function)
             self._exec_fn_with_tmp_ctx(context, ros_config, load_rosparam_fn)
 

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -303,9 +303,14 @@ class XmlLoader(loader.Loader):
             params_restore_point = copy.deepcopy(context.params)
             resolve_dict_restore_point = copy.deepcopy(context.resolve_dict)
             # Use context to emulate get_param functionality in substitution_args
-            for key,v in ros_config.params.items():
-                p = Param(key,v)
-                context.add_param(p)
+            if ros_config.params:
+                if type(ros_config.params) is list:
+                    for p in ros_config.params:
+                        context.add_param(p)
+                else: # implies map
+                    for key,v in ros_config.params.items():
+                        p = Param(key,v)
+                        context.add_param(p)
             value, default, doc = self.opt_attrs(tag, context, ('value', 'default', 'doc'))
             context.params = copy.deepcopy(params_restore_point)
             context.resolve_dict = copy.deepcopy(resolve_dict_restore_point)

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -290,8 +290,8 @@ class XmlLoader(loader.Loader):
 
             # compute name and value
             ptype = (tag.getAttribute('type') or 'auto').lower().strip()
-            
-            vals = self.opt_attrs(tag, context, ('value', 'textfile', 'binfile', 'command'))
+            opt_attrs_fn = lambda ctx: self.opt_attrs(tag, ctx, ('value', 'textfile', 'binfile', 'command'))
+            vals = self._exec_fn_with_tmp_ctx(context, ros_config, opt_attrs_fn)
             if len([v for v in vals if v is not None]) != 1:
                 raise XmlParseException(
                     "<param> tag must have one and only one of value/textfile/binfile.")

--- a/tools/roslaunch/test/params_load_subst.yaml
+++ b/tools/roslaunch/test/params_load_subst.yaml
@@ -1,0 +1,1 @@
+param_subst_test_for_tags: bar

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -224,6 +224,8 @@ class TestXmlLoader(unittest.TestCase):
             p = [p for p in mock.params if p.key == '/commandoutput'][0]
             self.assertEquals(contents, p.value, 1)
         
+        p = [p for p in mock.params if p.key == '/param_from_param'][0]
+        self.assertEquals("a base param can be extended", p.value)
         
     def test_rosparam_valid(self):
         mock = self._load(os.path.join(self.xml_dir, 'test-rosparam-valid.xml'))

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -954,7 +954,12 @@ class TestXmlLoader(unittest.TestCase):
         self.assertEquals(param_d['/include3/include_test/p2_test'], 'optional3')
         self.assertEquals(param_d['/include3/include_test/p3_test'], 'set')
         self.assertEquals(param_d['/include3/include_test/p4_test'], 'new3')
-        
+
+        self.assertEquals(param_d['/arg_fetched_from_param'], True)
+        self.assertEquals(param_d['/arg_fetched_from_param2'], True)
+
+        self.assertEquals(param_d['/composite_param'], 'do_not_go_gentle_into_that_good_night')
+
     # Test the new attribute <include pass_all_args={"true"|"false"}>
     def test_arg_all(self):
         loader = roslaunch.xmlloader.XmlLoader()

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -322,7 +322,13 @@ class TestXmlLoader(unittest.TestCase):
         self.assertAlmostEquals(p.value, math.pi)
         p = [p for p in mock.params if p.key == '/dict_rad/rad2pi'][0]
         self.assertAlmostEquals(p.value, 2 * math.pi)
-                    
+
+        p = [p for p in mock.params if p.key == '/get_from_launch_param'][0]
+        self.assertAlmostEquals(3.7231, p.value)
+
+        p = [p for p in mock.params if p.key == '/param_subst_test_for_tags'][0]
+        self.assertEquals('bar', p.value)
+
         # rosparam file also contains empty params
         mock = self._load(os.path.join(self.xml_dir, 'test-rosparam-empty.xml'))
         self.assertEquals([], mock.params)

--- a/tools/roslaunch/test/xml/test-arg-include.xml
+++ b/tools/roslaunch/test/xml/test-arg-include.xml
@@ -23,4 +23,5 @@
     <param name="$(arg param4_name)_test" value="$(arg include_arg)" />
   </group>
 
+  <param name="param_for_other_include" value="p5"/>
 </launch>

--- a/tools/roslaunch/test/xml/test-arg.xml
+++ b/tools/roslaunch/test/xml/test-arg.xml
@@ -94,5 +94,20 @@
     <arg name="optional" value="optional3" />
     <arg name="include_arg" value="new3" />
   </include>
-  
+
+  <param name="use_for_arg" value="test_param_arg_subst"/>
+  <arg name="from_param" value="$(param use_for_arg)"/>
+  <param name="arg_fetched_from_param" value="true" if="$(eval arg('from_param') == 'test_param_arg_subst')"/>
+  <param name="arg_fetched_from_param" value="false" unless="$(eval arg('from_param') == 'test_param_arg_subst')"/>
+
+  <arg name="from_other_launch_param" value="$(param param_for_other_include)"/>
+  <param name="arg_fetched_from_param2" value="true" if="$(eval arg('from_other_launch_param') == 'p5')"/>
+  <param name="arg_fetched_from_param2" value="false" unless="$(eval arg('from_other_launch_param') == 'p5')"/>
+
+  <param name="first_part" value="do_not"/>
+  <param name="second_part" value="go_gentle"/>
+  <param name="third_part" value="into_that"/>
+  <param name="fourth_part" value="good_night"/>
+  <arg name="from_multiple_params" value="$(param first_part)_$(param second_part)_$(param third_part)_$(param fourth_part)"/>
+  <param name="composite_param" value="$(arg from_multiple_params)"/>
 </launch>

--- a/tools/roslaunch/test/xml/test-params-valid.xml
+++ b/tools/roslaunch/test/xml/test-params-valid.xml
@@ -45,5 +45,8 @@
   <!-- test that we can override params -->
   <param name="override" value="fail" />
   <param name="override" value="pass" />
+
+  <param name="base_param" value="a base param"/>
+  <param name="param_from_param" value="$(param base_param) can be extended"/>
   
 </launch>

--- a/tools/roslaunch/test/xml/test-rosparam-valid.xml
+++ b/tools/roslaunch/test/xml/test-rosparam-valid.xml
@@ -61,6 +61,13 @@
   <rosparam file="$(find roslaunch)/test/params_empty2.yaml" command="load" />
   <rosparam command="load"/>
 
+  <param name="for_rosparam" value="3.7231" type="double"/>
+  <rosparam param="get_from_launch_param" subst_value="True">$(param for_rosparam)</rosparam>
+
+  <param name="file_from_param" value="params_load_subst"/>
+  <rosparam file="$(find roslaunch)/test/$(param file_from_param).yaml" subst_value="True"/>
+
+
 
 </launch>
 


### PR DESCRIPTION
This PR implements the functionality proposed in #723. I only tested with `double`, `int` and `string` types. Actually, it converts any specified parameter of YAML into string to conform to the native behavior in `roslaunch`. It might require additional testing for different use cases.