### PR TITLE
/rosbag_storage/CMakeLists.txt: require C++14

### DIFF
--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -1,4 +1,7 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 project(rosbag_storage)
 


### PR DESCRIPTION
A first step to fix #1600. The C++-version is now set to C++14 explicitly.