### PR TITLE
Solved static linking problems against rosbag_storage

### DIFF
--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 find_package(console_bridge REQUIRED)
 find_package(catkin REQUIRED COMPONENTS cpp_common pluginlib roscpp_serialization roscpp_traits rostime roslz4)
 find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options regex)
-find_package(BZip2 REQUIRED)
+find_package(BZIP2 REQUIRED)
 
 catkin_package(
   CFG_EXTRAS rosbag_storage-extras.cmake

--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -16,7 +16,7 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES rosbag_storage
   CATKIN_DEPENDS pluginlib roslz4
-  DEPENDS console_bridge Boost
+  DEPENDS console_bridge Boost BZIP2
 )
 
 # Support large bags (>2GB) on 32-bit systems


### PR DESCRIPTION
BZip2 wasn't exported in rosbag_storage DEPENDS list, so static linking against it failed.
This solves the issue.