### PR TITLE
/topic_tools/mux: do not dereference the end-iterator

### DIFF
--- a/tools/topic_tools/src/mux.cpp
+++ b/tools/topic_tools/src/mux.cpp
@@ -168,7 +168,7 @@ void in_cb(const boost::shared_ptr<ShapeShifter const>& msg,
     }
   }
   
-  if (s != g_selected->msg)
+  if (g_selected == g_subs.end() || s != g_selected->msg)
     return;
   
   // If we're in lazy subscribe mode, and nobody's listening, then unsubscribe


### PR DESCRIPTION
This fixes a global-buffer-overflow reported by ASAN.