### PR TITLE
Fix $(dirname) for roslaunch-check.

### DIFF
--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -118,6 +118,7 @@ def _parse_subcontext(tags, context):
     return subcontext
 
 def _parse_launch(tags, launch_file, file_deps, verbose, context):
+    context['filename'] = os.path.abspath(launch_file)
     dir_path = os.path.dirname(os.path.abspath(launch_file))
     launch_file_pkg = rospkg.get_package_name(dir_path)
             


### PR DESCRIPTION
Small fix for using `$(dirname)` in launch files covered by the roslaunch-check tests. Currently you get the test failing with a traceback like this:

```
Traceback (most recent call last):
  File "<ws>/share/roslaunch/scripts/roslaunch-check", line 90, in <module>
    error_msg = check_roslaunch_file(roslaunch_path, use_test_depends=options.test_depends)
  File "<ws>/share/roslaunch/scripts/roslaunch-check", line 47, in check_roslaunch_file
    error_msg = roslaunch.rlutil.check_roslaunch(roslaunch_file, use_test_depends=use_test_depends)
  File "<ws>/lib/python2.7/dist-packages/roslaunch/rlutil.py", line 201, in check_roslaunch
    base_pkg, file_deps, missing = roslaunch.depends.roslaunch_deps([f], use_test_depends=use_test_depends)
  File "<ws>/lib/python2.7/dist-packages/roslaunch/depends.py", line 332, in roslaunch_deps
    rl_file_deps(file_deps, launch_file, verbose)
  File "<ws>/lib/python2.7/dist-packages/roslaunch/depends.py", line 226, in rl_file_deps
    parse_launch(launch_file, file_deps, verbose)
  File "<ws>/lib/python2.7/dist-packages/roslaunch/depends.py", line 211, in parse_launch
    _parse_launch(launch_tag.childNodes, launch_file, file_deps, verbose, context)
  File "<ws>/lib/python2.7/dist-packages/roslaunch/depends.py", line 141, in _parse_launch
    sub_launch_file = resolve_args(tag.attributes['file'].value, context)
  File "<ws>/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 389, in resolve_args
    resolved = _resolve_args(arg_str, context, resolve_anon, commands)
  File "<ws>/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 407, in _resolve_args
    resolved = commands[command](resolved, a, args, context)
  File "<ws>/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 136, in _dirname
    return resolved.replace("$(%s)" % a, _eval_dirname(context.get('filename', None)))
  File "<ws>/lib/python2.7/dist-packages/roslaunch/substitution_args.py", line 125, in _eval_dirname
    raise SubstitutionException("Cannot substitute $(dirname), no file/directory information available.")
roslaunch.substitution_args.SubstitutionException: Cannot substitute $(dirname), no file/directory information available.
```

The file/directory information it's referring to comes in via xmlloader, here:

https://github.com/ros/ros_comm/blob/acd831359ea245c523d1d12449f52bdac41de229/tools/roslaunch/src/roslaunch/xmlloader.py#L181-L191

However, `roslaunch-check` bypasses this logic so the context value never gets set. This change corrects that.