### PR TITLE
/libros/node_handle: keep shared pointer to TopicManager and ServiceM…

### DIFF
--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -56,8 +56,8 @@ int32_t g_nh_refcount = 0;
 bool g_node_started_by_nh = false;
 
 // postpone desctruction of the managers until every NodeHandle has been desctructed.
-TopicManagerPtr g_topic_manager_;
-ServiceManagerPtr g_service_manager_;
+TopicManagerPtr g_topic_manager_{nullptr};
+ServiceManagerPtr g_service_manager_{nullptr};
 
 class NodeHandleBackingCollection
 {


### PR DESCRIPTION
…anager to avoid boost::lock_error exceptions.

Fixes #838.
This solution does not change the object-layout of NodeHandle. 