### PR TITLE
roscpp: Add const specifier to NodeHandle::param(param_name, default_val)

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -2150,7 +2150,7 @@ if (service)  // Enter if advertised service is valid
    * or is an otherwise invalid graph resource name.
    */
   template<typename T>
-  T param(const std::string& param_name, const T& default_val)
+  T param(const std::string& param_name, const T& default_val) const
   {
       T param_val;
       param(param_name, param_val, default_val);


### PR DESCRIPTION
Otherwise the compiler will not allow the following:
```cpp
void foo(const ros::NodeHandle& nh) {
  const bool val = nh.param("bool_param", false);
}
```