### PR TITLE
Add pycryptodome as default on melodic

### DIFF
--- a/tools/rosbag/package.xml
+++ b/tools/rosbag/package.xml
@@ -30,7 +30,7 @@
   <run_depend>boost</run_depend>
   <run_depend>genmsg</run_depend>
   <run_depend>genpy</run_depend>
-  <run_depend>python-crypto</run_depend>
+  <run_depend>python-pycryptodome</run_depend>
   <run_depend>python-gnupg</run_depend>
   <run_depend>python-rospkg</run_depend>
   <run_depend>rosbag_storage</run_depend>

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -50,8 +50,9 @@ import threading
 import time
 import yaml
 
-from Crypto import Random
-from Crypto.Cipher import AES
+from Cryptodome.Cipher import AES
+from Cryptodome.Random import random
+
 import gnupg
 
 try:
@@ -221,7 +222,7 @@ class _ROSBagAesCbcEncryptor(_ROSBagEncryptor):
         f.seek(chunk_data_pos)
         chunk = _read(f, chunk_size)
         # Encrypt chunk
-        iv = Random.new().read(AES.block_size)
+        iv = random.getrandbits(AES.block_size)
         f.seek(chunk_data_pos)
         f.write(iv)
         cipher = AES.new(self._symmetric_key, AES.MODE_CBC, iv)
@@ -299,7 +300,7 @@ class _ROSBagAesCbcEncryptor(_ROSBagEncryptor):
                 v = v.encode()
             header_str += _pack_uint32(len(k) + 1 + len(v)) + k + equal + v
 
-        iv = Random.new().read(AES.block_size)
+        iv = random.getrandbits(AES.block_size)
         enc_str = iv
         cipher = AES.new(self._symmetric_key, AES.MODE_CBC, iv)
         enc_str += cipher.encrypt(_add_padding(header_str))
@@ -345,7 +346,7 @@ class _ROSBagAesCbcEncryptor(_ROSBagEncryptor):
     def _build_symmetric_key(self):
         if not self._gpg_key_user:
             return
-        self._symmetric_key = Random.new().read(AES.block_size)
+        self._symmetric_key = random.getrandbits(AES.block_size)
         self._encrypted_symmetric_key = _encrypt_string_gpg(self._gpg_key_user, self._symmetric_key)
 
     def _decrypt_encrypted_header(self, f):


### PR DESCRIPTION
Fix #1599 

This patch will only work on Ubuntu 18.04 and up (Melodic and up). The package pycryptodome is not available on earlier version.