### PR TITLE
Add PR template (SQWG trial)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Thanks for submitting a Pull Request!
+
+Please shortly explain your contribution, and if fixing an issue from the tracker, please add a link to the issue.
+
+Be sure to go over each item in the list below before submitting your pull request.
+-->
+
+### Description
+
+Add your description here
+
+
+### Checklist
+
+- [ ] If you are changing ros_comm, then please include details on how it's functionality was *before* and *after* your change
+- [ ] Did you change how ros_comm works? Added new functionality? Do not forget to update the tutorials and/or documentation on the [ROS wiki](http://wiki.ros.org/ros_comm)
+- [ ] If needed, please include (updated) tests with your PR
+- [ ] While waiting for someone to review your request, please consider reviewing [another open pull request](https://github.com/ros/ros_comm/pulls) to support the maintainers of ros_comm. Refer to the [ROS code review guide](https://github.com/rosin-project/ros_code_review_guide/blob/master/README.md) for general reviewing guidelines.


### PR DESCRIPTION
This is basically a modified copy of https://github.com/ros-visualization/rviz/pull/1312.

Adds a PR template (inspired by the one from MoveIt) with the express request to review other outstanding PRs.

It points to the general review guidelines as being prototyped over at [rosin-project/ros_code_review_guide.](https://github.com/rosin-project/ros_code_review_guide)

This is part of the trial started by the members of the software quality working group trying to get more people involved in maintainership and increase community participation in these processes.