### PR TITLE
Fix string error on windows

### DIFF
--- a/clients/roscpp/src/libros/names.cpp
+++ b/clients/roscpp/src/libros/names.cpp
@@ -107,7 +107,7 @@ std::string clean(const std::string& name)
     pos = clean.find("//", pos);
   }
 
-  if (*clean.rbegin() == '/')
+  if (!name.empty() && *clean.rbegin() == '/')
   {
     clean.erase(clean.size() - 1, 1);
   }


### PR DESCRIPTION
Check if name is empty before read it, or it will cause 'cannot decrement string iterator before begin' error on Windows in debug mode.