### PR TITLE
[Kinetic] Adding 'template' to resolve compile error

### DIFF
--- a/utilities/message_filters/include/message_filters/synchronizer.h
+++ b/utilities/message_filters/include/message_filters/synchronizer.h
@@ -355,7 +355,7 @@ private:
   template<int i>
   void cb(const typename mpl::at_c<Events, i>::type& evt)
   {
-    this->add<i>(evt);
+    this->template add<i>(evt);
   }
 
   uint32_t queue_size_;


### PR DESCRIPTION
This syntax has already been used a few lines above in the same file. It prevents the compiler from assuming that `add` is being compared to `i` using the operator `<`.

Hoping to see this land soon :smile: (or am I the only one using Kinetic now :cold_sweat: )

Checked melodic-devel, and this bug [has been resolved there](https://github.com/ros/ros_comm/commit/65e4ce3de9747e359f38db65cf78763f75bcfbd1)