### PR TITLE
fix topic message count for rosbag indexed v1.2.

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -1044,8 +1044,11 @@ class Bag(object):
 
                     msg_count = 0
                     for connection in connections:
-                        for chunk in self._chunks:
-                            msg_count += chunk.connection_counts.get(connection.id, 0)
+                        if self._chunks:
+                            for chunk in self._chunks:
+                                msg_count += chunk.connection_counts.get(connection.id, 0)
+                        else:
+                            msg_count += len(self._connection_indexes.get(connection.id, []))
                     topic_msg_counts[topic] = msg_count
 
                     if self._connection_indexes_read:


### PR DESCRIPTION
We have many indexed v1.2 bags. But command `rosbag info` can not display message count per topic in bags.
The current output like this:
> topics:      /velodyne_packets                    0 msg  @  10.0 Hz : av_msgs/VelodyneScan

The frequency is right, but the message count is always zero.

