### PR TITLE
Add a new option to publish when a bag write begin

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -55,6 +55,7 @@
 #include <ros/time.h>
 
 #include <std_msgs/Empty.h>
+#include <std_msgs/String.h>
 #include <topic_tools/shape_shifter.h>
 
 #include "rosbag/bag.h"
@@ -96,6 +97,7 @@ struct ROSBAG_DECL RecorderOptions
     bool            append_date;
     bool            snapshot;
     bool            verbose;
+    bool            publish;
     CompressionType compression;
     std::string     prefix;
     std::string     name;
@@ -186,6 +188,8 @@ private:
     boost::mutex                  check_disk_mutex_;
     ros::WallTime                 check_disk_next_;
     ros::WallTime                 warn_next_;
+
+    ros::Publisher                pub_begin_write;
 };
 
 } // namespace rosbag

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -53,6 +53,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("regex,e", "match topics using regular expressions")
       ("exclude,x", po::value<std::string>(), "exclude topics matching regular expressions")
       ("quiet,q", "suppress console output")
+      ("publish,p", "Publish a msg when the record begin")
       ("output-prefix,o", po::value<std::string>(), "prepend PREFIX to beginning of bag name")
       ("output-name,O", po::value<std::string>(), "record bagnamed NAME.bag")
       ("buffsize,b", po::value<int>()->default_value(256), "Use an internal buffer of SIZE MB (Default: 256)")
@@ -103,6 +104,8 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     }
     if (vm.count("quiet"))
       opts.quiet = true;
+    if (vm.count("publish"))
+      opts.publish = true;
     if (vm.count("output-prefix"))
     {
       opts.prefix = vm["output-prefix"].as<std::string>();

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -99,6 +99,7 @@ RecorderOptions::RecorderOptions() :
     append_date(true),
     snapshot(false),
     verbose(false),
+    publish(false),
     compression(compression::Uncompressed),
     prefix(""),
     name(""),
@@ -151,6 +152,11 @@ int Recorder::run() {
     ros::NodeHandle nh;
     if (!nh.ok())
         return 0;
+
+    if (options_.publish)
+    {
+        pub_begin_write = nh.advertise<std_msgs::String>("begin_write", 1, true);
+    }
 
     last_buffer_warn_ = Time();
     queue_ = new std::queue<OutgoingMessage>;
@@ -392,6 +398,13 @@ void Recorder::startWriting() {
         ros::shutdown();
     }
     ROS_INFO("Recording to %s.", target_filename_.c_str());
+
+    if (options_.publish)
+    {
+        std_msgs::String msg;
+        msg.data = target_filename_.c_str();
+        pub_begin_write.publish(msg);
+    }
 }
 
 void Recorder::stopWriting() {

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -79,6 +79,7 @@ def record_cmd(argv):
 
     parser.add_option("-a", "--all",           dest="all",           default=False, action="store_true",          help="record all topics")
     parser.add_option("-e", "--regex",         dest="regex",         default=False, action="store_true",          help="match topics using regular expressions")
+    parser.add_option("-p", "--publish",       dest="publish",       default=False, action="store_true",          help="publish a msg when the record begin")
     parser.add_option("-x", "--exclude",       dest="exclude_regex", default="",    action="store",               help="exclude topics matching the follow regular expression (subtracts from -a or regex)")
     parser.add_option("-q", "--quiet",         dest="quiet",         default=False, action="store_true",          help="suppress console output")
     parser.add_option("-o", "--output-prefix", dest="prefix",        default=None,  action="store",               help="prepend PREFIX to beginning of bag name (name will always end with date stamp)")
@@ -119,6 +120,7 @@ def record_cmd(argv):
     if options.exclude_regex: cmd.extend(["--exclude", options.exclude_regex])
     if options.all:           cmd.extend(["--all"])
     if options.regex:         cmd.extend(["--regex"])
+    if options.publish:       cmd.extend(["--publish"])
     if options.compression:   cmd.extend(["--%s" % options.compression])
     if options.split:
         if not options.duration and not options.size:


### PR DESCRIPTION
I use the split mode of the bag recorder to save multiples hours bags. And I need to know when the rosbag record node begin to write a new bag, because I want to publish some topics just at the begin.

I don't wan't to publish in continuous topics to be sure it is in bags.
I did the PR in the kinetic branch because in my project i use it and i can't change.

This pull request is linked to the #1522 pull request. This is the same changes but done on melodic instead of kinetic.