### PR TITLE
query ipv6 only if specified

### DIFF
--- a/utilities/roswtf/src/roswtf/network.py
+++ b/utilities/roswtf/src/roswtf/network.py
@@ -48,7 +48,7 @@ def ip_check(ctx):
     # best we can do is compare roslib's routine against socket resolution and make sure they agree
     local_addrs = rosgraph.network.get_local_addresses()
 
-    if use_ipv6():
+    if rosgraph.network.use_ipv6():
         resolved_ips = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(), 0, 0, 0, socket.SOL_TCP)]
     else:
         resolved_ips = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(), 0, socket.AF_INET, 0, socket.SOL_TCP)]

--- a/utilities/roswtf/src/roswtf/network.py
+++ b/utilities/roswtf/src/roswtf/network.py
@@ -48,7 +48,11 @@ def ip_check(ctx):
     # best we can do is compare roslib's routine against socket resolution and make sure they agree
     local_addrs = rosgraph.network.get_local_addresses()
 
-    resolved_ips = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(), 0, 0, 0, socket.SOL_TCP)]
+    if use_ipv6():
+        resolved_ips = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(), 0, 0, 0, socket.SOL_TCP)]
+    else:
+        resolved_ips = [host[4][0] for host in socket.getaddrinfo(socket.gethostname(), 0, socket.AF_INET, 0, socket.SOL_TCP)]
+
     global_ips = [ ip for ip in resolved_ips if not ip.startswith('127.') and not ip == '::1']
 
     remote_ips = list(set(global_ips) - set(local_addrs))


### PR DESCRIPTION
query ipv6 only if `rosgraph.network.use_ipv6()` returns `true`; otherwise, scope the query to ipv4 only using `socket.AF_INET`