### PR TITLE
use resource _retriever if available

### DIFF
--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -45,6 +45,7 @@ import rospkg
 import rospkg.distro
 import rosgraph.names
 import rosgraph.network
+import resource_retriever
 
 from .core import Master, local_machine, is_machine_local, RLException
 import roslaunch.loader
@@ -448,6 +449,7 @@ def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None,
 
     # load the roslaunch_files into the config
     for f in roslaunch_files:
+        f = resource_retriever.get_filename(f, False)
         if isinstance(f, tuple):
             f, args = f
         else:

--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -45,7 +45,11 @@ import rospkg
 import rospkg.distro
 import rosgraph.names
 import rosgraph.network
-import resource_retriever
+resource_retriever = None
+try:
+    import resource_retriever
+except ImportError:
+    pass
 
 from .core import Master, local_machine, is_machine_local, RLException
 import roslaunch.loader
@@ -449,7 +453,8 @@ def load_config_default(roslaunch_files, port, roslaunch_strs=None, loader=None,
 
     # load the roslaunch_files into the config
     for f in roslaunch_files:
-        f = resource_retriever.get_filename(f, False)
+        if resource_retriever:
+            f = resource_retriever.get_filename(f, False)
         if isinstance(f, tuple):
             f, args = f
         else:

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -41,7 +41,12 @@ import os
 from copy import deepcopy
 
 import yaml
-import resource_retriever
+resource_retriever = None
+try:
+    import resource_retriever
+except ImportError:
+    pass
+
 from roslaunch.core import Param, RosbinExecutable, RLException, PHASE_SETUP
 
 from rosgraph.names import make_global_ns, ns_join, PRIV_NAME, load_mappings, is_legal_name, canonicalize_name
@@ -382,7 +387,8 @@ class Loader(object):
         @raise ValueError: if parameters cannot be processed into valid rosparam setting
         """
         if file_ is not None:
-            file_ = resource_retriever.get_filename(file_, False)
+            if resource_retriever:
+                file_ = resource_retriever.get_filename(file_, False)
 
         if not cmd in ('load', 'dump', 'delete'):
             raise ValueError("command must be 'load', 'dump', or 'delete'")

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -41,7 +41,7 @@ import os
 from copy import deepcopy
 
 import yaml
-
+import resource_retriever
 from roslaunch.core import Param, RosbinExecutable, RLException, PHASE_SETUP
 
 from rosgraph.names import make_global_ns, ns_join, PRIV_NAME, load_mappings, is_legal_name, canonicalize_name
@@ -381,6 +381,9 @@ class Loader(object):
         @type  text: str
         @raise ValueError: if parameters cannot be processed into valid rosparam setting
         """
+        if file_ is not None:
+            file_ = resource_retriever.get_filename(file_, False)
+
         if not cmd in ('load', 'dump', 'delete'):
             raise ValueError("command must be 'load', 'dump', or 'delete'")
         if file_ is not None:

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -42,7 +42,11 @@ import itertools
 import sys
 import traceback
 import logging
-import resource_retriever
+resource_retriever = None
+try:
+    import resource_retriever
+except ImportError:
+    pass
 
 from xml.dom.minidom import parse, parseString
 from xml.dom import Node as DomNode #avoid aliasing
@@ -725,7 +729,8 @@ class XmlLoader(loader.Loader):
         
     def _parse_launch(self, filename, verbose):
         try:
-            filename = resource_retriever.get_filename(filename, False)
+            if resource_retriever:
+                filename = resource_retriever.get_filename(filename, False)
             if verbose:            
                 print("... loading XML file [%s]"%filename)
             root = parse(filename).getElementsByTagName('launch')

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -42,6 +42,7 @@ import itertools
 import sys
 import traceback
 import logging
+import resource_retriever
 
 from xml.dom.minidom import parse, parseString
 from xml.dom import Node as DomNode #avoid aliasing
@@ -724,6 +725,7 @@ class XmlLoader(loader.Loader):
         
     def _parse_launch(self, filename, verbose):
         try:
+            filename = resource_retriever.get_filename(filename, False)
             if verbose:            
                 print("... loading XML file [%s]"%filename)
             root = parse(filename).getElementsByTagName('launch')


### PR DESCRIPTION
use `resource _retriever` in `roslaunch` if the module is available, so that `package://` can be used in launch files