### PR TITLE
added is_legal_remap() to rosgraph to make remap-detection more precise

### DIFF
--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -82,7 +82,7 @@ def myargv(argv=None):
     """
     if argv is None:
         argv = sys.argv
-    return [a for a in argv if not rosgraph.names.REMAP in a]
+    return [a for a in argv if not rosgraph.names.is_legal_remap(a)]
 
 def load_command_line_node_params(argv):
     """
@@ -97,7 +97,7 @@ def load_command_line_node_params(argv):
     try:
         mappings = {}
         for arg in argv:
-            if rosgraph.names.REMAP in arg:
+            if rosgraph.names.is_legal_remap(arg):
                 src, dst = [x.strip() for x in arg.split(rosgraph.names.REMAP)]
                 if src and dst:
                     if len(src) > 1 and src[0] == '_' and src[1] != '_':

--- a/test/test_rospy/test/unit/test_rospy_client.py
+++ b/test/test_rospy/test/unit/test_rospy_client.py
@@ -86,7 +86,7 @@ class TestRospyClient(unittest.TestCase):
             self.assertEquals(['-foo', 'bar', '-baz'], myargv(['-foo','bar', '-baz']))
             
             self.assertEquals(['foo'], myargv(['foo','bar:=baz']))
-            self.assertEquals(['foo'], myargv(['foo','-bar:=baz']))
+            self.assertEquals(['foo','-bar:=baz'], myargv(['foo','-bar:=baz']))
         finally:
             sys.argv = orig_argv
     

--- a/tools/rosgraph/src/rosgraph/names.py
+++ b/tools/rosgraph/src/rosgraph/names.py
@@ -51,7 +51,6 @@ PRIV_NAME = '~'
 REMAP = ":="
 ANYTYPE = '*'
 
-
 if sys.hexversion > 0x03000000: #Python3
     def isstring(s):
         return isinstance(s, str) #Python 3.x

--- a/tools/rosgraph/src/rosgraph/names.py
+++ b/tools/rosgraph/src/rosgraph/names.py
@@ -51,6 +51,7 @@ PRIV_NAME = '~'
 REMAP = ":="
 ANYTYPE = '*'
 
+
 if sys.hexversion > 0x03000000: #Python3
     def isstring(s):
         return isinstance(s, str) #Python 3.x
@@ -191,7 +192,7 @@ def load_mappings(argv):
     """    
     mappings = {}
     for arg in argv:
-        if REMAP in arg:
+        if is_legal_remap(arg):
             try:
                 src, dst = [x.strip() for x in arg.split(REMAP)]
                 if src and dst:
@@ -242,6 +243,17 @@ def is_legal_base_name(name):
         return False
     m = BASE_NAME_LEGAL_CHARS_P.match(name)
     return m is not None and m.group(0) == name
+
+REMAP_PATTERN = re.compile('^([\~\/A-Za-z]|_|__)[\w\/]*' + REMAP + '.*')
+
+def is_legal_remap(arg):
+    """
+    Validates that arg is a legal remap according to U{http://wiki.ros.org/Remapping%20Arguments}.
+    """
+    if arg is None:
+        return False
+    m = REMAP_PATTERN.match(arg)
+    return m is not None and m.group(0) == arg
 
 def canonicalize_name(name):
     """


### PR DESCRIPTION
This fixes #1459 . Remaps are no longer only defined by the presence of *:='.

The criterion, a string need to satisfy to be considered as an remap, could be more precise (according to https://wiki.ros.org/Remapping%20Arguments), if #1671 gets fixed.