### PR TITLE
TimeSynchronizer - Added import for python3 compatability

### DIFF
--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -33,6 +33,7 @@ Message Filter Objects
 import itertools
 import threading
 import rospy
+from functools import reduce
 
 
 class SimpleFilter(object):


### PR DESCRIPTION
```[ERROR] [1551279039.648695, 1527.159000]: bad callback: <bound method Subscriber.callback of <message_filters.Subscriber object at 0x7fcf2c55b198>>

Traceback (most recent call last):

  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)

  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 75, in callback
    self.signalMessage(msg)

  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 57, in signalMessage

    cb(*(msg + args))

  File "/opt/ros/kinetic/lib/python2.7/dist-packages/message_filters/__init__.py", line 220, in add
    common = reduce(set.intersection, [set(q) for q in self.queues])

NameError: name 'reduce' is not defined
```

 happens on callback when using `message_filters.TimeSynchronizer` with python3.

Adding the import should work for both python2 and 3 per [https://python-future.org/compatible_idioms.html#reduce](https://python-future.org/compatible_idioms.html#reduce)