### PR TITLE
fix paths (and regex for paths) comparison issues

### DIFF
--- a/test/test_rospy/test/unit/test_rospy_core.py
+++ b/test/test_rospy/test/unit/test_rospy_core.py
@@ -116,6 +116,8 @@ class TestRospyCore(unittest.TestCase):
             base, ext = os.path.splitext(this_file)
             if ext == '.pyc':
                 this_file = base + '.py'
+            if os.sep == '\\':
+                this_file = this_file.replace(os.sep, r'\\')
 
             try:
                 # hack to replace the stream handler with a debug version

--- a/test/test_rospy/test/unit/test_rospy_core.py
+++ b/test/test_rospy/test/unit/test_rospy_core.py
@@ -116,7 +116,6 @@ class TestRospyCore(unittest.TestCase):
             base, ext = os.path.splitext(this_file)
             if ext == '.pyc':
                 this_file = base + '.py'
-            this_file = re.escape(this_file)
 
             try:
                 # hack to replace the stream handler with a debug version
@@ -179,7 +178,7 @@ class TestRospyCore(unittest.TestCase):
                         '[0-9]*\.[0-9]*',
                         '[0-9]*',
                         'rosout',
-                        this_file,
+                        re.escape(this_file),
                         '[0-9]*',
                         'TestRospyCore.test_loggers',
                         '/unnamed',

--- a/test/test_rospy/test/unit/test_rospy_core.py
+++ b/test/test_rospy/test/unit/test_rospy_core.py
@@ -116,8 +116,7 @@ class TestRospyCore(unittest.TestCase):
             base, ext = os.path.splitext(this_file)
             if ext == '.pyc':
                 this_file = base + '.py'
-            if os.path.sep == '\\':
-                this_file = this_file.replace(os.path.sep, r'\\')
+            this_file = re.escape(this_file)
 
             try:
                 # hack to replace the stream handler with a debug version

--- a/test/test_rospy/test/unit/test_rospy_core.py
+++ b/test/test_rospy/test/unit/test_rospy_core.py
@@ -116,8 +116,8 @@ class TestRospyCore(unittest.TestCase):
             base, ext = os.path.splitext(this_file)
             if ext == '.pyc':
                 this_file = base + '.py'
-            if os.sep == '\\':
-                this_file = this_file.replace(os.sep, r'\\')
+            if os.path.sep == '\\':
+                this_file = this_file.replace(os.path.sep, r'\\')
 
             try:
                 # hack to replace the stream handler with a debug version

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -55,6 +55,7 @@ class RospyLogger(logging.getLoggerClass()):
         file name, line number, and function name with class name if possible.
         """
         file_name, lineno, func_name = super(RospyLogger, self).findCaller()[:3]
+        file_name = os.path.normcase(file_name)
 
         f = inspect.currentframe()
         if f is not None:

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -93,8 +93,8 @@ try:
         if ext == '.pyc':
             this_file = base + '.py'
         
-        if os.sep == '\\':
-            this_file = this_file.replace(os.sep, r'\\')
+        if os.path.sep == '\\':
+            this_file = this_file.replace(os.path.sep, r'\\')
 
         for i, loc in enumerate(['module', 'function', 'method']):
             if loc == 'module':

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -92,6 +92,9 @@ try:
         base, ext = os.path.splitext(this_file)
         if ext == '.pyc':
             this_file = base + '.py'
+        
+        if sys.platform in ['win32']:
+            this_file = this_file.replace('\\', r'\\')
 
         for i, loc in enumerate(['module', 'function', 'method']):
             if loc == 'module':

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -93,7 +93,6 @@ try:
         base, ext = os.path.splitext(this_file)
         if ext == '.pyc':
             this_file = base + '.py'
-        this_file = re.escape(this_file)
 
         for i, loc in enumerate(['module', 'function', 'method']):
             if loc == 'module':
@@ -111,7 +110,7 @@ try:
                 '[0-9]*\.[0-9]*',
                 '[0-9]*',
                 'rosout',
-                this_file,
+                re.escape(this_file),
                 '[0-9]*',
                 function,
                 '/unnamed',

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -35,6 +35,7 @@ import os
 from StringIO import StringIO
 import sys
 
+import re
 from nose.tools import assert_regexp_matches
 import rosgraph.roslogging
 
@@ -92,9 +93,7 @@ try:
         base, ext = os.path.splitext(this_file)
         if ext == '.pyc':
             this_file = base + '.py'
-        
-        if os.path.sep == '\\':
-            this_file = this_file.replace(os.path.sep, r'\\')
+        this_file = re.escape(this_file)
 
         for i, loc in enumerate(['module', 'function', 'method']):
             if loc == 'module':

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -93,8 +93,8 @@ try:
         if ext == '.pyc':
             this_file = base + '.py'
         
-        if sys.platform in ['win32']:
-            this_file = this_file.replace('\\', r'\\')
+        if os.sep == '\\':
+            this_file = this_file.replace(os.sep, r'\\')
 
         for i, loc in enumerate(['module', 'function', 'method']):
             if loc == 'module':


### PR DESCRIPTION
- [both filenames](https://github.com/ros/ros_comm/blob/melodic-devel/tools/rosgraph/src/rosgraph/roslogging.py#L65) need to be normalized before comparison
- for platforms that use `\` as path separator (Windows, Mac OS), need to escape `os.path.sep` for regular expression comparison