### PR TITLE
normalize strings to utf-8 before setting as environment variable

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -209,7 +209,7 @@ def setup_env(node, machine, master_uri, env=None):
         if ns[-1] == '/':
             ns = ns[:-1]
         if ns:
-            d[rosgraph.ROS_NAMESPACE] = ns 
+            d[rosgraph.ROS_NAMESPACE] = str(ns)
         for name, value in node.env_args:
             d[str(name)] = str(value)
 

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -211,7 +211,7 @@ def setup_env(node, machine, master_uri, env=None):
         if ns:
             d[rosgraph.ROS_NAMESPACE] = ns 
         for name, value in node.env_args:
-            d[name] = value
+            d[str(name)] = str(value)
 
     return d
 


### PR DESCRIPTION
normalize strings to utf-8 before setting as environment variable