### PR TITLE
Fix race due unprotected access to callbacks_ in roscpp client

### DIFF
--- a/clients/roscpp/src/libros/publication.cpp
+++ b/clients/roscpp/src/libros/publication.cpp
@@ -324,6 +324,8 @@ void Publication::dropAllConnections()
 
 void Publication::peerConnect(const SubscriberLinkPtr& sub_link)
 {
+  boost::mutex::scoped_lock lock(callbacks_mutex_);
+
   V_Callback::iterator it = callbacks_.begin();
   V_Callback::iterator end = callbacks_.end();
   for (; it != end; ++it)
@@ -339,6 +341,8 @@ void Publication::peerConnect(const SubscriberLinkPtr& sub_link)
 
 void Publication::peerDisconnect(const SubscriberLinkPtr& sub_link)
 {
+  boost::mutex::scoped_lock lock(callbacks_mutex_);
+
   V_Callback::iterator it = callbacks_.begin();
   V_Callback::iterator end = callbacks_.end();
   for (; it != end; ++it)


### PR DESCRIPTION
Access to **callbacks_** in **Publication::peerConnect()** and **Publication::peerDisconnect()** is not protected with mutex, so if other thread removes callback while call to one of these functions, we may fall into SEGFAULT, trying to access via invalid iterator.