### PR TITLE
normalize paths before comparison in rosmsg

### DIFF
--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -551,7 +551,7 @@ def _get_package_paths(pkgname, rospack):
     path = rospack.get_path(pkgname)
     paths.append(path)
     results = find_in_workspaces(search_dirs=['share'], project=pkgname, first_match_only=True, workspace_to_source_spaces=_catkin_workspace_to_source_spaces, source_path_to_packages=_catkin_source_path_to_packages)
-    if results and path.replace(os.path.sep, '/') != results[0].replace(os.path.sep, '/'):
+    if results and results[0].replace(os.path.sep, '/') != path.replace(os.path.sep, '/'):
         paths.append(results[0])
     return paths
     

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -549,14 +549,15 @@ _catkin_source_path_to_packages = {}
 def _get_package_paths(pkgname, rospack):
     paths = []
     path = rospack.get_path(pkgname)
-    path = os.path.normcase(os.path.normpath(path))
     paths.append(path)
     results = find_in_workspaces(search_dirs=['share'], project=pkgname, first_match_only=True, workspace_to_source_spaces=_catkin_workspace_to_source_spaces, source_path_to_packages=_catkin_source_path_to_packages)
     if results:
-        path_in_workspaces = results[0]
-        path_in_workspaces = os.path.normcase(os.path.normpath(path_in_workspaces))
-        if path_in_workspaces != path:
-            paths.append(results[0])
+        if os.path.sep != '/':
+            if path.replace(os.path.sep, '/') != results[0].replace(os.path.sep, '/'):
+                paths.append(results[0])
+        else:
+            if path_in_workspaces != path:
+                paths.append(results[0])
     return paths
     
 def rosmsg_search(rospack, mode, base_type):

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -551,15 +551,10 @@ def _get_package_paths(pkgname, rospack):
     path = rospack.get_path(pkgname)
     paths.append(path)
     results = find_in_workspaces(search_dirs=['share'], project=pkgname, first_match_only=True, workspace_to_source_spaces=_catkin_workspace_to_source_spaces, source_path_to_packages=_catkin_source_path_to_packages)
-    if results:
-        if os.path.sep != '/':
-            if path.replace(os.path.sep, '/') != results[0].replace(os.path.sep, '/'):
-                paths.append(results[0])
-        else:
-            if path_in_workspaces != path:
-                paths.append(results[0])
+    if results and path.replace(os.path.sep, '/') != results[0].replace(os.path.sep, '/'):
+        paths.append(results[0])
     return paths
-    
+
 def rosmsg_search(rospack, mode, base_type):
     """
     Iterator for all packages that contain a message matching base_type

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -549,10 +549,14 @@ _catkin_source_path_to_packages = {}
 def _get_package_paths(pkgname, rospack):
     paths = []
     path = rospack.get_path(pkgname)
+    path = os.path.normcase(os.path.normpath(path))
     paths.append(path)
     results = find_in_workspaces(search_dirs=['share'], project=pkgname, first_match_only=True, workspace_to_source_spaces=_catkin_workspace_to_source_spaces, source_path_to_packages=_catkin_source_path_to_packages)
-    if results and results[0] != path:
-        paths.append(results[0])
+    if results:
+        path_in_workspaces = results[0]
+        path_in_workspaces = os.path.normcase(os.path.normpath(path_in_workspaces))
+        if path_in_workspaces != path:
+            paths.append(results[0])
     return paths
     
 def rosmsg_search(rospack, mode, base_type):

--- a/tools/rosmsg/src/rosmsg/__init__.py
+++ b/tools/rosmsg/src/rosmsg/__init__.py
@@ -554,7 +554,7 @@ def _get_package_paths(pkgname, rospack):
     if results and path.replace(os.path.sep, '/') != results[0].replace(os.path.sep, '/'):
         paths.append(results[0])
     return paths
-
+    
 def rosmsg_search(rospack, mode, base_type):
     """
     Iterator for all packages that contain a message matching base_type


### PR DESCRIPTION
this is a minor update to the existing `results[0] != path:` comparison:
normalize all paths before comparison or adding them into `paths` to make sure all elements in `paths` are really unique
* `_get_package_paths` will return 2 paths for the same package; for example: `C:\\ros-win\\install_isolated\\share\\test_rosmaster` and `C:/ros-win/install_isolated\\share\\test_rosmaster` will both be returned for `test_rosmaster`, resulting in duplicated output