### PR TITLE
rosnode: Explicitly handle socket.timeout in rosnode ping

### DIFF
--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -361,7 +361,7 @@ def rosnode_ping(node_name, max_count=None, verbose=False):
                             continue
                         print("ERROR: connection refused to [%s]"%(node_api), file=sys.stderr)
                     else:
-                        print("connection to [%s] timed out"%node_name, file=sys.stderr)
+                        print("connection to [%s] failed"%node_name, file=sys.stderr)
                     return False
                 except ValueError:
                     print("unknown network error contacting node: %s"%(str(e)))

--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -336,6 +336,9 @@ def rosnode_ping(node_name, max_count=None, verbose=False):
                 if verbose:
                     print("xmlrpc reply from %s\ttime=%fms"%(node_api, dur))
                 # 1s between pings
+            except socket.timeout:
+                print("connection to [%s] timed out"%node_name, file=sys.stderr)
+                return False
             except socket.error as e:
                 # 3786: catch ValueError on unpack as socket.error is not always a tuple
                 try:


### PR DESCRIPTION
This pull request is in response to #1516. There are some cases where rosnode ping would take over 30 seconds to scan all the nodes due to ValueError happening when trying to unpack socket.error. 

This pull request adds handling of socket.timeout explicitly.

Please let me know if there is anything else you would like me to change.