### PR TITLE
Fix template syntax bug

### DIFF
--- a/utilities/message_filters/include/message_filters/synchronizer.h
+++ b/utilities/message_filters/include/message_filters/synchronizer.h
@@ -355,7 +355,7 @@ private:
   template<int i>
   void cb(const typename mpl::at_c<Events, i>::type& evt)
   {
-    this->add<i>(evt);
+    this->template add<i>(evt);
   }
 
   uint32_t queue_size_;


### PR DESCRIPTION
This patch is a continuation of PR #1388 and issue #1383. The previous PR missed an occurance of `this->add<i>(evt);`. This PR aims to complete the fix,