### PR TITLE
move winsock2.h into .cpp and add macro guard for pollfds

### DIFF
--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
@@ -15,9 +15,7 @@
 # include <map>
 # include <string>
 # include <vector>
-# if defined(_WINDOWS)
-#  include <winsock2.h>
-# else
+# ifndef _WINDOWS
 #  include <poll.h>
 # endif
 #endif
@@ -127,8 +125,10 @@ namespace XmlRpc {
 
     // Minimum number of free file descriptors before rejecting clients.
     static const int FREE_FD_BUFFER;
+#ifndef _WINDOWS
     // List of all file descriptors, used for counting open files.
     std::vector<struct pollfd> pollfds;
+#endif
   };
 } // namespace XmlRpc
 

--- a/utilities/xmlrpcpp/src/XmlRpcServer.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServer.cpp
@@ -13,6 +13,8 @@
 #include <string.h>
 #if !defined(_WINDOWS)
 # include <sys/resource.h>
+#else
+# include <winsock2.h>
 #endif
 
 using namespace XmlRpc;


### PR DESCRIPTION
- `winsock2.h` is not used in the header file, move into the `.cpp` file that actually uses it
- the use of `pollfds` is [guarded by macros](https://github.com/ros/ros_comm/blob/melodic-devel/utilities/xmlrpcpp/src/XmlRpcServer.cpp#L31), add `_WINDOWS` macro guard to fix build failure on Windows