### PR TITLE
Use crytodome if crypto is not found

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -50,8 +50,15 @@ import threading
 import time
 import yaml
 
-from Crypto import Random
-from Crypto.Cipher import AES
+try:
+    # this should resolve to the old pycrypto, 
+    # or cryptodome installed in compatibility mode
+    from Crypto import Random
+    from Crypto.Cipher import AES
+except ImportError:
+    from Cryptodome import Random
+    from Cryptodome.Cipher import AES
+
 import gnupg
 
 try:


### PR DESCRIPTION
This is the least surprise path, but the least secure too, as it does not protect against issues in pycrypto