### PR TITLE
Improves lunar-devel jenkins test stability (backport to kinetic-devel)

### DIFF
--- a/test/test_rosbag/bag_migration_tests/test/random_play.py
+++ b/test/test_rosbag/bag_migration_tests/test/random_play.py
@@ -152,7 +152,7 @@ class RandomPlay(unittest.TestCase):
             # these bounds are much larger than they ought to be, but
             # you never know with a heavily loaded system.
             self.assertTrue(input_time - expect_time > -.5)
-            self.assertTrue(abs(input_time - expect_time) < .5)
+            self.assertTrue(abs(input_time - expect_time) < 5.0)
             break
 
         if not msg_match:

--- a/test/test_rosbag/test/test_bag.py
+++ b/test/test_rosbag/test/test_bag.py
@@ -325,7 +325,7 @@ class TestRosbag(unittest.TestCase):
             # the value varies each run, I suspect based on rand, but seems
             # to generally be around 960 to 980 on my comp
             self.assertLess(info.compressed, 1000)
-            self.assertGreater(info.compressed, 900)
+            self.assertGreater(info.compressed, 880)
         
     def test_get_time(self):
         fn = '/tmp/test_get_time.bag'

--- a/test/test_rosbag/test/test_bag.py
+++ b/test/test_rosbag/test/test_bag.py
@@ -324,8 +324,8 @@ class TestRosbag(unittest.TestCase):
             
             # the value varies each run, I suspect based on rand, but seems
             # to generally be around 960 to 980 on my comp
-            self.assertLess(info.compressed, 1000)
-            self.assertGreater(info.compressed, 880)
+            self.assertLess(info.compressed, 1050)
+            self.assertGreater(info.compressed, 850)
         
     def test_get_time(self):
         fn = '/tmp/test_get_time.bag'

--- a/test/test_roscpp/test/test_callback_queue.cpp
+++ b/test/test_roscpp/test/test_callback_queue.cpp
@@ -439,9 +439,8 @@ void ConditionObject::add()
 {
   while(!condition_stop.load())
   {
-    if(condition_sync.load())
+    if(condition_sync.load() && queue->isEmpty())
     {
-      condition_sync.store(false);
       condition_one.store(true);
       id++;
       queue->addCallback(boost::make_shared<RaceConditionCallback>(this, &id), id);
@@ -458,6 +457,7 @@ TEST(CallbackQueue, raceConditionCallback)
   boost::thread t(boost::bind(&ConditionObject::add, &condition_object));
   for(unsigned int i = 0; i < 1000000; ++i)
   {
+    condition_object.condition_sync.store(false);
     if (queue.callOne() == CallbackQueue::Called)
     {
       if(condition_object.condition_one.load())


### PR DESCRIPTION
Backport of #1135 to `kinetic-devel`. Fixes flaky unit test `CallbackQueue.raceConditionCallback` on kinetic-devel (http://build.ros.org/job/Kpr__ros_comm__ubuntu_xenial_amd64/464/).

This patch has not been selected for backporting to kinetic in https://github.com/ros/ros_comm/pull/1205 for some reason, although it cleanly applies and only affects unit tests:

> - improves lunar-devel jenkins test stability #1135
>   - not backporting improvements