### PR TITLE
clear message queue on simtime jumping back

### DIFF
--- a/utilities/message_filters/test/test_approxsync.py
+++ b/utilities/message_filters/test/test_approxsync.py
@@ -63,6 +63,7 @@ class TestApproxSync(unittest.TestCase):
         self.collector.append((msg1, msg2))
 
     def test_approx(self):
+        rospy.rostime.set_rostime_initialized(True)
         m0 = MockFilter()
         m1 = MockFilter()
         ts = ApproximateTimeSynchronizer([m0, m1], 1, 0.1)


### PR DESCRIPTION
With this pull request, message_filters queue is cleared when rosbag is played with `--loop` option enabled in order to prevent to synchronize with messages published in early loops.
The current implementation in this PR may not be in an efficient way so any feedback is very welcome.