### PR TITLE
Pickleable rosbag exceptions (#1210 revisited).

### DIFF
--- a/test/test_rosbag/test/test_bag.py
+++ b/test/test_rosbag/test/test_bag.py
@@ -432,6 +432,20 @@ class TestRosbag(unittest.TestCase):
 
                 print(bag._OP_CODES.get(op, op))
 
+    # #1209
+    def test_rosbag_exceptions_are_pickleable(self):
+        #bag_exception = rosbag.ROSBagException("msg string")
+        def test(bag_exception):
+            import pickle
+            pickle_str = pickle.dumps(bag_exception)
+            unpickled = pickle.loads(pickle_str)
+            self.assertTrue(bag_exception.value == unpickled.value)
+        test(bag.ROSBagException("msg string"))
+        test(bag.ROSBagFormatException("msg string 2"))
+        test(bag.ROSBagUnindexedException())
+        test(bag.ROSBagEncryptNotSupportedException("msg string 3"))
+        test(bag.ROSBagEncryptException("msg string 4"))
+
 if __name__ == '__main__':
     import rostest
     PKG='rosbag'

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -79,8 +79,11 @@ class ROSBagException(Exception):
     """
     Base class for exceptions in rosbag.
     """
-    def __init__(self, value):
+    def __init__(self, value = None):
         self.value = value
+        #fix for #1209. needed in Python 2.7.
+        # For details: https://stackoverflow.com/questions/41808912/cannot-unpickle-exception-subclass
+        self.args = (value,)
 
     def __str__(self):
         return self.value
@@ -96,7 +99,8 @@ class ROSBagUnindexedException(ROSBagException):
     """
     Exception for unindexed bags.
     """
-    def __init__(self):
+    def __init__(self, *args):
+        #*args needed for #1209
         ROSBagException.__init__(self, 'Unindexed bag')
 
 class ROSBagEncryptNotSupportedException(ROSBagException):

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -79,7 +79,7 @@ class ROSBagException(Exception):
     """
     Base class for exceptions in rosbag.
     """
-    def __init__(self, value = None):
+    def __init__(self, value=None):
         self.value = value
         #fix for #1209. needed in Python 2.7.
         # For details: https://stackoverflow.com/questions/41808912/cannot-unpickle-exception-subclass


### PR DESCRIPTION
This fixes  #1209 in a API preserving way. It replaces #1210. Also tests for the pickleability have been added.