### PR TITLE
rospy: added get_param_cached

### DIFF
--- a/clients/rospy/src/rospy/__init__.py
+++ b/clients/rospy/src/rospy/__init__.py
@@ -51,7 +51,7 @@ from .client import spin, myargv, init_node, \
     wait_for_message, \
     get_master, \
     on_shutdown, \
-    get_param, get_param_names, set_param, delete_param, has_param, search_param,\
+    get_param, get_param_cached, get_param_names, set_param, delete_param, has_param, search_param,\
     DEBUG, INFO, WARN, ERROR, FATAL
 from .timer import sleep, Rate, Timer
 from .core import is_shutdown, signal_shutdown, \
@@ -85,6 +85,7 @@ __all__ = [
     'wait_for_service',
     'on_shutdown',
     'get_param',
+    'get_param_cached',
     'get_param_names',
     'set_param',
     'delete_param',

--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -469,6 +469,29 @@ def get_param(param_name, default=_unspecified):
         else:
             raise
 
+
+def get_param_cached(param_name, default=_unspecified):
+    """
+    Retrieve a parameter from the param server with local caching
+
+    NOTE: this method is thread-safe.
+
+    @param default: (optional) default value to return if key is not set
+    @type  default: any
+    @return: parameter value
+    @rtype: XmlRpcLegalValue
+    @raise ROSException: if parameter server reports an error
+    @raise KeyError: if value not set and default is not given
+    """
+    try:
+        _init_param_server()
+        return _param_server.get_param_cached(param_name)
+    except KeyError:
+        if default != _unspecified:
+            return default
+        else:
+            raise
+
 def get_param_names():
     """
     Retrieve list of parameter names.

--- a/clients/rospy/src/rospy/impl/paramserver.py
+++ b/clients/rospy/src/rospy/impl/paramserver.py
@@ -36,7 +36,6 @@
 import threading
 from rosgraph.names import GLOBALNS, SEP
 
-
 class ParamServerCache(object):
     """
     Cache of values on the parameter server. Implementation
@@ -120,7 +119,7 @@ class ParamServerCache(object):
                 d[value_key] = value
             if self.notifier is not None:
                 self.notifier(key, value)
-
+                
     def set(self, key, value):
         """
         Set the value of the parameter in the cache. This is a

--- a/clients/rospy/src/rospy/impl/paramserver.py
+++ b/clients/rospy/src/rospy/impl/paramserver.py
@@ -173,6 +173,8 @@ class ParamServerCache(object):
                     if not type(val) == dict:
                         raise KeyError(val)
                     val = val[ns]
+            if isinstance(val, dict) and not val:
+                raise KeyError(key)
             return val
 
 _param_server_cache = None

--- a/clients/rospy/src/rospy/impl/paramserver.py
+++ b/clients/rospy/src/rospy/impl/paramserver.py
@@ -35,7 +35,6 @@
 
 import threading
 from rosgraph.names import GLOBALNS, SEP
-from rospy.names import resolve_name
 
 class ParamServerCache(object):
     """
@@ -137,7 +136,9 @@ class ParamServerCache(object):
                 # - last namespace is the actual key we're storing in
                 value_key = namespaces[-1]
                 namespaces = namespaces[:-1]
-                d = self.d or {}
+                if self.d is None:
+                    self.d = {}
+                d = self.d
                 # - descend tree to the node we're setting
                 for ns in namespaces:
                     if ns not in d:
@@ -162,13 +163,12 @@ class ParamServerCache(object):
         """
         with self.lock:
             # borrowed from rosmaster/paramserver.py
-            resolved_key = resolve_name(key)
             if self.d is None:
                 raise KeyError(key)
             val = self.d
-            if resolved_key != GLOBALNS:
+            if key != GLOBALNS:
                 # split by the namespace separator, ignoring empty splits
-                namespaces = [x for x in resolved_key.split(SEP) if x]
+                namespaces = [x for x in key.split(SEP) if x]
                 for ns in namespaces:
                     if not type(val) == dict:
                         raise KeyError(val)

--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -165,6 +165,8 @@ class MasterProxy(object):
                 raise KeyError(key)
             # set the value in the cache so that it's marked as subscribed
             rospy.impl.paramserver.get_param_server_cache().set(resolved_key, value)
+            if isinstance(value, dict) and not value:
+                raise KeyError(key)
             return value
         
     def __delitem__(self, key):

--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -164,7 +164,8 @@ class MasterProxy(object):
             return rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
         except KeyError:
             # first access, make call to parameter server
-            code, msg, value = self.target.subscribeParam(rospy.names.get_caller_id(), rospy.core.get_node_uri(), resolved_key)
+            with self._lock:
+                code, msg, value = self.target.subscribeParam(rospy.names.get_caller_id(), rospy.core.get_node_uri(), resolved_key)
             if code != 1: #unwrap value with Python semantics
                 raise KeyError(key)
             # set the value in the cache so that it's marked as subscribed

--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -117,6 +117,10 @@ class MasterProxy(object):
         #NOTE: remapping occurs here!
         resolved_key = rospy.names.resolve_name(key)
         with self._lock:
+            try:
+                return rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
+            except KeyError:
+                pass
             code, msg, value = self.target.getParam(rospy.names.get_caller_id(), resolved_key)
         if code != 1: #unwrap value with Python semantics
             raise KeyError(key)

--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -116,25 +116,11 @@ class MasterProxy(object):
         """
         #NOTE: remapping occurs here!
         resolved_key = rospy.names.resolve_name(key)
-        if 1: # disable param cache
-            with self._lock:
-                code, msg, value = self.target.getParam(rospy.names.get_caller_id(), resolved_key)
-            if code != 1: #unwrap value with Python semantics
-                raise KeyError(key)
-            return value
-
-        try:
-            # check for value in the parameter server cache
-            return rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
-        except KeyError:
-            # first access, make call to parameter server
-            with self._lock:
-                code, msg, value = self.target.subscribeParam(rospy.names.get_caller_id(), rospy.core.get_node_uri(), resolved_key)
-            if code != 1: #unwrap value with Python semantics
-                raise KeyError(key)
-            # set the value in the cache so that it's marked as subscribed
-            rospy.impl.paramserver.get_param_server_cache().set(resolved_key, value)
-            return value
+        with self._lock:
+            code, msg, value = self.target.getParam(rospy.names.get_caller_id(), resolved_key)
+        if code != 1: #unwrap value with Python semantics
+            raise KeyError(key)
+        return value
         
     def __setitem__(self, key, val):
         """
@@ -166,6 +152,20 @@ class MasterProxy(object):
             return None
         else:
             raise rospy.exceptions.ROSException("cannot search for parameter: %s"%msg)
+
+    def get_param_cached(self, key):
+        resolved_key = rospy.names.resolve_name(key)
+        try:
+            # check for value in the parameter server cache
+            return rospy.impl.paramserver.get_param_server_cache().get(resolved_key)
+        except KeyError:
+            # first access, make call to parameter server
+            code, msg, value = self.target.subscribeParam(rospy.names.get_caller_id(), rospy.core.get_node_uri(), resolved_key)
+            if code != 1: #unwrap value with Python semantics
+                raise KeyError(key)
+            # set the value in the cache so that it's marked as subscribed
+            rospy.impl.paramserver.get_param_server_cache().set(resolved_key, value)
+            return value
         
     def __delitem__(self, key):
         """
@@ -180,9 +180,6 @@ class MasterProxy(object):
             raise KeyError(key)
         elif code != 1:
             raise rospy.exceptions.ROSException("cannot delete parameter: %s"%msg)
-        elif 0: #disable parameter cache
-            # set the value in the cache so that it's marked as subscribed
-            rospy.impl.paramserver.get_param_server_cache().delete(resolved_key)
 
     def __contains__(self, key):
         """


### PR DESCRIPTION
rospy had an incomplete version of a local parameter cache in the code base. The code was never called due to https://github.com/ros/ros_comm/blob/melodic-devel/clients/rospy/src/rospy/msproxy.py#L119 .

I borrowed some of the code in rosmaster and added the rospy toplevel function `get_param_cached` (in accordance to `roscpp::getParamCached`). It was surprisingly easy since the subscribeParam functionality was already there.