### PR TITLE
Fix #889 : Exclude unused args check if pass_all_args is set

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -632,8 +632,9 @@ class XmlLoader(loader.Loader):
                 self._recurse_load(ros_config, launch.childNodes, child_ns, \
                                        default_machine, is_core, verbose)
 
-            # check for unused args
-            loader.post_process_include_args(child_ns)
+            if not pass_all_args:
+                # check for unused args
+                loader.post_process_include_args(child_ns)
 
         except ArgException as e:
             raise XmlParseException("included file [%s] requires the '%s' arg to be set"%(inc_filename, str(e)))

--- a/tools/roslaunch/test/xml/test-arg-valid-include.xml
+++ b/tools/roslaunch/test/xml/test-arg-valid-include.xml
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="another_parameter_not_used" value="dummy"/>
   <arg name="grounded" value="not_set"/>
   <include file="$(find roslaunch)/test/xml/test-arg-invalid-included.xml" pass_all_args="true"/>
 </launch>


### PR DESCRIPTION
This follows #889.

The dummy argument added to the test launch file should be fine to verify that there will be no exception even if there is an extra unused argument.