### PR TITLE
xmlrpcpp: fixed invalid zero index as suggested in #1547

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -497,7 +497,7 @@ namespace XmlRpc {
     xml.resize(xml.size() + base64EncodedSize(_value.asBinary->size()));
 
     base64::encoder encoder;
-    offset += encoder.encode(&(*_value.asBinary)[0], _value.asBinary->size(), &xml[offset]);
+    offset += encoder.encode(_value.asBinary->data(), _value.asBinary->size(), &xml[offset]);
     offset += encoder.encode_end(&xml[offset]);
     xml.resize(offset);
 
@@ -613,7 +613,7 @@ namespace XmlRpc {
       case TypeBase64:
         {
           std::stringstream buffer;
-          buffer.write(&(*_value.asBinary)[0], _value.asBinary->size());
+          buffer.write(_value.asBinary->data(), _value.asBinary->size());
           base64::encoder encoder;
           encoder.encode(buffer, os);
           break;

--- a/utilities/xmlrpcpp/test/test_base64.cpp
+++ b/utilities/xmlrpcpp/test/test_base64.cpp
@@ -61,7 +61,7 @@ TEST_P(Base64Test, Decode) {
   out.resize(encoded_size);
 
   base64::decoder decoder;
-  const int size = decoder.decode(in.c_str(), encoded_size, &out[0]);
+  const int size = decoder.decode(in.c_str(), encoded_size, out.data());
   ASSERT_LE(0, size);
   out.resize(size);
 
@@ -127,7 +127,7 @@ TEST_P(Base64ErrorTest, DecodeErrors) {
   out.resize(encoded_size);
 
   base64::decoder decoder;
-  const int size = decoder.decode(in.c_str(), encoded_size, &out[0]);
+  const int size = decoder.decode(in.c_str(), encoded_size, out.data());
   // Assert that size is greater or equal to 0, to make sure that the follow-up
   // resize will always succeed.
   ASSERT_LE(0, size);


### PR DESCRIPTION
This replaces #1547 .