### PR TITLE
roscpp/TopicManager: avoid deadlock

### DIFF
--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -97,9 +97,10 @@ void TopicManager::shutdown()
   }
 
   {
-    boost::recursive_mutex::scoped_lock lock1(advertised_topics_mutex_);
-    boost::mutex::scoped_lock lock2(subs_mutex_);
+    boost::lock(subs_mutex_, advertised_topics_mutex_);
     shutting_down_ = true;
+    subs_mutex_.unlock();
+    advertised_topics_mutex_.unlock();
   }
 
   // actually one should call poll_manager_->removePollThreadListener(), but the connection is not stored above


### PR DESCRIPTION
 `TopicManager::subscribe` locks first `TopicManager::subs_mutex` and then `TopicManager::advertised_topics_mutex_`. `TopicManager::shutdown` locks them in reverse order. If the run concurrently, this can result in a deadlock, which is the cause of #1644 .

`TopicManager::shutdown` uses now [`boost::lock`](https://www.boost.org/doc/libs/1_69_0/doc/html/thread/synchronization.html#thread.synchronization.lock_functions.lock_multiple), which avoids deadlocks.