### PR TITLE
topic_tools: Improvements to relay_field

### DIFF
--- a/tools/topic_tools/scripts/relay_field
+++ b/tools/topic_tools/scripts/relay_field
@@ -32,6 +32,27 @@ import std_msgs
 __author__ = 'www.kentaro.wada@gmail.com (Kentaro Wada)'
 
 
+def _eval_in_str_impl(str_, globals_, locals_):
+    type_ = type(str_)
+    if (type_ is str or type_ is unicode) and 'm.' in str_:
+        try:
+            evaluated = eval(str_, globals_, locals_)
+        except NameError or SyntaxError as e:
+            rospy.logerr(e)
+            return str_
+
+        if isinstance(evaluated, genpy.Time):
+            res = {
+                'secs': evaluated.secs,
+                'nsecs': evaluated.nsecs,
+            }
+        else:
+            res = yaml.load(str(evaluated))
+        return res
+    else:
+        return str_
+
+
 def _eval_in_dict_impl(dict_, globals_, locals_):
     res = copy.deepcopy(dict_)
     for k, v in res.items():
@@ -39,12 +60,9 @@ def _eval_in_dict_impl(dict_, globals_, locals_):
         if type_ is dict:
             res[k] = _eval_in_dict_impl(v, globals_, locals_)
         elif (type_ is str) or (type_ is unicode):
-            try:
-                res[k] = eval(v, globals_, locals_)
-            except NameError:
-                pass
-            except SyntaxError:
-                pass
+            res[k] = _eval_in_str_impl(v, globals_, locals_)
+        else:
+            res[k] = v
     return res
 
 

--- a/tools/topic_tools/scripts/relay_field
+++ b/tools/topic_tools/scripts/relay_field
@@ -117,7 +117,10 @@ class RelayField(object):
             m = self.input_fn(m)
 
         msg_generation = yaml.load(self.expression)
-        pub_args = _eval_in_dict_impl(msg_generation, None, {'m': m})
+        if type(msg_generation) is dict:
+            pub_args = _eval_in_dict_impl(msg_generation, None, {'m': m})
+        else:
+            pub_args = _eval_in_str_impl(msg_generation, None, {'m': m})
 
         now = rospy.get_rostime()
         keys = {'now': now, 'auto': std_msgs.msg.Header(stamp=now)}


### PR DESCRIPTION
Several improvements are made to the `relay_field` script in `topic_tools` as described as follows:

## 1: Fix `ValueError` when `m.header.stamp` is used

```
rosrun topic_tools relay_field /imu/data /only_header std_msgs/Header \
'stamp: m.header.stamp
seq: m.header.seq
frame_id: imu'
```

This results in:

```
ValueError: invalid msg_args type: 1544172626663751871
```

because `genpy.Time` represents itself as an integer and not in a
dictionary form which we want (i.e. `{'secs': 42, 'nsecs', 42}`)

## 2: Fix error when built-in function name is used for string

```
rosrun topic_tools relay_field /imu/data /only_header std_msgs/Header \
'stamp: now
seq: m.header.seq
frame_id: map'
```

This results in:

```
ROSSerializationException: field frame_id must be of type str
```

because `map` is a built-in function name.

## 3: Fix bug where further expansion of field values is not performed

```
rosrun topic_tools relay_field /imu/data /imu_orientation geometry_msgs/QuaternionStamped \
'header: auto
quaternion: m.orientation'
```

This results in:

```
ValueError: invalid msg_args type: x: -0.03408677876
y: -0.0217779036611
z: 0.936430633068
w: -0.348513394594
```

because evaluating m.orientation results in a YAML string, which is not
further processed.

## 4. Allow specifying just one field to relay

For example, if we have a sensor_msgs/Imu and we only want to relay the
`orientation` field, we can do:

```
rosrun topic_tools relay_field /imu/data /imu_orientation geometry_msgs/Quaternion \
'm.orientation'
```