### PR TITLE
add windows.h usage explicitly

### DIFF
--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -39,6 +39,8 @@
 #if !defined(_MSC_VER)
   #include <termios.h>
   #include <unistd.h>
+#else
+  #include <windows.h>
 #endif
 #include <time.h>
 


### PR DESCRIPTION
add `windows.h` usage explicitly to enable build on Windows