### PR TITLE
rostest: use AnyMsg in publishtest

### DIFF
--- a/tools/rostest/nodes/publishtest
+++ b/tools/rostest/nodes/publishtest
@@ -72,10 +72,8 @@ class PublishChecker(object):
         self.topic_name = topic_name
         self.negative = negative
         self.deadline = rospy.Time.now() + rospy.Duration(timeout)
-        msg_class, _, _ = rostopic.get_topic_class(
-            rospy.resolve_name(topic_name), blocking=True)
         self.msg = None
-        self.sub = rospy.Subscriber(topic_name, msg_class, self._callback)
+        self.sub = rospy.Subscriber(topic_name, rospy.AnyMsg, self._callback)
 
     def _callback(self, msg):
         self.msg = msg


### PR DESCRIPTION
Right now publishtest only works correctly when a publisher of the given topic exists: If no publisher exists, the retrieval of the topic class blocks until the test times out. This leads to aborted tests when one would expect a failed one with correct error message, stating that no message on the given topic was published. Using `rospy.AnyMsg` fixes that.

This also makes it impossible to test that a certain topic is not being published, when no publisher exists.