### PR TITLE
[C++14] remove explicit -std=c++11, default to 14

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(roscpp)
 
 if(NOT WIN32)
-  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11;-Wall;-Wextra")
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Wextra")
 endif()
 
 find_package(catkin REQUIRED COMPONENTS

--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -8,7 +8,6 @@ if(TARGET test_base64)
   target_link_libraries(test_base64 xmlrpcpp)
 endif()
 
-set_target_properties(test_base64 PROPERTIES COMPILE_FLAGS -std=c++11)
 if(WIN32)
   # On Windows, gtest can be built as shared (dll) or static (lib),
   # to simplify the problem, here we require to match BUILD_SHARED_LIBS we used


### PR DESCRIPTION
From REP-0003
> Melodic
> As of ROS Melodic, we are using the C++14 (ISO/IEC 14882:2014) standard.

Related to discussion on ros-planning/moveit#1146