### PR TITLE
fix compiler warnings about unused variables (backport to kinetic-devel)

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -604,8 +604,6 @@ void shutdown()
     XMLRPCManager::instance()->shutdown();
   }
 
-  WallTime end = WallTime::now();
-
   g_started = false;
   g_ok = false;
   Time::shutdown();

--- a/test/test_rosbag/test/test_bag.cpp.in
+++ b/test/test_rosbag/test/test_bag.cpp.in
@@ -376,6 +376,7 @@ TEST(rosbag, bad_topic_query_works) {
 
     rosbag::View view(bag, rosbag::TopicQuery(t));
     foreach(rosbag::MessageInstance const m, view) {
+      (void)m;
       FAIL();
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/ros/ros_comm/pull/1428 to fix PR builds that target `kinetic-devel`, in particular:
- https://github.com/ros/ros_comm/pull/1557 (http://build.ros.org/job/Kpr__ros_comm__ubuntu_xenial_amd64/461/)