### PR TITLE
roscpp: Multiple latched publishers per process on the same topic (fix #146)

### DIFF
--- a/clients/roscpp/include/ros/forwards.h
+++ b/clients/roscpp/include/ros/forwards.h
@@ -118,6 +118,7 @@ struct SubscriberCallbacks
   }
   SubscriberStatusCallback connect_;
   SubscriberStatusCallback disconnect_;
+  boost::function<void(const SubscriberLinkPtr&)> push_latched_message_;
 
   bool has_tracked_object_;
   VoidConstWPtr tracked_object_;

--- a/clients/roscpp/include/ros/publication.h
+++ b/clients/roscpp/include/ros/publication.h
@@ -178,7 +178,6 @@ private:
 
   bool latch_;
   bool has_header_;
-  SerializedMessage last_message_;
 
   uint32_t intraprocess_subscriber_count_;
 

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -304,9 +304,14 @@ Publisher NodeHandle::advertise(AdvertiseOptions& ops)
   SubscriberCallbacksPtr callbacks(boost::make_shared<SubscriberCallbacks>(ops.connect_cb, ops.disconnect_cb, 
                                                                            ops.tracked_object, ops.callback_queue));
 
+  Publisher pub(ops.topic, ops.md5sum, ops.datatype, ops.latch, *this, callbacks);
+
+  if (ops.latch) {
+    callbacks->push_latched_message_ = pub.getLastMessageCallback();
+  }
+
   if (TopicManager::instance()->advertise(ops, callbacks))
   {
-    Publisher pub(ops.topic, ops.md5sum, ops.datatype, *this, callbacks);
 
     {
       boost::mutex::scoped_lock lock(collection_->mutex_);

--- a/clients/roscpp/src/libros/publication.cpp
+++ b/clients/roscpp/src/libros/publication.cpp
@@ -185,11 +185,6 @@ bool Publication::enqueueMessage(const SerializedMessage& m)
     sub_link->enqueueMessage(m, true, false);
   }
 
-  if (latch_)
-  {
-    last_message_ = m;
-  }
-
   return true;
 }
 
@@ -209,11 +204,6 @@ void Publication::addSubscriberLink(const SubscriberLinkPtr& sub_link)
     {
       ++intraprocess_subscriber_count_;
     }
-  }
-
-  if (latch_ && last_message_.buf)
-  {
-    sub_link->enqueueMessage(last_message_, true, true);
   }
 
   // This call invokes the subscribe callback if there is one.
@@ -331,6 +321,10 @@ void Publication::peerConnect(const SubscriberLinkPtr& sub_link)
   for (; it != end; ++it)
   {
     const SubscriberCallbacksPtr& cbs = *it;
+    if (cbs->push_latched_message_)
+    {
+      cbs->push_latched_message_(sub_link);
+    }
     if (cbs->connect_ && cbs->callback_queue_)
     {
       CallbackInterfacePtr cb(boost::make_shared<PeerConnDisconnCallback>(cbs->connect_, sub_link, cbs->has_tracked_object_, cbs->tracked_object_));

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -346,6 +346,13 @@ bool TopicManager::advertise(const AdvertiseOptions& ops, const SubscriberCallba
         return false;
       }
 
+      if (pub->isLatched() != ops.latch)
+      {
+        ROS_ERROR("Tried to advertise on topic [%s] with latch=%d but the topic is already advertised with latch=%d",
+                  ops.topic.c_str(), ops.latch, pub->isLatched());
+        return false;
+      }
+
       pub->addCallbacks(callbacks);
 
       return true;

--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -151,5 +151,8 @@ add_rostest(launch/search_param.xml)
 add_rostest(launch/stamped_topic_statistics_with_empty_timestamp.xml)
 add_rostest(launch/topic_statistic_frequency.xml DEPENDENCIES ${PROJECT_NAME}-publisher_rate ${PROJECT_NAME}-subscriber ${PROJECT_NAME}-topic_statistic_frequency)
 
+# Test multiple latched publishers within the same process
+add_rostest(launch/multiple_latched_publishers.xml)
+
 # Test spinners
 add_rostest(launch/spinners.xml)

--- a/test/test_roscpp/test/launch/multiple_latched_publishers.xml
+++ b/test/test_roscpp/test/launch/multiple_latched_publishers.xml
@@ -1,0 +1,4 @@
+<launch>
+  <test test-name="multiple_latched_publishers" pkg="test_roscpp" type="test_roscpp-multiple_latched_publishers"/>
+</launch>
+

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -208,6 +208,11 @@ target_link_libraries(${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp $
 add_executable(${PROJECT_NAME}-topic_statistic_frequency EXCLUDE_FROM_ALL topic_statistic_frequency.cpp)
 target_link_libraries(${PROJECT_NAME}-topic_statistic_frequency ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 
+add_executable(${PROJECT_NAME}-multiple_latched_publishers EXCLUDE_FROM_ALL multiple_latched_publishers.cpp)
+target_link_libraries(${PROJECT_NAME}-multiple_latched_publishers ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+add_dependencies(${PROJECT_NAME}-multiple_latched_publishers ${std_msgs_EXPORTED_TARGETS})
+set_property(TARGET ${PROJECT_NAME}-multiple_latched_publishers PROPERTY CXX_STANDARD 11)
+
 # The publishers and subscriber are compiled but not registered as a unit test
 # since the test execution requires a network connection which drops packages.
 # Call scripts/test_udp_with_dropped_packets.sh to run the test.
@@ -289,6 +294,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-subscriber
     ${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp
     ${PROJECT_NAME}-topic_statistic_frequency
+    ${PROJECT_NAME}-multiple_latched_publishers
   )
 endif()
 
@@ -355,3 +361,4 @@ add_dependencies(${PROJECT_NAME}-string_msg_expect ${${PROJECT_NAME}_EXPORTED_TA
 add_dependencies(${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp
  ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-topic_statistic_frequency ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}-multiple_latched_publishers ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -211,7 +211,6 @@ target_link_libraries(${PROJECT_NAME}-topic_statistic_frequency ${GTEST_LIBRARIE
 add_executable(${PROJECT_NAME}-multiple_latched_publishers EXCLUDE_FROM_ALL multiple_latched_publishers.cpp)
 target_link_libraries(${PROJECT_NAME}-multiple_latched_publishers ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME}-multiple_latched_publishers ${std_msgs_EXPORTED_TARGETS})
-set_property(TARGET ${PROJECT_NAME}-multiple_latched_publishers PROPERTY CXX_STANDARD 11)
 
 # The publishers and subscriber are compiled but not registered as a unit test
 # since the test execution requires a network connection which drops packages.

--- a/test/test_roscpp/test/src/multiple_latched_publishers.cpp
+++ b/test/test_roscpp/test/src/multiple_latched_publishers.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018, Intermodalics BVBA.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Author: Hans-Joachim Krauch */
+
+/*
+ * Verify that every latched publisher sends its last published message to
+ * a newly connected subscriber.
+ */
+
+#include <chrono>
+#include <future>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "ros/ros.h"
+#include <std_msgs/builtin_bool.h>
+
+
+TEST(MultipleLatchedPublishers, PublisherIncompatibleAdvertise)
+{
+  {
+    ros::NodeHandle nh;
+    auto pub1 = nh.advertise<bool>("foo", 10, true);
+    auto pub2 = nh.advertise<bool>("foo", 10, false);
+    EXPECT_TRUE(pub1);
+    EXPECT_FALSE(pub2);
+  }
+  {
+    ros::NodeHandle nh;
+    auto pub1 = nh.advertise<bool>("foo", 10, false);
+    auto pub2 = nh.advertise<bool>("foo", 10, true);
+    EXPECT_TRUE(pub1);
+    EXPECT_FALSE(pub2);
+  }
+  {
+    ros::NodeHandle nh;
+    auto pub1 = nh.advertise<bool>("foo", 10, true);
+    auto pub2 = nh.advertise<bool>("foo", 10, true);
+    EXPECT_TRUE(pub1);
+    EXPECT_TRUE(pub2);
+  }
+  {
+    ros::NodeHandle nh;
+    auto pub1 = nh.advertise<bool>("foo", 10, false);
+    auto pub2 = nh.advertise<bool>("foo", 10, false);
+    EXPECT_TRUE(pub1);
+    EXPECT_TRUE(pub2);
+  }
+}
+
+TEST(MultipleLatchedPublishers, LatchedPublisherReceiveMultiple)
+{
+  ros::NodeHandle nh;
+  std::vector<ros::Publisher> latched_publishers = {
+    nh.advertise<bool>("foo", 10, true),
+    nh.advertise<bool>("foo", 10, true),
+    nh.advertise<bool>("foo", 10, true),
+  };
+
+  for (auto& pub : latched_publishers) {
+    pub.publish(true);
+  }
+
+  std::size_t msg_count = 0;
+  std::promise<bool> received_promise;
+  auto received_future = received_promise.get_future();
+
+  const auto sub = nh.subscribe<std_msgs::Bool>("foo", 10, [&](const std_msgs::Bool::ConstPtr&) {
+    if (++msg_count == latched_publishers.size()) {
+      received_promise.set_value(true);
+    }
+  });
+
+  ASSERT_EQ(std::future_status::ready, received_future.wait_for(std::chrono::seconds(1)));
+  const auto received = received_future.get();
+  EXPECT_TRUE(received);
+  EXPECT_EQ(latched_publishers.size(), msg_count);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_multiple_latched_publishers");
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
At the moment roscpp (and probably most other client libraries) does not support multiple latched publishers on the same topic within a single process, because the latched message is stored in the Publication singleton instead of in individual publishers (#146) and each publication of another publisher invalidates the previous latched message. This situation is unfortunate because in many cases it is hard to control which components in a single process do publish latched topics and how they are deployed, e.g. for Gazebo or move_base plugins.

My colleague @achim-k and I have been working on a patch for `roscpp` that enables multiple latched subscribers in a single process, following my proposal in https://github.com/ros/ros_comm/issues/146#issuecomment-433454967. The solution is similar to what @mgrrx has [done for Python](https://github.com/ros/ros_comm/issues/146#issuecomment-433969222).

~~While this patch does solve the issue for online publishing and our current needs, I do not see a good general solution for `rosbag` yet. It would be possible to instantiate one patched `Publisher` per connection during the replay, such that latched topics from different original publishers would mimic the recorded situation correctly during the replay.~~ `rosbag` already creates one internal publisher per topic and callerid. So with this patch in `roscpp` latched publications of *different* nodes will be replayed correctly (see also https://github.com/ros/ros_comm/pull/1537). But without modifications to the ROS protocol there is no way to tell which *internal* publisher instance of a node published which message if there is more than one, which would be required to replay messages as seen during the recording and to know which message invalidates which message seen earlier on the same topic.

For the special case of replaying `tf_static` it might be an option to collect static transforms while iterating over the bag file and each time publish a new [TFMessage](http://docs.ros.org/api/tf2_msgs/html/msg/TFMessage.html) message that contains all found transformations so far.

Unfortunately the patch is not ABI compatible and also changes the behavior significantly, so it can not be merged in `melodic-devel` or even backported to `kinetic`.