### PR TITLE
 #1455 reviseted: make roslaunch-check respect arg remappings with command line argument

### DIFF
--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -26,7 +26,6 @@
   <run_depend>rosclean</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
   <run_depend>roslib</run_depend>
-  <run_depend>rospy</run_depend>
   <run_depend version_gte="1.11.16">rosmaster</run_depend>
   <run_depend>rosout</run_depend>
   <run_depend>rosparam</run_depend>

--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -26,6 +26,7 @@
   <run_depend>rosclean</run_depend>
   <run_depend>rosgraph_msgs</run_depend>
   <run_depend>roslib</run_depend>
+  <run_depend>rospy</run_depend>
   <run_depend version_gte="1.11.16">rosmaster</run_depend>
   <run_depend>rosout</run_depend>
   <run_depend>rosparam</run_depend>

--- a/tools/roslaunch/resources/example.launch
+++ b/tools/roslaunch/resources/example.launch
@@ -70,4 +70,10 @@
     <include file="does/not/exist.launch" />
     <node pkg="doesnt_exist" type="nope" name="nope" />
   </group>
+
+  <!-- Pass over argument from commandline. Set to false should fail -->
+  <arg name="commandline_true_arg" default="true" />
+  <group unless="$(arg commandline_true_arg)">
+    <node pkg="doesnt_exist" type="nope" name="nope" />
+  </group>
 </launch>

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -45,7 +45,7 @@ from xml.dom import Node as DomNode
 
 import rospkg
 
-from .loader import convert_value
+from .loader import convert_value, load_mappings
 from .substitution_args import resolve_args
 
 NAME="roslaunch-deps"
@@ -205,7 +205,7 @@ def parse_launch(launch_file, file_deps, verbose):
 
     file_deps[launch_file] = RoslaunchDeps()
     launch_tag = dom[0]
-    context = { 'arg': {}}
+    context = { 'arg': load_mappings(sys.argv) }
     _parse_launch(launch_tag.childNodes, launch_file, file_deps, verbose, context)
 
 def rl_file_deps(file_deps, launch_file, verbose=False):


### PR DESCRIPTION
Fix the changes of #1455 . It should not fail anymore.