### PR TITLE
Use cryto only if cryptodome is not found

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -50,8 +50,14 @@ import threading
 import time
 import yaml
 
-from Crypto import Random
-from Crypto.Cipher import AES
+try:
+    # safer version: favors cryptodome over crypto
+    from Cryptodome import Random
+    from Cryptodome.Cipher import AES
+except ImportError:
+    from Crypto import Random
+    from Crypto.Cipher import AES
+
 import gnupg
 
 try:


### PR DESCRIPTION
This is a bit safer as cryptodome is favored over crypto. Yet if crypto is the only installed lib, it will be used.