### PR TITLE
Add new option to publish when a bag write begin

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -55,6 +55,7 @@
 #include <ros/time.h>
 
 #include <std_msgs/Empty.h>
+#include <std_msgs/String.h>
 #include <topic_tools/shape_shifter.h>
 
 #include "rosbag/bag.h"
@@ -96,6 +97,7 @@ struct ROSBAG_DECL RecorderOptions
     bool            append_date;
     bool            snapshot;
     bool            verbose;
+    bool            publish;
     CompressionType compression;
     std::string     prefix;
     std::string     name;
@@ -186,6 +188,8 @@ private:
     boost::mutex                  check_disk_mutex_;
     ros::WallTime                 check_disk_next_;
     ros::WallTime                 warn_next_;
+
+    ros::Publisher                pub_begin_write;
 };
 
 } // namespace rosbag

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -53,6 +53,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("regex,e", "match topics using regular expressions")
       ("exclude,x", po::value<std::string>(), "exclude topics matching regular expressions")
       ("quiet,q", "suppress console output")
+      ("publish,p", "Publish a msg when the record begin")
       ("output-prefix,o", po::value<std::string>(), "prepend PREFIX to beginning of bag name")
       ("output-name,O", po::value<std::string>(), "record bagnamed NAME.bag")
       ("buffsize,b", po::value<int>()->default_value(256), "Use an internal buffer of SIZE MB (Default: 256)")
@@ -103,6 +104,8 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     }
     if (vm.count("quiet"))
       opts.quiet = true;
+    if (vm.count("publish"))
+      opts.publish = true;
     if (vm.count("output-prefix"))
     {
       opts.prefix = vm["output-prefix"].as<std::string>();

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -405,7 +405,7 @@ void Recorder::startWriting() {
     {
         std_msgs::String msg;
         msg.data = target_filename_.c_str();
-        pub.publish(msg);
+        pub_begin_write.publish(msg);
     }
 }
 

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -99,6 +99,7 @@ RecorderOptions::RecorderOptions() :
     append_date(true),
     snapshot(false),
     verbose(false),
+    publish(false),
     compression(compression::Uncompressed),
     prefix(""),
     name(""),
@@ -151,6 +152,11 @@ int Recorder::run() {
     ros::NodeHandle nh;
     if (!nh.ok())
         return 0;
+
+    if (options_.publish)
+    {
+        pub_begin_write = nh.advertise<std_msgs::String>("begin_write", 1, true);
+    }
 
     last_buffer_warn_ = Time();
     queue_ = new std::queue<OutgoingMessage>;
@@ -394,6 +400,13 @@ void Recorder::startWriting() {
         ros::shutdown();
     }
     ROS_INFO("Recording to %s.", target_filename_.c_str());
+    
+    if (options_.publish)
+    {
+        std_msgs::String msg;
+        msg.data = target_filename_.c_str();
+        pub.publish(msg);
+    }
 }
 
 void Recorder::stopWriting() {


### PR DESCRIPTION
I use the split mode of the bag recorder to save multiples hours bags.  And I need to know when the rosbag record node begin to write a new bag, because I want to publish some topics just at the begin.

I don't wan't to publish in continuous topics to be sure it is in bags.
I did the PR in the kinetic branch because in my project i use it and i can't change.

Note: I've seen the build didn't pass, I'll fix it.