### PR TITLE
Avoid calling memcpy on NULL pointer with size 0.

### DIFF
--- a/utilities/xmlrpcpp/test/test_socket.cpp
+++ b/utilities/xmlrpcpp/test/test_socket.cpp
@@ -721,7 +721,8 @@ int test_getsockname(int sockfd, struct sockaddr* addr, socklen_t* addrlen) {
   EXPECT_LE(getsockname_len, *addrlen);
   if (NULL != addr) {
     socklen_t len = std::min(*addrlen, getsockname_len);
-    memcpy(addr, getsockname_addr, len);
+    if (len > 0)
+      memcpy(addr, getsockname_addr, len);
   }
   EXPECT_TRUE(NULL != addrlen);
   if (NULL != addrlen) {


### PR DESCRIPTION
This fixes a warning with undefined behavior sanitizer (UBSAN). UBSAN is a compiler tool to check for code that is undefined according to the C standard and can be activated with -fsanitize=undefined.

The problem here is that this code is sometimes called with a NULL pointer of size 0. It's not allowed to call memcpy with a NULL pointer, even if the buffer has a size of zero. Avoid it by not calling memcpy if len is zero.

Stack trace and warning from UBSAN:
```
/var/tmp/portage/dev-ros/xmlrpcpp-1.14.3/work/ros_comm-1.14.3/utilities/xmlrpcpp/test/test_socket.cpp:726:13: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x555b1d591ade in test_getsockname(int, sockaddr*, unsigned int*) /var/tmp/portage/dev-ros/xmlrpcpp-1.14.3/work/ros_comm-1.14.3/utilities/xmlrpcpp/test/test_socket.cpp:726
    #1 0x555b1d612a10 in XmlRpc::XmlRpcSocket::get_port(int) /var/tmp/portage/dev-ros/xmlrpcpp-1.14.3/work/ros_comm-1.14.3/utilities/xmlrpcpp/src/XmlRpcSocket.cpp:386
    #2 0x555b1d59233d in XmlRpcSocketTest_get_port_Test::TestBody() /var/tmp/portage/dev-ros/xmlrpcpp-1.14.3/work/ros_comm-1.14.3/utilities/xmlrpcpp/test/test_socket.cpp:775
    #3 0x7f6f8bc145d9 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (//usr/lib64/libgtest.so+0x3f5d9)
    #4 0x7f6f8bc0a289 in testing::Test::Run() (//usr/lib64/libgtest.so+0x35289)
    #5 0x7f6f8bc0a3e7 in testing::TestInfo::Run() (//usr/lib64/libgtest.so+0x353e7)
    #6 0x7f6f8bc0a4b4 in testing::TestCase::Run() (//usr/lib64/libgtest.so+0x354b4)
    #7 0x7f6f8bc0a997 in testing::internal::UnitTestImpl::RunAllTests() (//usr/lib64/libgtest.so+0x35997)
    #8 0x7f6f8bc14a99 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (//usr/lib64/libgtest.so+0x3fa99)
    #9 0x7f6f8bc0aaec in testing::UnitTest::Run() (//usr/lib64/libgtest.so+0x35aec)
    #10 0x555b1d578bfa in RUN_ALL_TESTS() /usr/include/gtest/gtest.h:2233
    #11 0x555b1d578bfa in main /var/tmp/portage/dev-ros/xmlrpcpp-1.14.3/work/ros_comm-1.14.3/utilities/xmlrpcpp/test/test_socket.cpp:1392
    #12 0x7f6f8a4f6ae6 in __libc_start_main (/lib64/libc.so.6+0x21ae6)
    #13 0x555b1d57e359 in _start (/var/tmp/portage/dev-ros/xmlrpcpp-1.14.3/work/xmlrpcpp-1.14.3_build/devel/libexec/xmlrpcpp/test_socket+0x9d359)
