### PR TITLE
Add timestamp formatting for rosconsole

### DIFF
--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -47,6 +47,7 @@ os.environ['ROSCONSOLE_FORMAT'] = ' '.join([
     '${severity}',
     '${message}',
     '${walltime}',
+    '${walltime:%Y-%m-%d %H:%M:%S}',
     '${thread}',
     '${logger}',
     '${file}',
@@ -54,6 +55,7 @@ os.environ['ROSCONSOLE_FORMAT'] = ' '.join([
     '${function}',
     '${node}',
     '${time}',
+    '${time:%Y-%m-%d %H:%M:%S}',
 ])
 rosgraph.roslogging.configure_logging('test_rosgraph', logging.INFO)
 loginfo = logging.getLogger('rosout').info
@@ -111,6 +113,7 @@ try:
                 'INFO',
                 'on ' + loc,
                 r'[0-9]*\.[0-9]*',
+                r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
                 '[0-9]*',
                 'rosout',
                 re.escape(this_file),
@@ -119,6 +122,7 @@ try:
                 # depending if rospy.get_name() is available
                 '(/unnamed|<unknown_node_name>)',
                 r'[0-9]*\.[0-9]*',
+                r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
             ])
             assert_regexp_matches(lout.getvalue().splitlines()[i], log_out)
 

--- a/tools/rosgraph/test/test_roslogging_user_logger.py
+++ b/tools/rosgraph/test/test_roslogging_user_logger.py
@@ -86,6 +86,7 @@ def test_roslogging_user_logger():
         '${severity}',
         '${message}',
         '${walltime}',
+        '${walltime:%Y-%m-%d %H:%M:%S}',
         '${thread}',
         '${logger}',
         '${file}',
@@ -93,6 +94,7 @@ def test_roslogging_user_logger():
         '${function}',
         '${node}',
         '${time}',
+        '${time:%Y-%m-%d %H:%M:%S}',
     ])
     rosgraph.roslogging.configure_logging('test_rosgraph', logging.INFO)
     loginfo = logging.getLogger('rosout.custom_logger_test').info
@@ -128,6 +130,7 @@ def test_roslogging_user_logger():
             os.environ['ROS_IP'],
             msg,
             r'[0-9]*\.[0-9]*',
+            r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
             '[0-9]*',
             'rosout.custom_logger_test',
             '<filename>',
@@ -136,6 +139,7 @@ def test_roslogging_user_logger():
             # depending if rospy.get_name() is available
             '(/unnamed|<unknown_node_name>)',
             r'[0-9]*\.[0-9]*',
+            r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
         ])
         assert_regexp_matches(lout.getvalue().strip(), log_expected)
 


### PR DESCRIPTION
It's Python part of formatter based on https://github.com/ros/ros_comm/pull/1458 and related to the https://github.com/ros/rosconsole/pull/22 for Cpp version.