### PR TITLE
[WIP] Fix subscription busy wait (melodic-devel)

### DIFF
--- a/clients/roscpp/include/ros/callback_queue.h
+++ b/clients/roscpp/include/ros/callback_queue.h
@@ -35,21 +35,6 @@
 #ifndef ROSCPP_CALLBACK_QUEUE_H
 #define ROSCPP_CALLBACK_QUEUE_H
 
-// check if we might need to include our own backported version boost::condition_variable
-// in order to use CLOCK_MONOTONIC for the condition variable
-// the include order here is important!
-#ifdef BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-#include <boost/version.hpp>
-#if BOOST_VERSION < 106100
-// use backported version of boost condition variable, see https://svn.boost.org/trac/boost/ticket/6377
-#include "boost_161_condition_variable.h"
-#else // Boost version is 1.61 or greater and has the steady clock fixes
-#include <boost/thread/condition_variable.hpp>
-#endif
-#else // !BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-#include <boost/thread/condition_variable.hpp>
-#endif // BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
-
 #include "ros/callback_queue_interface.h"
 #include "ros/time.h"
 #include "common.h"

--- a/clients/roscpp/include/ros/callback_queue_interface.h
+++ b/clients/roscpp/include/ros/callback_queue_interface.h
@@ -35,8 +35,22 @@
 #ifndef ROSCPP_CALLBACK_QUEUE_INTERFACE_H
 #define ROSCPP_CALLBACK_QUEUE_INTERFACE_H
 
-#include <boost/shared_ptr.hpp>
+// check if we might need to include our own backported version boost::condition_variable
+// in order to use CLOCK_MONOTONIC for the condition variable
+// the include order here is important!
+#ifdef BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
+#include <boost/version.hpp>
+#if BOOST_VERSION < 106100
+// use backported version of boost condition variable, see https://svn.boost.org/trac/boost/ticket/6377
+#include "boost_161_condition_variable.h"
+#else // Boost version is 1.61 or greater and has the steady clock fixes
 #include <boost/thread/condition_variable.hpp>
+#endif
+#else // !BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
+#include <boost/thread/condition_variable.hpp>
+#endif // BOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC
+
+#include <boost/shared_ptr.hpp>
 #include "common.h"
 #include "ros/types.h"
 

--- a/clients/roscpp/include/ros/callback_queue_interface.h
+++ b/clients/roscpp/include/ros/callback_queue_interface.h
@@ -36,6 +36,7 @@
 #define ROSCPP_CALLBACK_QUEUE_INTERFACE_H
 
 #include <boost/shared_ptr.hpp>
+#include <boost/thread/condition_variable.hpp>
 #include "common.h"
 #include "ros/types.h"
 
@@ -70,6 +71,8 @@ public:
    * before call() actually takes place.
    */
   virtual bool ready() { return true; }
+
+  virtual void setNotifyWhenReady(boost::condition_variable *condition) {};
 };
 typedef boost::shared_ptr<CallbackInterface> CallbackInterfacePtr;
 

--- a/clients/roscpp/include/ros/subscription_queue.h
+++ b/clients/roscpp/include/ros/subscription_queue.h
@@ -74,6 +74,8 @@ public:
 
   virtual CallbackInterface::CallResult call();
   virtual bool ready();
+  virtual void setNotifyWhenReady(boost::condition_variable* condition);
+
   bool full();
 
 private:
@@ -86,6 +88,8 @@ private:
   D_Item queue_;
   uint32_t queue_size_;
   bool allow_concurrent_callbacks_;
+
+  boost::condition_variable* notify_when_ready_condition_;
 
   boost::recursive_mutex callback_mutex_;
 };

--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -238,6 +238,8 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
       return Disabled;
     }
 
+    ros::WallTime start_time(ros::WallTime::now());
+
     if (callbacks_.empty())
     {
       if (!timeout.isZero())
@@ -279,6 +281,15 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
 
     if (!cb_info.callback)
     {
+      // do not spend more than `timeout` seconds in the callback; we already waited for some time when waiting for
+      // nonempty queue
+      ros::WallTime now(ros::WallTime::now());
+      ros::WallDuration time_spent = now - start_time;
+      ros::WallDuration time_to_wait = timeout - time_spent;
+
+      if (time_to_wait.toSec() > 0)
+        condition_.timed_wait(lock, boost::posix_time::microseconds(time_to_wait.toSec() * 1000000.0f));
+
       return TryAgain;
     }
 
@@ -297,6 +308,7 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
   {
     boost::mutex::scoped_lock lock(mutex_);
     --calling_;
+    condition_.notify_one();
   }
   return res;
 }

--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -115,6 +115,17 @@ void CallbackQueue::addCallback(const CallbackInterfacePtr& callback, uint64_t r
   info.removal_id = removal_id;
 
   {
+    boost::mutex::scoped_lock lock(mutex_);
+
+    if (!enabled_)
+    {
+      return;
+    }
+
+    callbacks_.push_back(info);
+  }
+
+  {
     boost::mutex::scoped_lock lock(id_info_mutex_);
 
     M_IDInfo::iterator it = id_info_.find(removal_id);
@@ -137,7 +148,10 @@ void CallbackQueue::addCallback(const CallbackInterfacePtr& callback, uint64_t r
     callbacks_.push_back(info);
   }
 
-  condition_.notify_one();
+  if (callback->ready())
+    condition_.notify_one();
+  else
+    callback->setNotifyWhenReady(&condition_);
 }
 
 CallbackQueue::IDInfoPtr CallbackQueue::getIDInfo(uint64_t id)
@@ -244,7 +258,7 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
     {
       if (!timeout.isZero())
       {
-        condition_.wait_for(lock, boost::chrono::nanoseconds(timeout.toNSec()));
+        condition_.timed_wait(lock, timeout.toBoost());
       }
 
       if (callbacks_.empty())
@@ -287,8 +301,9 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
       ros::WallDuration time_spent = now - start_time;
       ros::WallDuration time_to_wait = timeout - time_spent;
 
-      if (time_to_wait.toSec() > 0)
-        condition_.timed_wait(lock, boost::posix_time::microseconds(time_to_wait.toSec() * 1000000.0f));
+      if (time_to_wait.toNSec() > 0) {
+        condition_.timed_wait(lock, time_to_wait.toBoost());
+      }
 
       return TryAgain;
     }
@@ -308,7 +323,6 @@ CallbackQueue::CallOneResult CallbackQueue::callOne(ros::WallDuration timeout)
   {
     boost::mutex::scoped_lock lock(mutex_);
     --calling_;
-    condition_.notify_one();
   }
   return res;
 }
@@ -330,7 +344,7 @@ void CallbackQueue::callAvailable(ros::WallDuration timeout)
     {
       if (!timeout.isZero())
       {
-        condition_.wait_for(lock, boost::chrono::nanoseconds(timeout.toNSec()));
+        condition_.timed_wait(lock, timeout.toBoost());
       }
 
       if (callbacks_.empty() || !enabled_)

--- a/clients/roscpp/src/libros/subscription_queue.cpp
+++ b/clients/roscpp/src/libros/subscription_queue.cpp
@@ -39,6 +39,7 @@ SubscriptionQueue::SubscriptionQueue(const std::string& topic, int32_t queue_siz
 , full_(false)
 , queue_size_(0)
 , allow_concurrent_callbacks_(allow_concurrent_callbacks)
+, notify_when_ready_condition_(NULL)
 {}
 
 SubscriptionQueue::~SubscriptionQueue()
@@ -164,6 +165,9 @@ CallbackInterface::CallResult SubscriptionQueue::call()
     i.helper->call(params);
   }
 
+  if (notify_when_ready_condition_)
+    notify_when_ready_condition_->notify_one();
+
   return CallbackInterface::Success;
 }
 
@@ -185,6 +189,10 @@ bool SubscriptionQueue::full()
 bool SubscriptionQueue::fullNoLock()
 {
   return (size_ > 0) && (queue_size_ >= (uint32_t)size_);
+}
+
+void SubscriptionQueue::setNotifyWhenReady(boost::condition_variable* condition) {
+  notify_when_ready_condition_ = condition;
 }
 
 }

--- a/clients/roscpp/src/libros/subscription_queue.cpp
+++ b/clients/roscpp/src/libros/subscription_queue.cpp
@@ -169,7 +169,11 @@ CallbackInterface::CallResult SubscriptionQueue::call()
 
 bool SubscriptionQueue::ready()
 {
-  return true;
+  if (!allow_concurrent_callbacks_) {
+    boost::recursive_mutex::scoped_try_lock lock(callback_mutex_, boost::try_to_lock);
+    return lock.owns_lock();
+  } else
+    return true;
 }
 
 bool SubscriptionQueue::full()

--- a/test/test_roscpp/test/fake_message.cpp
+++ b/test/test_roscpp/test/fake_message.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2009, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Author: Josh Faust */
+
+/*
+ * Subscription queue test helper classes
+ */
+
+#include "ros/subscription_callback_helper.h"
+
+using namespace ros;
+
+class FakeMessage
+{
+public:
+    virtual const std::string __getDataType() const { return ""; }
+    virtual const std::string __getMD5Sum() const { return ""; }
+    virtual const std::string __getMessageDefinition() const { return ""; }
+    virtual uint32_t serializationLength() const { return 0; }
+    virtual uint8_t *serialize(uint8_t *write_ptr, uint32_t seq) const { (void)seq; return write_ptr; }
+    virtual uint8_t *deserialize(uint8_t *read_ptr) { return read_ptr; }
+};
+
+class FakeSubHelper : public SubscriptionCallbackHelper
+{
+public:
+    FakeSubHelper()
+        : calls_(0)
+    {}
+
+    virtual VoidConstPtr deserialize(const SubscriptionCallbackHelperDeserializeParams&)
+    {
+      return boost::make_shared<FakeMessage>();
+    }
+
+    virtual std::string getMD5Sum() { return ""; }
+    virtual std::string getDataType() { return ""; }
+
+    virtual void call(SubscriptionCallbackHelperCallParams& params)
+    {
+      (void)params;
+      {
+        boost::mutex::scoped_lock lock(mutex_);
+        ++calls_;
+      }
+
+      if (cb_)
+      {
+        cb_();
+      }
+    }
+
+    virtual const std::type_info& getTypeInfo() { return typeid(FakeMessage); }
+    virtual bool isConst() { return true; }
+    virtual bool hasHeader() { return false; }
+
+    boost::mutex mutex_;
+    int32_t calls_;
+
+    boost::function<void(void)> cb_;
+};
+typedef boost::shared_ptr<FakeSubHelper> FakeSubHelperPtr;

--- a/test/test_roscpp/test/test_callback_queue.cpp
+++ b/test/test_roscpp/test/test_callback_queue.cpp
@@ -36,6 +36,9 @@
 #include <gtest/gtest.h>
 #include <ros/callback_queue.h>
 #include <ros/console.h>
+#include <ros/message_deserializer.h>
+#include <ros/subscription_queue.h>
+#include <ros/subscription_callback_helper.h>
 #include <ros/timer.h>
 
 #include <boost/atomic.hpp>
@@ -43,6 +46,8 @@
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>
 #include <boost/function.hpp>
+
+#include "fake_message.cpp"
 
 using namespace ros;
 
@@ -258,23 +263,29 @@ TEST(CallbackQueue, recursive4)
   EXPECT_EQ(cb->count, 3U);
 }
 
-void callAvailableThread(CallbackQueue* queue, bool& done)
+void callAvailableThread(CallbackQueue* queue, bool& done, boost::atomic<size_t>* num_calls)
 {
+  size_t i = 0;
   while (!done)
   {
     queue->callAvailable(ros::WallDuration(0.1));
+    ++i;
   }
+
+  if (num_calls)
+    num_calls->fetch_add(i);
 }
 
-size_t runThreadedTest(const CountingCallbackPtr& cb, const boost::function<void(CallbackQueue*, bool&)>& threadFunc)
+size_t runThreadedTest(const CallbackInterfacePtr& cb, const boost::function<void(CallbackQueue*, bool&, boost::atomic<size_t>*)>& threadFunc, size_t* num_calls = NULL)
 {
   CallbackQueue queue;
   boost::thread_group tg;
   bool done = false;
+  boost::atomic<size_t> calls(0);
 
   for (uint32_t i = 0; i < 10; ++i)
   {
-    tg.create_thread(boost::bind(threadFunc, &queue, boost::ref(done)));
+    tg.create_thread(boost::bind(threadFunc, &queue, boost::ref(done), &calls));
   }
 
   ros::WallTime start = ros::WallTime::now();
@@ -293,6 +304,9 @@ size_t runThreadedTest(const CountingCallbackPtr& cb, const boost::function<void
   done = true;
   tg.join_all();
 
+  if (num_calls)
+    *num_calls = calls;
+
   return i;
 }
 
@@ -304,12 +318,17 @@ TEST(CallbackQueue, threadedCallAvailable)
   EXPECT_EQ(cb->count, i);
 }
 
-void callOneThread(CallbackQueue* queue, bool& done)
+void callOneThread(CallbackQueue* queue, bool& done, boost::atomic<size_t>* num_calls)
 {
+  size_t i = 0;
   while (!done)
   {
     queue->callOne(ros::WallDuration(0.1));
+    ++i;
   }
+
+  if (num_calls)
+    num_calls->fetch_add(i);
 }
 
 TEST(CallbackQueue, threadedCallOne)
@@ -318,6 +337,78 @@ TEST(CallbackQueue, threadedCallOne)
   size_t i = runThreadedTest(cb, callOneThread);
   ROS_INFO_STREAM(i);
   EXPECT_EQ(cb->count, i);
+}
+
+class CountingSubscriptionQueue : public SubscriptionQueue
+{
+public:
+    CountingSubscriptionQueue(const std::string& topic, int32_t queue_size,
+                              bool allow_concurrent_callbacks)
+        : SubscriptionQueue(topic, queue_size, allow_concurrent_callbacks),
+          ready_count(0)
+    {}
+
+    virtual bool ready() {
+      boost::mutex::scoped_lock lock(ready_mutex);
+      ++ready_count;
+      return SubscriptionQueue::ready();
+    }
+
+    boost::mutex ready_mutex;
+    size_t ready_count;
+};
+typedef boost::shared_ptr<CountingSubscriptionQueue> CountingSubscriptionQueuePtr;
+
+TEST(CallbackQueue, threadedCallOneSlow)
+{
+  // test for https://github.com/ros/ros_comm/issues/1545
+  // "roscpp multithreaded spinners eat up CPU when callbacks take too long"
+
+  // create a subscription queue counting the number of ready() calls and with limited
+  // queue_size so that most of the messages should be thrown away
+  const int32_t queue_size = 3;
+  const CountingSubscriptionQueuePtr cb(
+      boost::make_shared<CountingSubscriptionQueue>("test", queue_size, false));
+
+  // create a slow subscription callback (takes 1 second to complete)
+  const FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
+  helper->cb_ = boost::bind(&ros::WallDuration::sleep, ros::WallDuration(1.0));
+  const MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(
+      helper, SerializedMessage(), boost::shared_ptr<M_string>()));
+
+  // put 10 callbacks on the subscription queue (more than we can process in 5 secs)
+  for (size_t i = 0; i < 10; ++i)
+    cb->push(helper, des, false, VoidConstWPtr(), true);
+
+  // keep filling the callback queue at maximum speed for 5 seconds and
+  // spin up 10 processing threads until the queue is empty
+  size_t num_call_one_calls = 0;
+  const size_t num_callbacks_to_call = runThreadedTest(cb, callOneThread, &num_call_one_calls);
+
+  const int32_t num_callbacks_called = helper->calls_;
+  const size_t num_ready_called = cb->ready_count;
+
+  // what should happen: even though we have multiple processing threads,
+  // the subscription queue has a per-topic lock which prevents multiple threads from
+  // processing the topic's callbacks simultaneously; so even though there were
+  // tens of thousands of callbacks in the callback queue, we only got time to process
+  // less than 5 of them because queue_size is quite limited (3), so most callbacks
+  // get thrown away during processing of the slow callbacks
+
+  // we test the number of SubscriptionQueue::ready() calls to see how often do the
+  // idle threads ask for more work; with bug 1545 unfixed, this gets to millions of
+  // calls which acts as a busy-wait; with the bug fixed, the number should not be
+  // higher than number of callbacks (~ 80k), since each newly added callback should
+  // wake one idle thread and let it ask for work
+
+  ROS_INFO_STREAM("Callback queue called " <<
+                  num_callbacks_called << " / " <<
+                  num_callbacks_to_call <<  " / " << num_call_one_calls << " callbacks. Ready called " <<
+                  num_ready_called << " times.");
+
+  EXPECT_GE(num_callbacks_called, 3);
+  EXPECT_LE(num_callbacks_called, 5);
+  EXPECT_LE(num_call_one_calls, 3 * num_callbacks_to_call);
 }
 
 // this class is just an ugly hack
@@ -384,10 +475,11 @@ TEST(CallbackQueue, recursiveTimer)
 
   boost::thread_group tg;
   bool done = false;
+  boost::atomic<size_t> calls(0);
 
   for (uint32_t i = 0; i < 2; ++i)
   {
-    tg.create_thread(boost::bind(callOneThread, &queue, boost::ref(done)));
+    tg.create_thread(boost::bind(callOneThread, &queue, boost::ref(done), &calls));
   }
 
   while (!queue.isEmpty())

--- a/test/test_roscpp/test/test_callback_queue.cpp
+++ b/test/test_roscpp/test/test_callback_queue.cpp
@@ -263,12 +263,13 @@ TEST(CallbackQueue, recursive4)
   EXPECT_EQ(cb->count, 3U);
 }
 
-void callAvailableThread(CallbackQueue* queue, bool& done, boost::atomic<size_t>* num_calls)
+void callAvailableThread(CallbackQueue* queue, bool& done, boost::atomic<size_t>* num_calls,
+                         ros::WallDuration call_timeout = ros::WallDuration(0.1))
 {
   size_t i = 0;
   while (!done)
   {
-    queue->callAvailable(ros::WallDuration(0.1));
+    queue->callAvailable(call_timeout);
     ++i;
   }
 
@@ -276,24 +277,31 @@ void callAvailableThread(CallbackQueue* queue, bool& done, boost::atomic<size_t>
     num_calls->fetch_add(i);
 }
 
-size_t runThreadedTest(const CallbackInterfacePtr& cb, const boost::function<void(CallbackQueue*, bool&, boost::atomic<size_t>*)>& threadFunc, size_t* num_calls = NULL)
+size_t runThreadedTest(const CallbackInterfacePtr& cb,
+    const boost::function<void(CallbackQueue*, bool&, boost::atomic<size_t>*, ros::WallDuration)>& threadFunc,
+    size_t* num_calls = NULL, size_t num_threads = 10,
+    ros::WallDuration duration = ros::WallDuration(5),
+    ros::WallDuration pause_between_callbacks = ros::WallDuration(0),
+    ros::WallDuration call_one_timeout = ros::WallDuration(0.1))
 {
   CallbackQueue queue;
   boost::thread_group tg;
   bool done = false;
   boost::atomic<size_t> calls(0);
 
-  for (uint32_t i = 0; i < 10; ++i)
+  for (uint32_t i = 0; i < num_threads; ++i)
   {
-    tg.create_thread(boost::bind(threadFunc, &queue, boost::ref(done), &calls));
+    tg.create_thread(boost::bind(threadFunc, &queue, boost::ref(done), &calls, call_one_timeout));
   }
 
   ros::WallTime start = ros::WallTime::now();
   size_t i = 0;
-  while (ros::WallTime::now() - start < ros::WallDuration(5))
+  while (ros::WallTime::now() - start < duration)
   {
     queue.addCallback(cb);
     ++i;
+    if (!pause_between_callbacks.isZero())
+      pause_between_callbacks.sleep();
   }
 
   while (!queue.isEmpty())
@@ -318,12 +326,13 @@ TEST(CallbackQueue, threadedCallAvailable)
   EXPECT_EQ(cb->count, i);
 }
 
-void callOneThread(CallbackQueue* queue, bool& done, boost::atomic<size_t>* num_calls)
+void callOneThread(CallbackQueue* queue, bool& done, boost::atomic<size_t>* num_calls,
+    ros::WallDuration timeout = ros::WallDuration(0.1))
 {
   size_t i = 0;
   while (!done)
   {
-    queue->callOne(ros::WallDuration(0.1));
+    queue->callOne(timeout);
     ++i;
   }
 
@@ -349,41 +358,60 @@ public:
     {}
 
     virtual bool ready() {
-      boost::mutex::scoped_lock lock(ready_mutex);
-      ++ready_count;
+      ready_count.fetch_add(1);
       return SubscriptionQueue::ready();
     }
 
-    boost::mutex ready_mutex;
-    size_t ready_count;
+    boost::atomic<size_t> ready_count;
 };
 typedef boost::shared_ptr<CountingSubscriptionQueue> CountingSubscriptionQueuePtr;
 
-TEST(CallbackQueue, threadedCallOneSlow)
+struct ThreadedCallOneSlowParams {
+    ros::WallDuration callback_duration; // long-lasting callback
+    size_t num_threads;
+    ros::WallDuration call_one_timeout;
+    ros::WallDuration test_duration;
+    ros::WallDuration pause_between_callbacks;
+};
+
+class CallbackQueueParamTest : public ::testing::TestWithParam<ThreadedCallOneSlowParams>
+{};
+
+TEST_P(CallbackQueueParamTest, threadedCallOneSlow)
 {
   // test for https://github.com/ros/ros_comm/issues/1545
   // "roscpp multithreaded spinners eat up CPU when callbacks take too long"
 
-  // create a subscription queue counting the number of ready() calls and with limited
-  // queue_size so that most of the messages should be thrown away
-  const int32_t queue_size = 3;
+  const ThreadedCallOneSlowParams param = GetParam();
+  const WallDuration& callback_duration = param.callback_duration; // long-lasting callback
+  const size_t num_threads = param.num_threads;
+  const ros::WallDuration call_one_timeout = param.call_one_timeout;
+  const ros::WallDuration test_duration = param.test_duration;
+  const ros::WallDuration pause_between_callbacks = param.pause_between_callbacks;
+  // queue_size is chosen such that it is larger than the max number of callbacks we
+  // are really able to process in 5 secs (since allow_concurrent_callbacks is false,
+  // it is equal to the number of seconds the queue is running)
+  const size_t queue_size = static_cast<size_t>(test_duration.toSec()) + 1;
+
+  // create a subscription queue counting the number of ready() calls
   const CountingSubscriptionQueuePtr cb(
       boost::make_shared<CountingSubscriptionQueue>("test", queue_size, false));
 
   // create a slow subscription callback (takes 1 second to complete)
   const FakeSubHelperPtr helper(boost::make_shared<FakeSubHelper>());
-  helper->cb_ = boost::bind(&ros::WallDuration::sleep, ros::WallDuration(1.0));
+  helper->cb_ = boost::bind(&ros::WallDuration::sleep, callback_duration);
   const MessageDeserializerPtr des(boost::make_shared<MessageDeserializer>(
       helper, SerializedMessage(), boost::shared_ptr<M_string>()));
 
-  // put 10 callbacks on the subscription queue (more than we can process in 5 secs)
-  for (size_t i = 0; i < 10; ++i)
+  // fill the subscription queue to get max performance
+  for (size_t i = 0; i < queue_size; ++i)
     cb->push(helper, des, false, VoidConstWPtr(), true);
 
   // keep filling the callback queue at maximum speed for 5 seconds and
   // spin up 10 processing threads until the queue is empty
   size_t num_call_one_calls = 0;
-  const size_t num_callbacks_to_call = runThreadedTest(cb, callOneThread, &num_call_one_calls);
+  const size_t num_callbacks_to_call = runThreadedTest(cb, callOneThread, &num_call_one_calls,
+      num_threads, test_duration, pause_between_callbacks, call_one_timeout);
 
   const int32_t num_callbacks_called = helper->calls_;
   const size_t num_ready_called = cb->ready_count;
@@ -401,15 +429,25 @@ TEST(CallbackQueue, threadedCallOneSlow)
   // higher than number of callbacks (~ 80k), since each newly added callback should
   // wake one idle thread and let it ask for work
 
-  ROS_INFO_STREAM("Callback queue called " <<
-                  num_callbacks_called << " / " <<
-                  num_callbacks_to_call <<  " / " << num_call_one_calls << " callbacks. Ready called " <<
-                  num_ready_called << " times.");
+  ROS_INFO_STREAM("Callback queue processed " <<
+                  num_callbacks_called << " callbacks out of " << num_callbacks_to_call);
+  ROS_INFO_STREAM("callOne() was called " << num_call_one_calls << " times.");
+  ROS_INFO_STREAM("ready() was called " << num_ready_called << " times.");
 
-  EXPECT_GE(num_callbacks_called, 3);
-  EXPECT_LE(num_callbacks_called, 5);
-  EXPECT_LE(num_call_one_calls, 3 * num_callbacks_to_call);
+  EXPECT_EQ(num_callbacks_called, queue_size);
+  EXPECT_LE(num_call_one_calls, 2 * num_callbacks_to_call + num_threads * (1/call_one_timeout.toSec()) * queue_size);
 }
+
+INSTANTIATE_TEST_CASE_P(slow, CallbackQueueParamTest, ::testing::Values(
+  //ThreadedCallOneSlowParams{callback_duration,        num_threads, call_one_timeout,       test_duration,        pause_between_callbacks}
+    ThreadedCallOneSlowParams{ros::WallDuration(1.0),   10,          ros::WallDuration(0.1), ros::WallDuration(2), ros::WallDuration(0)},
+    ThreadedCallOneSlowParams{ros::WallDuration(1.0),   10,          ros::WallDuration(0.1), ros::WallDuration(2), ros::WallDuration(0.1)},
+    ThreadedCallOneSlowParams{ros::WallDuration(1.0),   10,          ros::WallDuration(0.1), ros::WallDuration(2), ros::WallDuration(0.001)},
+    ThreadedCallOneSlowParams{ros::WallDuration(0.1),   10,          ros::WallDuration(0.1), ros::WallDuration(2), ros::WallDuration(0)},
+    ThreadedCallOneSlowParams{ros::WallDuration(0.001), 10,          ros::WallDuration(0.1), ros::WallDuration(2), ros::WallDuration(0)},
+    ThreadedCallOneSlowParams{ros::WallDuration(1.0),    1,          ros::WallDuration(0.1), ros::WallDuration(2), ros::WallDuration(0)},
+    ThreadedCallOneSlowParams{ros::WallDuration(1.0),    2,          ros::WallDuration(0.1), ros::WallDuration(2), ros::WallDuration(0)}
+    ));
 
 // this class is just an ugly hack
 // to access the constructor Timer(TimerOptions)
@@ -479,7 +517,7 @@ TEST(CallbackQueue, recursiveTimer)
 
   for (uint32_t i = 0; i < 2; ++i)
   {
-    tg.create_thread(boost::bind(callOneThread, &queue, boost::ref(done), &calls));
+    tg.create_thread(boost::bind(callOneThread, &queue, boost::ref(done), &calls, ros::WallDuration(0.1)));
   }
 
   while (!queue.isEmpty())

--- a/test/test_roscpp/test/test_subscription_queue.cpp
+++ b/test/test_roscpp/test/test_subscription_queue.cpp
@@ -44,58 +44,9 @@
 #include <boost/bind.hpp>
 #include <boost/thread.hpp>
 
+#include "fake_message.cpp"
+
 using namespace ros;
-
-class FakeMessage
-{
-public:
-  virtual const std::string __getDataType() const { return ""; }
-  virtual const std::string __getMD5Sum() const { return ""; }
-  virtual const std::string __getMessageDefinition() const { return ""; }
-  virtual uint32_t serializationLength() const { return 0; }
-  virtual uint8_t *serialize(uint8_t *write_ptr, uint32_t seq) const { (void)seq; return write_ptr; }
-  virtual uint8_t *deserialize(uint8_t *read_ptr) { return read_ptr; }
-};
-
-class FakeSubHelper : public SubscriptionCallbackHelper
-{
-public:
-  FakeSubHelper()
-  : calls_(0)
-  {}
-
-  virtual VoidConstPtr deserialize(const SubscriptionCallbackHelperDeserializeParams&)
-  {
-    return boost::make_shared<FakeMessage>();
-  }
-
-  virtual std::string getMD5Sum() { return ""; }
-  virtual std::string getDataType() { return ""; }
-
-  virtual void call(SubscriptionCallbackHelperCallParams& params)
-  {
-    (void)params;
-    {
-      boost::mutex::scoped_lock lock(mutex_);
-      ++calls_;
-    }
-
-    if (cb_)
-    {
-      cb_();
-    }
-  }
-
-  virtual const std::type_info& getTypeInfo() { return typeid(FakeMessage); }
-  virtual bool isConst() { return true; }
-  virtual bool hasHeader() { return false; }
-
-  boost::mutex mutex_;
-  int32_t calls_;
-
-  boost::function<void(void)> cb_;
-};
-typedef boost::shared_ptr<FakeSubHelper> FakeSubHelperPtr;
 
 TEST(SubscriptionQueue, queueSize)
 {


### PR DESCRIPTION
PR showing a solution for bug #1545 .

This is not yet meant to be merged - treat it like I'm offering a solution open for comments.

This PR consists of two commits.

The first one solves the issue in a backwards-compatible way, however I've noticed that it's performance when calling CallbackQueue::addCallback rapidly drops compared to upstream (to thousands/sec compared to hundreds of thousands/sec).

The second one takes it further, breaking ABI and API. This solution doesn't suffer from the performance issues, or at least not as much (there is some mutex locking added, so it is probably a bit slower, but taking into account that the upstream now fully throttles the CPU...)

What should the tests show: calling callOne() too often (as in upstream) is quite expensive, and since upstream enters a busy-wait-loop around callOne, it throttles 10 cores to maximum. The fixed versions should be much more friendly to your CPU, which is shown by the fact that it does not call excessive numbers of callOne (roughly 2-3 times the number of subscription callbacks pushed to the queue).

Another interesting metric showed to be the number of subscription callbacks that it's possible to push in the queue in the given time-frame. As I stated earlier, the version from first commit has a very strong drop in this metric. It might be interesting to test it with some real pusblisher/subscriber system, but I haven't yet had time to test it... The numbers are in the logs below. In the "callbacks out of xxx" , `xxx` stands for the number of subscription callbacks pushed to the queue.

Upstream version test log:

```
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/0
[ INFO] [1548938917.404902150]: Callback queue processed 3 callbacks out of 667009
[ INFO] [1548938917.404940298]: callOne() was called 3758024 times.
[ INFO] [1548938917.404954253]: ready() was called 3758014 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/1
[ INFO] [1548938920.505888627]: Callback queue processed 3 callbacks out of 20
[ INFO] [1548938920.505926685]: callOne() was called 3337665 times.
[ INFO] [1548938920.505950341]: ready() was called 3337639 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/2
[ INFO] [1548938923.608300818]: Callback queue processed 3 callbacks out of 1886
[ INFO] [1548938923.608333159]: callOne() was called 3068045 times.
[ INFO] [1548938923.608353024]: ready() was called 3068034 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/3
[ INFO] [1548938925.709150726]: Callback queue processed 3 callbacks out of 419769
[ INFO] [1548938925.709195557]: callOne() was called 791304 times.
[ INFO] [1548938925.709217588]: ready() was called 625407 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/4
[ INFO] [1548938927.810144076]: Callback queue processed 3 callbacks out of 355726
[ INFO] [1548938927.810197815]: callOne() was called 530189 times.
[ INFO] [1548938927.810222560]: ready() was called 360343 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/5
[ INFO] [1548938935.456306184]: Callback queue processed 3 callbacks out of 15238870
[ INFO] [1548938935.456362651]: callOne() was called 15238871 times.
[ INFO] [1548938935.456381335]: ready() was called 15238870 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/6
[ INFO] [1548938941.061697745]: Callback queue processed 3 callbacks out of 3588249
[ INFO] [1548938941.061720978]: callOne() was called 9609083 times.
[ INFO] [1548938941.061725780]: ready() was called 9609081 times.
```

This PR test log:

```
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/0
[ INFO] [1548938720.093230241]: Callback queue processed 3 callbacks out of 889294
[ INFO] [1548938720.093278796]: callOne() was called 985194 times.
[ INFO] [1548938720.093297881]: ready() was called 193324301 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/1
[ INFO] [1548938723.201363924]: Callback queue processed 3 callbacks out of 20
[ INFO] [1548938723.201433658]: callOne() was called 301 times.
[ INFO] [1548938723.201456722]: ready() was called 3136 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/2
[ INFO] [1548938726.309720284]: Callback queue processed 3 callbacks out of 1616
[ INFO] [1548938726.309784458]: callOne() was called 1959 times.
[ INFO] [1548938726.309807322]: ready() was called 287749 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/3
[ INFO] [1548938728.413855536]: Callback queue processed 3 callbacks out of 1120820
[ INFO] [1548938728.413915389]: callOne() was called 1298560 times.
[ INFO] [1548938728.413951201]: ready() was called 15516349 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/4
[ INFO] [1548938730.514903314]: Callback queue processed 3 callbacks out of 107694
[ INFO] [1548938730.514953862]: callOne() was called 154534 times.
[ INFO] [1548938730.514977241]: ready() was called 232839 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/5
[ INFO] [1548938738.808855148]: Callback queue processed 3 callbacks out of 17052751
[ INFO] [1548938738.808911622]: callOne() was called 17052752 times.
[ INFO] [1548938738.808930124]: ready() was called 34105502 times.
[ RUN      ] slow/CallbackQueueParamTest.threadedCallOneSlow/6
[ INFO] [1548938746.801665835]: Callback queue processed 3 callbacks out of 6715023
[ INFO] [1548938746.801720953]: callOne() was called 7147840 times.
[ INFO] [1548938746.801738988]: ready() was called 172077382 times.
```