### PR TITLE
add python prefix for python scripts when there is no .py extension

### DIFF
--- a/tools/roslaunch/src/roslaunch/node_args.py
+++ b/tools/roslaunch/src/roslaunch/node_args.py
@@ -261,8 +261,9 @@ def create_local_process_args(node, machine, env=None):
         raise NodeParamsException("Cannot locate node of type [%s] in package [%s]"%(node.type, node.package))
     cmd = [cmd]
 
-    # ROS nodes as python scripts without .py extension could run on Linux thanks to the shebang line
-    # add python prefix to execute such kind of scrips on Windows
+    # Python scripts in ROS tend to omit .py extension since they could become executable
+    # by adding a shebang line (#!/usr/bin/env python) in Linux environments
+    # special handle this case by executing the script with the Python executable in Windows environment
     if os.name == 'nt' and os.path.splitext(cmd[0])[1].lower() in ['.py', '']:
         cmd = ['python'] + cmd
     return _launch_prefix_args(node) + cmd + args

--- a/tools/roslaunch/src/roslaunch/node_args.py
+++ b/tools/roslaunch/src/roslaunch/node_args.py
@@ -261,10 +261,8 @@ def create_local_process_args(node, machine, env=None):
         raise NodeParamsException("Cannot locate node of type [%s] in package [%s]"%(node.type, node.package))
     cmd = [cmd]
 
-    # add python prefix for python script in Windows environment
-    if os.name == 'nt':
-        _, ext = os.path.splitext(cmd[0])
-        # ROS nodes as python scripts tend to omit .py extension, still try launching with python
-        if ext.lower() in ['.py', '']:
-            cmd = ['python'] + cmd
+    # ROS nodes as python scripts without .py extension could run on Linux thanks to the shebang line
+    # add python prefix to execute such kind of scrips on Windows
+    if os.name == 'nt' and os.path.splitext(cmd[0])[1].lower() in ['.py', '']:
+        cmd = ['python'] + cmd
     return _launch_prefix_args(node) + cmd + args

--- a/tools/roslaunch/src/roslaunch/node_args.py
+++ b/tools/roslaunch/src/roslaunch/node_args.py
@@ -260,7 +260,11 @@ def create_local_process_args(node, machine, env=None):
     if not cmd:
         raise NodeParamsException("Cannot locate node of type [%s] in package [%s]"%(node.type, node.package))
     cmd = [cmd]
-    if sys.platform in ['win32']:
-        if os.path.splitext(cmd[0])[1] == '.py':
+
+    # add python prefix for python script in Windows environment
+    if os.name == 'nt':
+        _, ext = os.path.splitext(cmd[0])
+        # ROS nodes as python scripts tend to omit .py extension, still try launching with python
+        if ext.lower() in ['.py', '']:
             cmd = ['python'] + cmd
     return _launch_prefix_args(node) + cmd + args

--- a/tools/roslaunch/src/roslaunch/node_args.py
+++ b/tools/roslaunch/src/roslaunch/node_args.py
@@ -264,6 +264,6 @@ def create_local_process_args(node, machine, env=None):
     # Python scripts in ROS tend to omit .py extension since they could become executable
     # by adding a shebang line (#!/usr/bin/env python) in Linux environments
     # special handle this case by executing the script with the Python executable in Windows environment
-    if os.name == 'nt' and os.path.splitext(cmd[0])[1].lower() in ['.py', '']:
+    if sys.platform in ['win32'] and os.path.splitext(cmd[0])[1].lower() in ['.py', '']:
         cmd = ['python'] + cmd
     return _launch_prefix_args(node) + cmd + args


### PR DESCRIPTION
similar to https://github.com/ros/ros/pull/197, a lot of python scripts don't have the `.py` extension. To work around this on Windows, add `python` prefix in order to execute/launch these python scripts