### PR TITLE
Add hasStarted() const to WallTimer and SteadyTimer API

### DIFF
--- a/clients/roscpp/include/ros/steady_timer.h
+++ b/clients/roscpp/include/ros/steady_timer.h
@@ -67,9 +67,11 @@ public:
 
   /**
    * \brief Set the period of this timer
+   * \param reset Whether to reset the timer. If true, timer ignores elapsed time and next cb occurs at now()+period
    */
   void setPeriod(const WallDuration& period, bool reset=true);
 
+  bool hasStarted() const { return impl_->hasStarted(); }
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void *) 1 : (void *) 0; }
 
@@ -97,6 +99,7 @@ private:
     Impl();
     ~Impl();
 
+    bool hasStarted() const;
     bool isValid();
     bool hasPending();
     void setPeriod(const WallDuration &period, bool reset=true);

--- a/clients/roscpp/include/ros/steady_timer.h
+++ b/clients/roscpp/include/ros/steady_timer.h
@@ -71,7 +71,7 @@ public:
    */
   void setPeriod(const WallDuration& period, bool reset=true);
 
-  bool hasStarted() const { return impl_->hasStarted(); }
+  bool hasStarted() const { return impl_ && impl_->hasStarted(); }
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void *) 1 : (void *) 0; }
 

--- a/clients/roscpp/include/ros/wall_timer.h
+++ b/clients/roscpp/include/ros/wall_timer.h
@@ -71,6 +71,7 @@ public:
    */
   void setPeriod(const WallDuration& period, bool reset=true);
 
+  bool hasStarted() const { return impl_->hasStarted(); }
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void*)1 : (void*)0; }
 
@@ -98,6 +99,7 @@ private:
     Impl();
     ~Impl();
 
+    bool hasStarted() const;
     bool isValid();
     bool hasPending();
     void setPeriod(const WallDuration& period, bool reset=true);

--- a/clients/roscpp/include/ros/wall_timer.h
+++ b/clients/roscpp/include/ros/wall_timer.h
@@ -71,7 +71,7 @@ public:
    */
   void setPeriod(const WallDuration& period, bool reset=true);
 
-  bool hasStarted() const { return impl_->hasStarted(); }
+  bool hasStarted() const { return impl_ && impl_->hasStarted(); }
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void*)1 : (void*)0; }
 

--- a/clients/roscpp/src/libros/steady_timer.cpp
+++ b/clients/roscpp/src/libros/steady_timer.cpp
@@ -125,6 +125,11 @@ SteadyTimer::Impl::~Impl()
   stop();
 }
 
+bool SteadyTimer::Impl::hasStarted() const
+{
+  return started_;
+}
+
 void SteadyTimer::Impl::start()
 {
   if (!started_)

--- a/clients/roscpp/src/libros/wall_timer.cpp
+++ b/clients/roscpp/src/libros/wall_timer.cpp
@@ -42,6 +42,11 @@ WallTimer::Impl::~Impl()
   stop();
 }
 
+bool WallTimer::Impl::hasStarted() const
+{
+  return started_;
+}
+
 void WallTimer::Impl::start()
 {
   if (!started_)


### PR DESCRIPTION
Completes https://github.com/ros/ros_comm/pull/1464 (_Add hasStarted() const to Timer API_):
Also add `hasStarted()` method to `ros::WallTimer` and `ros::SteadyTimer`, such that the timer APIs are identical.

Whitespace changes are the result of merging [steady_timer.cpp](https://github.com/ros/ros_comm/blob/d0021d822f7b3d56ec488ef6fa45943c4fbc64c3/clients/roscpp/src/libros/steady_timer.cpp) with [timer.cpp](https://github.com/ros/ros_comm/blob/d0021d822f7b3d56ec488ef6fa45943c4fbc64c3/clients/roscpp/src/libros/timer.cpp) and [wall_timer.cpp](https://github.com/ros/ros_comm/blob/d0021d822f7b3d56ec488ef6fa45943c4fbc64c3/clients/roscpp/src/libros/wall_timer.cpp). In a future release it would be possible to define a template class `TimerBase<T,D,E>` and three `typedef`s for `Timer`, `WallTimer` and `SteadyTimer` to avoid code duplication.

The patch is fully ABI-compatible because it only adds two new non-virtual member functions.

Addresses https://github.com/ros/ros_comm/pull/1557#issuecomment-447349467:
> I guess it would actually make sense to create a separate PR for the added hasStarted methods...
They have nothing to do with the rest and can then more easily be reviewed/merged separately.

