### PR TITLE
Remove signals from find_package(Boost COMPONENTS ...)

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -22,7 +22,7 @@ list(GET roscpp_VERSION_LIST 2 roscpp_VERSION_PATCH)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/ros/common.h.in ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros/common.h)
 
-find_package(Boost REQUIRED COMPONENTS chrono filesystem signals system)
+find_package(Boost REQUIRED COMPONENTS chrono filesystem system)
 
 include_directories(include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 

--- a/test/test_roscpp/CMakeLists.txt
+++ b/test/test_roscpp/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 if(CATKIN_ENABLE_TESTING)
-  find_package(Boost REQUIRED COMPONENTS signals filesystem system)
+  find_package(Boost REQUIRED COMPONENTS filesystem system)
 
   include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 

--- a/utilities/message_filters/CMakeLists.txt
+++ b/utilities/message_filters/CMakeLists.txt
@@ -13,7 +13,7 @@ catkin_package(
 )
 catkin_python_setup()
 
-find_package(Boost REQUIRED COMPONENTS signals thread)
+find_package(Boost REQUIRED COMPONENTS thread)
 
 include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 link_directories(${catkin_LIBRARY_DIRS})


### PR DESCRIPTION
The packages here use `signals2`, not `signals`. Only boost libraries with compiled code should be passed to find_package(Boost COMPONENTS ...), and the signals2 library has always been header only.

Boost 1.69 has removed the deprecated `signals` library, so the otherwise useless but harmless `signals` component now breaks the build.