### PR TITLE
Make sigterm handling python3 compatible.

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -605,7 +605,7 @@ def signal_shutdown(reason):
 def _ros_signal(sig, stackframe):
     signal_shutdown("signal-"+str(sig))
     prev_handler = _signalChain.get(sig, None)
-    if prev_handler is not None and not type(prev_handler) == int:
+    if callable(prev_handler):
         try:
             prev_handler(sig, stackframe)
         except KeyboardInterrupt:


### PR DESCRIPTION
SIGTERM handling on python3 results in the following error:

```
Traceback (most recent call last):
  File "test.py", line 3, in <module>
    rospy.spin()
  File "/opt/ros/lunar/lib/python3.7/site-packages/rospy/client.py", line 129, in spin
    rospy.rostime.wallsleep(0.5)
  File "/opt/ros/lunar/lib/python3.7/site-packages/rospy/rostime.py", line 277, in wallsleep
    time.sleep(duration) 
  File "/opt/ros/lunar/lib/python3.7/site-packages/rospy/core.py", line 565, in _ros_signal
    prev_handler(sig, stackframe)
TypeError: 'Handlers' object is not callable
```

That is because the following has changed from python2:
```
>>> import signal
>>> signal.SIG_DFL
0
```

to python3:
```
>>> import signal
>>> signal.SIG_DFL
<Handlers.SIG_DFL: 0>
```

Where `Handlers` is an enum.

This PR changes the check to specifically check if the previous handler is callable, since that is basically all we are interested in, in that part of the code.