### PR TITLE
Add set_rate service

### DIFF
--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -5,11 +5,15 @@ if(NOT WIN32)
   set_directory_properties(PROPERTIES COMPILE_OPTIONS "-Wall;-Wextra")
 endif()
 
-find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
+find_package(catkin REQUIRED COMPONENTS message_generation rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
 find_package(Boost REQUIRED COMPONENTS date_time regex program_options filesystem)
 find_package(BZip2 REQUIRED)
 
 catkin_python_setup()
+
+add_service_files(DIRECTORY srv FILES SetRate.srv)
+
+generate_messages()
 
 # Support large bags (>2GB) on 32-bit systems
 add_definitions(-D_FILE_OFFSET_BITS=64)
@@ -21,13 +25,13 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS}
 catkin_package(
   LIBRARIES rosbag
   INCLUDE_DIRS include
-  CATKIN_DEPENDS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
+  CATKIN_DEPENDS message_runtime rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
 
 add_library(rosbag
   src/player.cpp
   src/recorder.cpp
   src/time_translator.cpp)
-
+add_dependencies(rosbag ${${PROJECT_NAME}_EXPORTED_TARGETS})
 target_link_libraries(rosbag ${catkin_LIBRARIES} ${Boost_LIBRARIES}
   ${BZIP2_LIBRARIES}
 )

--- a/tools/rosbag/include/rosbag/player.h
+++ b/tools/rosbag/include/rosbag/player.h
@@ -58,6 +58,8 @@
 #include "rosbag/time_translator.h"
 #include "rosbag/macros.h"
 
+#include <rosbag/SetRate.h>
+
 namespace rosbag {
 
 //! Helper function to create AdvertiseOptions from a MessageInstance
@@ -128,6 +130,9 @@ public:
     /*! Get the current time */
     ros::Time const& getTime() const;
 
+    /*! Get the horizon */
+    ros::Time const& getHorizon() const;
+
     /*! Run the clock for AT MOST duration
      *
      * If horizon has been reached this function returns immediately
@@ -191,7 +196,11 @@ private:
 
     bool pauseCallback(std_srvs::SetBool::Request &req, std_srvs::SetBool::Response &res);
 
+    bool setRateCallback(rosbag::SetRate::Request& req, rosbag::SetRate::Response& res);
+
     void processPause(const bool paused, ros::WallTime &horizon);
+
+    void updateRate(const double rate);
 
     void waitForSubscribers() const;
 
@@ -203,6 +212,7 @@ private:
     ros::NodeHandle node_handle_;
 
     ros::ServiceServer pause_service_;
+    ros::ServiceServer set_rate_service_;
 
     bool paused_;
     bool delayed_;

--- a/tools/rosbag/include/rosbag/time_translator.h
+++ b/tools/rosbag/include/rosbag/time_translator.h
@@ -63,6 +63,11 @@ public:
     void      shift(ros::Duration const& d);               //!< Increments the translated start time by shift.  Useful for pausing.
     ros::Time translate(ros::Time const& t);
 
+    const double& getTimeScale() const
+    {
+        return time_scale_;
+    }
+
 private:
     double    time_scale_;
     ros::Time real_start_;

--- a/tools/rosbag/package.xml
+++ b/tools/rosbag/package.xml
@@ -18,6 +18,7 @@
 
   <build_depend>boost</build_depend>
   <build_depend>cpp_common</build_depend>
+  <build_depend>message_generation</build_depend>
   <build_depend>python-imaging</build_depend>
   <build_depend>rosbag_storage</build_depend>
   <build_depend>rosconsole</build_depend>
@@ -30,6 +31,7 @@
   <run_depend>boost</run_depend>
   <run_depend>genmsg</run_depend>
   <run_depend>genpy</run_depend>
+  <run_depend>message_runtime</run_depend>
   <run_depend>python-crypto</run_depend>
   <run_depend>python-gnupg</run_depend>
   <run_depend>python-rospkg</run_depend>

--- a/tools/rosbag/srv/SetRate.srv
+++ b/tools/rosbag/srv/SetRate.srv
@@ -1,0 +1,4 @@
+float64 rate   # playback rate (must be > 0.0)
+---
+bool success   # indicate successful run of triggered service
+string message # informational, e.g. for error messages


### PR DESCRIPTION
This adds a `set_rate` service to `rosbag play` and also captures the `+` and `-` keys to scale up or down the current rate by a factor of `2`.