### PR TITLE
Fix invalid zero index

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -497,8 +497,11 @@ namespace XmlRpc {
     xml.resize(xml.size() + base64EncodedSize(_value.asBinary->size()));
 
     base64::encoder encoder;
-    offset += encoder.encode(&(*_value.asBinary)[0], _value.asBinary->size(), &xml[offset]);
-    offset += encoder.encode_end(&xml[offset]);
+    if (_value.asBinary->size() > 0)
+    {
+      offset += encoder.encode(&(*_value.asBinary)[0], _value.asBinary->size(), &xml[offset]);
+      offset += encoder.encode_end(&xml[offset]);
+    }
     xml.resize(offset);
 
     xml += BASE64_ETAG;
@@ -613,7 +616,8 @@ namespace XmlRpc {
       case TypeBase64:
         {
           std::stringstream buffer;
-          buffer.write(&(*_value.asBinary)[0], _value.asBinary->size());
+          if (_value.asBinary->size() > 0)
+            buffer.write(&(*_value.asBinary)[0], _value.asBinary->size());
           base64::encoder encoder;
           encoder.encode(buffer, os);
           break;

--- a/utilities/xmlrpcpp/test/test_base64.cpp
+++ b/utilities/xmlrpcpp/test/test_base64.cpp
@@ -61,7 +61,9 @@ TEST_P(Base64Test, Decode) {
   out.resize(encoded_size);
 
   base64::decoder decoder;
-  const int size = decoder.decode(in.c_str(), encoded_size, &out[0]);
+  int size = 0;
+  if (encoded_size > 0)
+    size = decoder.decode(in.c_str(), encoded_size, &out[0]);
   ASSERT_LE(0, size);
   out.resize(size);
 
@@ -127,7 +129,9 @@ TEST_P(Base64ErrorTest, DecodeErrors) {
   out.resize(encoded_size);
 
   base64::decoder decoder;
-  const int size = decoder.decode(in.c_str(), encoded_size, &out[0]);
+  int size = 0;
+  if (encoded_size > 0)
+    size = decoder.decode(in.c_str(), encoded_size, &out[0]);
   // Assert that size is greater or equal to 0, to make sure that the follow-up
   // resize will always succeed.
   ASSERT_LE(0, size);


### PR DESCRIPTION
At various places the code uses &variable[0] to reference the start of a vector buffer. However in case the vector is of size zero this is invalid, because there is no index [0] in a zero-sized vector.

This avoids 4 such cases, separated in two commits, one for XmlRpcValue.cpp and one for test_base64.cpp.

Together with #1546 this makes the test suite run without warnings from UBSAN.