### PR TITLE
roslaunch/xmlloader: use continue instead of pass for args_only

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -659,7 +659,7 @@ class XmlLoader(loader.Loader):
                 self._arg_tag(tag, context, ros_config, verbose=verbose)
             elif self.args_only:
                 # do not load other tags
-                pass
+                continue
             elif name == 'group':
                 if ifunless_test(self, tag, context):
                     self._check_attrs(tag, context, ros_config, XmlLoader.GROUP_ATTRS)


### PR DESCRIPTION
As discussed in #1521, it works either way.

However, using `continue` is slightly more appropriate in this current situation.