### PR TITLE
fix compiler warnings about unused variables (backport to lunar-devel)

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -604,8 +604,6 @@ void shutdown()
     XMLRPCManager::instance()->shutdown();
   }
 
-  WallTime end = WallTime::now();
-
   g_started = false;
   g_ok = false;
   Time::shutdown();

--- a/test/test_rosbag/test/test_bag.cpp.in
+++ b/test/test_rosbag/test/test_bag.cpp.in
@@ -379,6 +379,7 @@ TEST(rosbag, bad_topic_query_works) {
 
     rosbag::View view(bag, rosbag::TopicQuery(t));
     foreach(rosbag::MessageInstance const m, view) {
+      (void)m;
       FAIL();
     }
 


### PR DESCRIPTION
Cherry-pick of #1428 to fix PR builds that target lunar-devel.