### PR TITLE
#961 revisited: Add default ROS_MASTER_URI

### DIFF
--- a/clients/roscpp/include/ros/init.h
+++ b/clients/roscpp/include/ros/init.h
@@ -215,6 +215,11 @@ ROSCPP_DECL std::string getROSArg(int argc, const char* const* argv, const std::
  */
 ROSCPP_DECL void removeROSArgs(int argc, const char* const* argv, V_string& args_out);
 
+/**
+ * \brief returns the default master uri that is used if no other is specified, e.g. by defining ROS_MASTER_URI.
+ */
+ROSCPP_DECL const std::string& getDefaultMasterURI();
+
 }
 
 #endif

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -626,4 +626,9 @@ void shutdown()
   Time::shutdown();
 }
 
+const std::string& getDefaultMasterURI() {
+  static const std::string uri = "http://localhost:11311";
+  return uri;
+}
+
 }

--- a/clients/roscpp/src/libros/master.cpp
+++ b/clients/roscpp/src/libros/master.cpp
@@ -63,19 +63,15 @@ void init(const M_string& remappings)
     #else
       master_uri_env = getenv("ROS_MASTER_URI");
     #endif
-    if (!master_uri_env)
-    {
-      ROS_FATAL( "ROS_MASTER_URI is not defined in the environment. Either " \
-                 "type the following or (preferrably) add this to your " \
-                 "~/.bashrc file in order set up your " \
-                 "local machine as a ROS master:\n\n" \
-                 "export ROS_MASTER_URI=http://localhost:11311\n\n" \
-                 "then, type 'roscore' in another shell to actually launch " \
-                 "the master program.");
-      ROS_BREAK();
-    }
 
-    g_uri = master_uri_env;
+    if (master_uri_env)
+    {
+      g_uri = master_uri_env;
+    }
+    else
+    {
+      g_uri = "http://localhost:11311";
+    }
 
 #ifdef _MSC_VER
     // http://msdn.microsoft.com/en-us/library/ms175774(v=vs.80).aspx

--- a/clients/roscpp/src/libros/master.cpp
+++ b/clients/roscpp/src/libros/master.cpp
@@ -70,7 +70,7 @@ void init(const M_string& remappings)
     }
     else
     {
-      g_uri = "http://localhost:11311";
+      g_uri = ros::getDefaultMasterURI();
     }
 
 #ifdef _MSC_VER

--- a/clients/rospy/src/rospy/impl/init.py
+++ b/clients/rospy/src/rospy/impl/init.py
@@ -55,8 +55,8 @@ from .tcpros import init_tcpros
 from .masterslave import ROSHandler
 
 DEFAULT_NODE_PORT = 0 #bind to any open port
-DEFAULT_MASTER_PORT=11311 #default port for master's to bind to
-DEFAULT_MASTER_URI = 'http://localhost:%s/'%DEFAULT_MASTER_PORT
+from rosgraph.rosenv import DEFAULT_MASTER_PORT #default port for master's to bind to
+from rosgraph.rosenv import DEFAULT_MASTER_URI
 
 ###################################################
 # rospy module lower-level initialization

--- a/clients/rospy/src/rospy/impl/init.py
+++ b/clients/rospy/src/rospy/impl/init.py
@@ -55,7 +55,7 @@ from .tcpros import init_tcpros
 from .masterslave import ROSHandler
 
 DEFAULT_NODE_PORT = 0 #bind to any open port
-from rosgraph.rosenv import DEFAULT_MASTER_PORT #default port for master's to bind to
+from rosgraph.rosenv import DEFAULT_MASTER_PORT  # default port for master's to bind to
 from rosgraph.rosenv import DEFAULT_MASTER_URI
 
 ###################################################

--- a/tools/rosgraph/src/rosgraph/rosenv.py
+++ b/tools/rosgraph/src/rosgraph/rosenv.py
@@ -40,6 +40,9 @@ ROS_IPV6         ="ROS_IPV6"
 ROS_HOSTNAME     ="ROS_HOSTNAME"
 ROS_NAMESPACE    ="ROS_NAMESPACE"
 
+DEFAULT_MASTER_PORT=11311 #default port for master's to bind to
+DEFAULT_MASTER_URI = 'http://localhost:%s/'%DEFAULT_MASTER_PORT
+
 def get_master_uri(env=None, argv=None):
     """
     Get the :envvar:`ROS_MASTER_URI` setting from the command-line args or
@@ -69,7 +72,7 @@ def get_master_uri(env=None, argv=None):
                 if not val:
                     raise ValueError("__master remapping argument '%s' improperly specified"%arg)
                 return val
-        return env.get(ROS_MASTER_URI, 'http://localhost:11311')
+        return env.get(ROS_MASTER_URI, DEFAULT_MASTER_URI)
     except KeyError as e:
         return None
         

--- a/tools/rosgraph/src/rosgraph/rosenv.py
+++ b/tools/rosgraph/src/rosgraph/rosenv.py
@@ -69,7 +69,7 @@ def get_master_uri(env=None, argv=None):
                 if not val:
                     raise ValueError("__master remapping argument '%s' improperly specified"%arg)
                 return val
-        return env[ROS_MASTER_URI]
+        return env.get(ROS_MASTER_URI, 'http://localhost:11311')
     except KeyError as e:
         return None
         

--- a/tools/rosgraph/src/rosgraph/rosenv.py
+++ b/tools/rosgraph/src/rosgraph/rosenv.py
@@ -40,7 +40,7 @@ ROS_IPV6         ="ROS_IPV6"
 ROS_HOSTNAME     ="ROS_HOSTNAME"
 ROS_NAMESPACE    ="ROS_NAMESPACE"
 
-DEFAULT_MASTER_PORT=11311  # default port for master's to bind to
+DEFAULT_MASTER_PORT = 11311  # default port for master's to bind to
 DEFAULT_MASTER_URI = 'http://localhost:%s/' % DEFAULT_MASTER_PORT
 
 def get_master_uri(env=None, argv=None):

--- a/tools/rosgraph/src/rosgraph/rosenv.py
+++ b/tools/rosgraph/src/rosgraph/rosenv.py
@@ -40,8 +40,8 @@ ROS_IPV6         ="ROS_IPV6"
 ROS_HOSTNAME     ="ROS_HOSTNAME"
 ROS_NAMESPACE    ="ROS_NAMESPACE"
 
-DEFAULT_MASTER_PORT=11311 #default port for master's to bind to
-DEFAULT_MASTER_URI = 'http://localhost:%s/'%DEFAULT_MASTER_PORT
+DEFAULT_MASTER_PORT=11311  # default port for master's to bind to
+DEFAULT_MASTER_URI = 'http://localhost:%s/' % DEFAULT_MASTER_PORT
 
 def get_master_uri(env=None, argv=None):
     """

--- a/tools/rosgraph/src/rosgraph/rosenv.py
+++ b/tools/rosgraph/src/rosgraph/rosenv.py
@@ -57,22 +57,20 @@ def get_master_uri(env=None, argv=None):
         env = os.environ
     if argv is None:
         argv = sys.argv
-    try:
-        for arg in argv:
-            if arg.startswith('__master:='):
-                val = None
-                try:
-                    _, val = arg.split(':=')
-                except:
-                    pass
-                
-                # we ignore required here because there really is no
-                # correct return value as the configuration is bad
-                # rather than unspecified
-                if not val:
-                    raise ValueError("__master remapping argument '%s' improperly specified"%arg)
-                return val
-        return env.get(ROS_MASTER_URI, DEFAULT_MASTER_URI)
-    except KeyError as e:
-        return None
+    
+    for arg in argv:
+        if arg.startswith('__master:='):
+            val = None
+            try:
+                _, val = arg.split(':=')
+            except:
+                pass
+            
+            # we ignore required here because there really is no
+            # correct return value as the configuration is bad
+            # rather than unspecified
+            if not val:
+                raise ValueError("__master remapping argument '%s' improperly specified"%arg)
+            return val
+    return env.get(ROS_MASTER_URI, DEFAULT_MASTER_URI)
         

--- a/tools/rosgraph/test/test_rosenv.py
+++ b/tools/rosgraph/test/test_rosenv.py
@@ -55,7 +55,7 @@ def test_get_master_uri():
     assert val == 'bar'
 
     # empty env
-    assert None == get_master_uri(env={})
+    assert 'http://localhost:11311' == get_master_uri(env={})
     
     # invalid argv
     try:

--- a/tools/rosgraph/test/test_rosenv.py
+++ b/tools/rosgraph/test/test_rosenv.py
@@ -54,8 +54,9 @@ def test_get_master_uri():
     val = get_master_uri(env=dict(ROS_MASTER_URI='foo'), argv=['__master:=bar', '__master:=bar2'])
     assert val == 'bar'
 
+    import rosgraph.rosenv
     # empty env
-    assert 'http://localhost:11311' == get_master_uri(env={})
+    assert rosgraph.rosenv.DEFAULT_MASTER_URI == get_master_uri(env={})
     
     # invalid argv
     try:

--- a/utilities/roswtf/src/roswtf/context.py
+++ b/utilities/roswtf/src/roswtf/context.py
@@ -301,6 +301,6 @@ def _load_env(ctx, env):
         raise WtfException("ROS_ROOT is not set")
     ctx.ros_package_path = env.get(rospkg.environment.ROS_PACKAGE_PATH, None)
     ctx.pythonpath = env.get('PYTHONPATH', None)
-    ctx.ros_master_uri = env.get(rosgraph.ROS_MASTER_URI, None)
+    ctx.ros_master_uri = rosgraph.rosenv.get_master_uri()
 
     


### PR DESCRIPTION
This is replaces #961. The suggested changes have been made:
  * added `ros::getDefaultMasterURI()` to roscpp
  * moved `DEFAULT_MASTER_URI` from rospy to rosgraph.rosenv, because it is needed there and import it from rospy is not possible, since this would introduce a circular dependency.