### PR TITLE
roslaunch: add an option in XmlLoader to only load arg tags

### DIFF
--- a/tools/roslaunch/src/roslaunch/arg_dump.py
+++ b/tools/roslaunch/src/roslaunch/arg_dump.py
@@ -45,7 +45,7 @@ from roslaunch.core import RLException
 from roslaunch.config import load_config_default
 
 def get_args(roslaunch_files):
-    loader = roslaunch.xmlloader.XmlLoader(resolve_anon=False)
+    loader = roslaunch.xmlloader.XmlLoader(resolve_anon=False, args_only=True)
     config = load_config_default(roslaunch_files, None, loader=loader, verbose=False, assign_machines=False)
     return loader.root_context.resolve_dict.get('arg_doc', {})
 

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -165,15 +165,18 @@ class XmlLoader(loader.Loader):
     Parser for roslaunch XML format. Loads parsed representation into ROSConfig model.
     """
 
-    def __init__(self, resolve_anon=True):
+    def __init__(self, resolve_anon=True, args_only=False):
         """
         @param resolve_anon: If True (default), will resolve $(anon foo). If
         false, will leave these args as-is.
         @type  resolve_anon: bool
+        @param args_only: if True, will only load arg tags (e.g. autocompletion purposes)
+        @type  args_only: bool
         """        
         # store the root XmlContext so that outside code can access it
         self.root_context = None
         self.resolve_anon = resolve_anon
+        self.args_only = args_only
 
     def resolve_args(self, args, context):
         """
@@ -651,7 +654,12 @@ class XmlLoader(loader.Loader):
         """
         for tag in [t for t in tags if t.nodeType == DomNode.ELEMENT_NODE]:
             name = tag.tagName
-            if name == 'group':
+            if name == 'arg':
+                self._arg_tag(tag, context, ros_config, verbose=verbose)
+            elif self.args_only:
+                # do not load other tags
+                pass
+            elif name == 'group':
                 if ifunless_test(self, tag, context):
                     self._check_attrs(tag, context, ros_config, XmlLoader.GROUP_ATTRS)
                     child_ns = self._ns_clear_params_attr(name, tag, context, ros_config)
@@ -693,8 +701,6 @@ class XmlLoader(loader.Loader):
                     default_machine = val
             elif name == 'env':
                 self._env_tag(tag, context, ros_config)
-            elif name == 'arg':
-                self._arg_tag(tag, context, ros_config, verbose=verbose)
             else:
                 ros_config.add_config_error("unrecognized tag "+tag.tagName)
         return default_machine


### PR DESCRIPTION
This fixes #1300. It's off/false by default, but it's used by `arg_dump` to stop `roslaunch-complete` from failing if any arg has no default value.