### PR TITLE
Added dependencies and Docker container alerts to manual test. Fixes #1567

### DIFF
--- a/test/test_roscpp/test/scripts/test_udp_with_dropped_packets.sh
+++ b/test/test_roscpp/test/scripts/test_udp_with_dropped_packets.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+for dep in sudo ifconfig iptables; do
+    if ! [ -x "$(command -v $dep)" ]; then
+        echo "Missing dependency $dep! please install and try again...";
+        exit 1;
+    fi
+done
+
+if [ -f /.dockerenv ]; then
+    echo "This file runs in a Docker container! make sure container was executed with --privileged flag";
+fi
+
 DROP_PROBABILITY=0.01
 IP=192.168.99.99
 


### PR DESCRIPTION
Avoid #1567 by checking all dependencies are installed and alert if not. also, added a check if script is running in docker container to make sure --privileged flag is used(required for iptables to work properly)...