### PR TITLE
include cctype for std::tolower

### DIFF
--- a/tools/rosout/rosout.cpp
+++ b/tools/rosout/rosout.cpp
@@ -29,6 +29,7 @@
 
 #include <cstring>
 #include <cstdlib>
+#include <cctype>
 
 #include "ros/ros.h"
 #include "ros/file_log.h"


### PR DESCRIPTION
`rosout.cpp` uses [`std::tolower`](https://github.com/ros/ros_comm/blob/melodic-devel/tools/rosout/rosout.cpp#L91) from `cctype`, adding this header to fix build break on Windows