### PR TITLE
roscpp: added missin include path (for bazel workspaces)

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -25,6 +25,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/ros/common.h.in ${CATKIN_DEVE
 find_package(Boost REQUIRED COMPONENTS chrono filesystem system)
 
 include_directories(include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}/ros ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+# this is needed for use within a bazel workspace. See #1548 for details.
+include_directories(${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION})
 
 add_message_files(
   DIRECTORY msg


### PR DESCRIPTION
This fixes #1548 .