### PR TITLE
update filename list in add_message_files

### DIFF
--- a/test/test_rosmaster/CMakeLists.txt
+++ b/test/test_rosmaster/CMakeLists.txt
@@ -5,21 +5,7 @@ project(test_rosmaster)
 find_package(catkin REQUIRED COMPONENTS genmsg rostest std_msgs)
 
 if(CATKIN_ENABLE_TESTING)
-  add_message_files(DIRECTORY msg
-    FILES
-    String.msg
-    Arrays.msg
-    CompositeA.msg CompositeB.msg Composite.msg
-    Embed.msg Floats.msg Simple.msg
-    RosmsgA.msg
-    RosmsgB.msg
-    RosmsgC.msg
-    TestArrays.msg
-    TestHeader.msg
-    TestPrimitives.msg
-    TestString.msg
-    TVals.msg
-  )
+  add_message_files(DIRECTORY msg)
   add_service_files(DIRECTORY srv
     FILES
     AddTwoInts.srv

--- a/test/test_rosmaster/CMakeLists.txt
+++ b/test/test_rosmaster/CMakeLists.txt
@@ -5,7 +5,26 @@ project(test_rosmaster)
 find_package(catkin REQUIRED COMPONENTS genmsg rostest std_msgs)
 
 if(CATKIN_ENABLE_TESTING)
-  add_message_files(DIRECTORY msg)
+  add_message_files(DIRECTORY msg
+    FILES
+    Arrays.msg
+    Composite.msg
+    CompositeA.msg
+    CompositeB.msg
+    Embed.msg
+    Empty.msg
+    Floats.msg
+    RosmsgA.msg
+    RosmsgB.msg
+    RosmsgC.msg
+    Simple.msg
+    String.msg
+    TestArrays.msg
+    TestHeader.msg
+    TestPrimitives.msg
+    TestString.msg
+    TVals.msg
+  )
   add_service_files(DIRECTORY srv
     FILES
     AddTwoInts.srv


### PR DESCRIPTION
not all the files under `test/test_rosmaster/msg` are included in [CMakeList.txt](https://github.com/ros/ros_comm/blob/melodic-devel/test/test_rosmaster/CMakeLists.txt#L8). to fix this, add all `.msg` files into the list for `add_message_files()`