### PR TITLE
#1470 revisited: Use node namespace when looking up topic 

### DIFF
--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -82,6 +82,7 @@ catkin_install_python(PROGRAMS
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest)
   find_package(rosunit)
+
   catkin_add_gtest(${PROJECT_NAME}-utest test/utest.cpp)
   if(TARGET ${PROJECT_NAME}-utest)
     target_link_libraries(${PROJECT_NAME}-utest topic_tools)
@@ -106,6 +107,7 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/lazy_transport.test)
   add_rostest(test/mux_initial_none.test)
   add_rostest(test/mux_initial_other.test)
+  add_rostest(test/transform.test)
   ## Latched test disabled until underlying issue in roscpp is resolved,
   ## #3385, #3434.
   #rosbuild_add_rostest(test/relay_latched.test)

--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -82,7 +82,6 @@ catkin_install_python(PROGRAMS
 if(CATKIN_ENABLE_TESTING)
   find_package(rostest)
   find_package(rosunit)
-
   catkin_add_gtest(${PROJECT_NAME}-utest test/utest.cpp)
   if(TARGET ${PROJECT_NAME}-utest)
     target_link_libraries(${PROJECT_NAME}-utest topic_tools)

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -79,7 +79,11 @@ class TopicOp:
 
         self.expression = args.expression
 
-        input_topic_in_ns = rospy.get_namespace() + args.input
+        if len(args.input) > 0 and args.input[0] != '/':
+            input_topic_in_ns = rospy.get_namespace() + args.input
+        else:
+            input_topic_in_ns = args.input
+
         input_class, input_topic, self.input_fn = rostopic.get_topic_class(
             input_topic_in_ns, blocking=args.wait_for_start)
         if input_topic is None:

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -79,10 +79,9 @@ class TopicOp:
 
         self.expression = args.expression
 
-        if len(args.input) > 0 and args.input[0] != '/':
+        input_topic_in_ns = args.input
+        if not input_topic_in_ns.startswith('/'):
             input_topic_in_ns = rospy.get_namespace() + args.input
-        else:
-            input_topic_in_ns = args.input
 
         input_class, input_topic, self.input_fn = rostopic.get_topic_class(
             input_topic_in_ns, blocking=args.wait_for_start)

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -79,10 +79,11 @@ class TopicOp:
 
         self.expression = args.expression
 
+        input_topic_in_ns = rospy.get_namespace() + args.input
         input_class, input_topic, self.input_fn = rostopic.get_topic_class(
-            args.input, blocking=args.wait_for_start)
+            input_topic_in_ns, blocking=args.wait_for_start)
         if input_topic is None:
-            print('ERROR: Wrong input topic (or topic field): %s' % args.input, file=sys.stderr)
+            print('ERROR: Wrong input topic (or topic field): %s' % input_topic_in_ns, file=sys.stderr)
             sys.exit(1)
 
         self.output_class = roslib.message.get_message_class(args.output_type)

--- a/tools/topic_tools/test/test_transform.py
+++ b/tools/topic_tools/test/test_transform.py
@@ -44,20 +44,15 @@ NAME = 'transform_sub'
 
 class TransformSub(unittest.TestCase):
 
-  def msg_cb(self, msg):
-    self.msg = msg
-
   def test_transform_sub(self):
     rospy.init_node(NAME)
     value = rospy.get_param("~value", 1.0)
 
-    self.msg = None
-    sub = rospy.Subscriber("input", Float32, self.msg_cb)
-
-    while not self.msg:
-      rospy.sleep(1.0)
-
-    self.assertEqual(self.msg.data, value)
+    try:
+        msg = rospy.wait_for_message("input", Float32, 1.0)
+        self.assertEqual(msg.data, value)
+    except rospy.ROSException as e:
+        self.fail(str(e))
 
 if __name__ == '__main__':
   rostest.rosrun(PKG, NAME, TransformSub, sys.argv)

--- a/tools/topic_tools/test/test_transform.py
+++ b/tools/topic_tools/test/test_transform.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+import rospy
+import rostest
+import sys
+from std_msgs.msg import *
+
+
+PKG = 'topic_tools'
+NAME = 'transform_sub'
+
+
+class TransformSub(unittest.TestCase):
+
+  def msg_cb(self, msg):
+    self.msg = msg
+
+  def test_transform_sub(self):
+    rospy.init_node(NAME)
+    value = rospy.get_param("~value", 1.0)
+
+    self.msg = None
+    sub = rospy.Subscriber("input", Float32, self.msg_cb)
+
+    while not self.msg:
+      rospy.sleep(1.0)
+
+    self.assertEqual(self.msg.data, value)
+
+if __name__ == '__main__':
+  rostest.rosrun(PKG, NAME, TransformSub, sys.argv)

--- a/tools/topic_tools/test/transform.test
+++ b/tools/topic_tools/test/transform.test
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<launch>
+  <!-- root namespace -->
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub"
+        args="pub -r 2 /num1 std_msgs/Float32 'data: 1.0'"/>
+  <node pkg="topic_tools" type="transform" name="transform"
+        args="/num1 /num2 std_msgs/Float32 'm.data * 3.0'"/>
+
+  <test test-name="transform_" pkg="topic_tools"
+      type="test_transform.py" time-limit="3.0"
+      retry="3">
+    <remap from="input" to="/num2" />
+    <param name="value" value="3.0" />
+  </test>
+
+  <!-- Test in namespace  -->
+  <group ns="foo" >
+    <node pkg="rostopic" type="rostopic" name="rostopic_pub"
+        args="pub -r 2 num3 std_msgs/Float32 'data: 3.0'" />
+    <node pkg="topic_tools" type="transform" name="transform"
+        args="num3 num4 std_msgs/Float32 'm.data * 2.0'"/>
+
+    <test test-name="transform_ns" pkg="topic_tools"
+        type="test_transform.py" time-limit="3.0"
+        retry="3">
+      <remap from="input" to="num4" />
+      <param name="value" value="6.0" />
+    </test>
+  </group>
+
+</launch>


### PR DESCRIPTION
Replaces #1470. Adds the suggested changes.