### PR TITLE
fix IOError during Python file operation

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -707,6 +707,7 @@ class Bag(object):
         """
         if self._file:
             if self._mode in 'wa':
+                self._file.seek(0, os.SEEK_CUR)
                 self._stop_writing()
             
             self._close_file()

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -707,7 +707,6 @@ class Bag(object):
         """
         if self._file:
             if self._mode in 'wa':
-                self._file.seek(0, os.SEEK_CUR)
                 self._stop_writing()
             
             self._close_file()
@@ -1573,6 +1572,12 @@ class Bag(object):
     def _stop_writing(self):
         # Write the open chunk (if any) to file
         self.flush()
+
+        # When read and write operations are mixed (e.g. bags in 'a' mode might be opened in 'r+b' mode)
+        # it could cause problems on Windows:
+        # https://stackoverflow.com/questions/14279658/mixing-read-and-write-on-python-files-in-windows
+        # to fix this, f.seek(0, os.SEEK_CUR) needs to be added after a read() before the next write()
+        self._file.seek(0, os.SEEK_CUR)
 
         # Remember this location as the start of the index
         self._index_data_pos = self._file.tell()


### PR DESCRIPTION
fix `IOError` during Python file operation

this error is Windows-specific and hard to catch, adding justification as comments so it's easier to understand