### PR TITLE
/libros/node_handle: alternative way to fix #838

### DIFF
--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -68,6 +68,10 @@ public:
   V_SrvCImpl srv_cs_;
 
   boost::mutex mutex_;
+
+  // keep shared_ptrs to these managers to avoid assertions. Fixes #838
+  TopicManagerPtr keep_alive_topic_manager = TopicManager::instance();
+  ServiceManagerPtr keep_alive_service_manager = ServiceManager::instance();
 };
 
 NodeHandle::NodeHandle(const std::string& ns, const M_string& remappings)


### PR DESCRIPTION
This is an alternative to #1630, also fixes #838.

This approach can actually guarantee, that the  TopicManager and ServiceManager instance live as long as the last NodeHandle. With #1630 's approach this can not be guaranteed.