### PR TITLE
Ensure minimal c++ standard is c++11

### DIFF
--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -28,18 +28,26 @@ add_library(rosbag
   src/recorder.cpp
   src/time_translator.cpp)
 
+target_compile_features(rosbag PUBLIC cxx_std_11)
+
 target_link_libraries(rosbag ${catkin_LIBRARIES} ${Boost_LIBRARIES}
   ${BZIP2_LIBRARIES}
 )
 
 add_executable(record src/record.cpp)
+target_compile_features(record PUBLIC cxx_std_11)
+
 target_link_libraries(record rosbag)
 
 add_executable(play src/play.cpp)
+target_compile_features(play PUBLIC cxx_std_11)
+
 target_link_libraries(play rosbag)
 
 if(NOT WIN32)
   add_executable(encrypt src/encrypt.cpp)
+  target_compile_features(encrypt PUBLIC cxx_std_11)
+
   target_link_libraries(encrypt ${catkin_LIBRARIES})
 endif()
 

--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(rosbag_storage
   src/view.cpp
   src/uncompressed_stream.cpp
 )
+target_compile_features(rosbag_storage PUBLIC cxx_std_11)
 target_link_libraries(rosbag_storage ${catkin_LIBRARIES} ${Boost_LIBRARIES} ${BZIP2_LIBRARIES} ${console_bridge_LIBRARIES} ${AES_ENCRYPT_LIBRARIES})
 
 install(TARGETS rosbag_storage


### PR DESCRIPTION
On older platforms (CentOS7 f.i.), by default the C++ compiler standard is c++98, which doesn't know about nullptr. This patch ensures to raise minimum compatibility with c++11