### PR TITLE
change how commands are executed

### DIFF
--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -491,7 +491,8 @@ class Loader(object):
                 print("... executing command param [%s]" % command)
             import subprocess, shlex #shlex rocks
             try:
-                p = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE)
+                os_posix = os.name == "posix"
+                p = subprocess.Popen(shlex.split(command, posix=os_posix), stdout=subprocess.PIPE)
                 c_value = p.communicate()[0]
                 if not isinstance(c_value, str):
                     c_value = c_value.decode('utf-8')

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -492,7 +492,9 @@ class Loader(object):
             import subprocess, shlex #shlex rocks
             try:
                 os_posix = os.name == "posix"
-                p = subprocess.Popen(shlex.split(command, posix=os_posix), stdout=subprocess.PIPE, shell=not os_posix)
+                if os_posix:
+                    command = shlex.split(command)
+                p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=not os_posix)
                 c_value = p.communicate()[0]
                 if not isinstance(c_value, str):
                     c_value = c_value.decode('utf-8')

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -38,6 +38,7 @@ General routines and representations for loading roslaunch model.
 
 import errno
 import os
+import sys
 from copy import deepcopy
 
 import yaml
@@ -522,7 +523,7 @@ class Loader(object):
                                     if (mode & stat.S_IRUSR == stat.S_IRUSR) and (mode & stat.S_IXUSR != stat.S_IXUSR):
                                         # when there is read permission but not execute permission, this is typically a Python script (in ROS)
                                         if os.path.splitext(f)[1].lower() in ['.py', '']:
-                                            executable_command = ' '.join(['python', f])
+                                            executable_command = ' '.join([sys.executable, f])
                             if executable_command:
                                 command = command.replace(cl[0], executable_command, 1)
                     # no need to call shlex.split() on Windows, underlying CreateProcess() operates on strings

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -492,7 +492,7 @@ class Loader(object):
             import subprocess, shlex #shlex rocks
             try:
                 os_posix = os.name == "posix"
-                p = subprocess.Popen(shlex.split(command, posix=os_posix), stdout=subprocess.PIPE)
+                p = subprocess.Popen(shlex.split(command, posix=os_posix), stdout=subprocess.PIPE, shell=not os_posix)
                 c_value = p.communicate()[0]
                 if not isinstance(c_value, str):
                     c_value = c_value.decode('utf-8')

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -498,7 +498,7 @@ class Loader(object):
                     # 1. search for a wrapper executable (of the same name) under the same directory with stat.S_IXUSR flag
                     # 2. if no wrapper is present, prepend command with 'python' executable
 
-                    cl = shlex.split(command, posix=False) # use non-posix method on Windows
+                    cl = shlex.split(command, posix=False)  # use non-posix method on Windows
                     if os.path.isabs(cl[0]):
                         # trying to launch an executable from a specific location(package), e.g. xacro
                         import stat


### PR DESCRIPTION
this is another problem due to the lack of shebang support on Windows, there are 2 common ways of using the `command` attribute in the launch file:
- call into an executable in `PATH` variable, for example, `rosversion`, an entry point that comes with an executable. this kind of executables tend to sit in `<python_install_dir>\Scripts`, and can be called and executed directly. because of this, usually only the executable's name (not an absolute path) is given, like this:
```xml
<... command="rosversion roslaunch" />
```
- call into an executable from a package (some specific location), so a specific path is given, like such:
```xml
<... command="$(find xacro)/xacro ......" />
```

the first scenario works like a charm on Windows too, thanks to the `console_script` support. However, for the second scenario, things are a little bit different:
- `$(find xacro)/xacro` would point to a file without any extension, that means the file would not be executable on Windows
- even if a win32 executable wrapper (like the one proposed in https://github.com/ros/catkin/pull/978) is added for the Python script under the same directory, the wrapper's name would be `xacro.exe`. unless the subprocess (`subprocess.Popen(command, stdout=subprocess.PIPE)`) is spawned with an extra `shell=True` flag, the following error would be returned:
```
Traceback (most recent call last):
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\__init__.py", line 322, in main
    p.start()
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\parent.py", line 277, in start
    self._start_infrastructure()
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\parent.py", line 226, in _start_infrastructure
    self._load_config()
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\parent.py", line 138, in _load_config
    roslaunch_strs=self.roslaunch_strs, verbose=self.verbose)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\config.py", line 464, in load_config_default
    loader.load(f, config, argv=args, verbose=verbose)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\xmlloader.py", line 769, in load
    self._load_launch(launch, ros_config, is_core=core, filename=filename, argv=argv, verbose=verbose)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\xmlloader.py", line 739, in _load_launch
    self._recurse_load(ros_config, launch.childNodes, self.root_context, None, is_core, verbose)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\xmlloader.py", line 705, in _recurse_load
    val = self._include_tag(tag, context, ros_config, default_machine, is_core, verbose)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\xmlloader.py", line 101, in call
    return f(*args, **kwds)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\xmlloader.py", line 641, in _include_tag
    default_machine, is_core, verbose)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\xmlloader.py", line 685, in _recurse_load
    self._param_tag(tag, context, ros_config, verbose=verbose)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\xmlloader.py", line 101, in call
    return f(*args, **kwds)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\xmlloader.py", line 276, in _param_tag
    value = self.param_value(verbose, name, ptype, *vals)
  File "C:\opt\ros\melodic\x64\lib\site-packages\roslaunch\loader.py", line 506, in param_value
    p = subprocess.Popen(command, stdout=subprocess.PIPE)
  File "C:\opt\python27amd64\lib\subprocess.py", line 394, in __init__
    errread, errwrite)
  File "C:\opt\python27amd64\lib\subprocess.py", line 644, in _execute_child
    startupinfo)
WindowsError: [Error 193] %1 is not a valid Win32 application
```

to fix this, here is our proposed solution:
1. when the executable from that package is a Python script:
    - try to find an executable of the same name, this would be a win32 executable wrapper (this might not always be generated)
    - if no executable is found, try to launch the Python script with the Python executable
2. when the executable from that package is a native executable (for example, `.exe` files on Windows), but no extension (e.g. `.exe`) is given
    - when a command is like `$(find pkg)/exec`, try to find an executable (`exec.exe` on Windows) of the same name

questions I asked myself:

**is this the best fix?**

not necessarily. since [`rosrun`](https://github.com/ros/ros/blob/kinetic-devel/tools/rosbash/scripts/rosrun) already does something very similar, this would create a separate logic from existing code. the actual right fix (imo) is to change commands like
```
$(find xacro)/xacro
```
to
```
rosrun xacro xacro
```
speaking of which, we're working on another pull request to create a Windows-version of `rosrun`. which just like the existing shell script, would be a batch script. however, it would probably be helpful to Python-ize `rosrun` in the future so we/ROS only need to maintain one code base across all platforms.

**is this fix still needed? can't we just change those commands to use `rosrun`?**

I believe so (that's why we're still sending this out =) ), the reasons are as follows:
- we don't know how the downstream packages are using the `command` attribute, it would be hard to find and fix them all
- there is possibility that people might be trying to use some executable from a specific location instead of a ROS package, so `rosrun` cannot be used, and for some reason, still don't want to add `.exe` extension, maybe for better portability across platforms. in this case, it would be helpful if `roslaunch` could search for an executable of the same name under the same directory