### PR TITLE
Switch to yaml.safe_load(_all) to prevent YAMLLoadWarning

### DIFF
--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -101,7 +101,7 @@ def load_command_line_node_params(argv):
                 src, dst = [x.strip() for x in arg.split(rosgraph.names.REMAP)]
                 if src and dst:
                     if len(src) > 1 and src[0] == '_' and src[1] != '_':
-                        mappings[src[1:]] = yaml.load(dst)
+                        mappings[src[1:]] = yaml.safe_load(dst)
         return mappings
     except Exception as e:
         raise rospy.exceptions.ROSInitException("invalid command-line parameters: %s"%(str(e)))

--- a/test/test_roslib_comm/test/test_roslib_message.py
+++ b/test/test_roslib_comm/test/test_roslib_message.py
@@ -61,7 +61,7 @@ class MessageTest(unittest.TestCase):
         def roundtrip(m):
             yaml_text = strify_message(m)
             print(yaml_text)
-            loaded = yaml.load(yaml_text) 
+            loaded = yaml.safe_load(yaml_text) 
             print("loaded", loaded)
             new_inst = m.__class__()
             if loaded is not None:

--- a/test/test_rosmaster/test/client_verification/test_slave_api.py
+++ b/test/test_rosmaster/test/client_verification/test_slave_api.py
@@ -106,7 +106,7 @@ class TestSlaveApi(unittest.TestCase):
     def load_profile(self, filename):
         import yaml
         with open(filename) as f:
-            d = yaml.load(f)
+            d = yaml.safe_load(f)
         self.required_pubs = d.get('pubs', {})
         self.required_subs = d.get('subs', {})
         

--- a/test/test_rosparam/test/check_rosparam.py
+++ b/test/test_rosparam/test/check_rosparam.py
@@ -227,7 +227,7 @@ class TestRosparam(unittest.TestCase):
         with fakestdout() as b:
             rosparam.yamlmain([cmd, 'get', "g1"])
             import yaml
-            d = yaml.load(b.getvalue())
+            d = yaml.safe_load(b.getvalue())
             self.assertEquals(d['float'], 10.0)
             self.assertEquals(d['int'], 10.0)
             self.assertEquals(d['string'], "g1-foo-value")
@@ -346,18 +346,18 @@ class TestRosparam(unittest.TestCase):
         import yaml
         with open(f_out) as b:
             with open(f) as b2:
-                self.assertEquals(yaml.load(b.read()), yaml.load(b2.read()))
+                self.assertEquals(yaml.safe_load(b.read()), yaml.safe_load(b2.read()))
 
         rosparam.yamlmain([cmd, 'dump', '-v', f_out, 'rosparam_dump'])                
         with open(f_out) as b:
             with open(f) as b2:
-                self.assertEquals(yaml.load(b.read()), yaml.load(b2.read()))
+                self.assertEquals(yaml.safe_load(b.read()), yaml.safe_load(b2.read()))
 
         # yaml file and std_out should be the same
         with fakestdout() as b:
             rosparam.yamlmain([cmd, 'dump'])
             with open(f) as b2:
-                self.assertEquals(yaml.load(b.getvalue())['rosparam_dump'], yaml.load(b2.read()))
+                self.assertEquals(yaml.safe_load(b.getvalue())['rosparam_dump'], yaml.safe_load(b2.read()))
 
     def test_fullusage(self):
         import rosparam

--- a/test/test_rosparam/test/check_rosparam_command_line_online.py
+++ b/test/test_rosparam/test/check_rosparam_command_line_online.py
@@ -120,7 +120,7 @@ class TestRosparamOnline(unittest.TestCase):
         # - dictionary
         output = Popen([cmd, 'get', "g1"], stdout=PIPE).communicate()[0]
         import yaml
-        d = yaml.load(output)
+        d = yaml.safe_load(output)
         self.assertEquals(d['float'], 10.0)
         self.assertEquals(d['int'], 10.0)
         self.assertEquals(d['string'], "g1-foo-value")

--- a/test/test_rosservice/test/check_rosservice_command_line_online.py
+++ b/test/test_rosservice/test/check_rosservice_command_line_online.py
@@ -122,7 +122,7 @@ class TestRosserviceOnline(unittest.TestCase):
             output = Popen([cmd, 'call', name, v], stdout=PIPE).communicate()[0]
             output = output.strip()
             self.assert_(output, output)
-            val = yaml.load(output)['header']
+            val = yaml.safe_load(output)['header']
             self.assertEquals('', val['frame_id'])
             self.assert_(val['seq'] >= 0)
             self.assertEquals(0, val['stamp']['secs'])
@@ -131,7 +131,7 @@ class TestRosserviceOnline(unittest.TestCase):
         # test with auto headers
         for v in ['{header: auto}', '{header: {stamp: now}}']:
             output = Popen([cmd, 'call', name, v], stdout=PIPE).communicate()[0]
-            val = yaml.load(output.strip())['header']
+            val = yaml.safe_load(output.strip())['header']
             self.assertEquals('', val['frame_id'])
             self.assert_(val['seq'] >= 0)
             self.assert_(val['stamp']['secs'] >= int(t))

--- a/test/test_rostopic/test/test_rostopic_unit.py
+++ b/test/test_rostopic/test/test_rostopic_unit.py
@@ -249,16 +249,16 @@ class TestRostopicUnit(unittest.TestCase):
         m = String('foo')
         self.assertEquals('data: "foo"', strify_message(m, field_filter=f))
         m = TVals(Time(123, 456), Duration(78, 90))
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'t': {'secs': 123, 'nsecs': 456}, 'd': {'secs': 78, 'nsecs': 90}}, v)
         m = simple_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(simple_d, v)
         m = arrays_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(arrays_d, v)
         m = embed_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(embed_d, v)
 
         f = create_field_filter(echo_nostr=True, echo_noarr=False)
@@ -267,16 +267,16 @@ class TestRostopicUnit(unittest.TestCase):
         m = String('foo')
         self.assertEquals('', strify_message(m, field_filter=f))
         m = TVals(Time(123, 456), Duration(78, 90))
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'t': {'secs': 123, 'nsecs': 456}, 'd': {'secs': 78, 'nsecs': 90}}, v)
         m = simple_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(simple_nostr, v)
         m = arrays_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(arrays_nostr, v)
         m = embed_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'simple': simple_nostr, 'arrays': arrays_nostr}, v)
 
         f = create_field_filter(echo_nostr=False, echo_noarr=True)
@@ -285,16 +285,16 @@ class TestRostopicUnit(unittest.TestCase):
         m = String('foo')
         self.assertEquals('data: "foo"', strify_message(m, field_filter=f))
         m = TVals(Time(123, 456), Duration(78, 90))
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'t': {'secs': 123, 'nsecs': 456}, 'd': {'secs': 78, 'nsecs': 90}}, v)
         m = simple_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(simple_d, v)
         m = arrays_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(None, v)
         m = embed_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'simple': simple_d, 'arrays': None}, v)
 
         f = create_field_filter(echo_nostr=True, echo_noarr=True)
@@ -303,13 +303,13 @@ class TestRostopicUnit(unittest.TestCase):
         m = String('foo')
         self.assertEquals('', strify_message(m, field_filter=f))
         m = TVals(Time(123, 456), Duration(78, 90))
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'t': {'secs': 123, 'nsecs': 456}, 'd': {'secs': 78, 'nsecs': 90}}, v)
         m = simple_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(simple_nostr, v)
         m = embed_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'simple': simple_nostr, 'arrays': None}, v)
 
     def test_create_field_filter(self):

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -1250,7 +1250,7 @@ class Bag(object):
                         else:
                            setattr(self, a, DictObject(b) if isinstance(b, dict) else b)
 
-            obj = DictObject(yaml.load(s))
+            obj = DictObject(yaml.safe_load(s))
             try:
                 val = eval('obj.' + key)
             except Exception as ex:

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -178,7 +178,7 @@ def configure_logging(logname, level=logging.INFO, filename=None, env=None):
     os.environ['ROS_LOG_FILENAME'] = log_filename
     if config_file.endswith(('.yaml', '.yml')):
         with open(config_file) as f:
-            dict_conf = yaml.load(f)
+            dict_conf = yaml.safe_load(f)
         dict_conf.setdefault('version', 1)
         logging.config.dictConfig(dict_conf)
     else:

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -99,7 +99,7 @@ def convert_value(value, type_):
         raise ValueError("%s is not a '%s' type"%(value, type_))
     elif type_ == 'yaml':
         try:
-            return yaml.load(value)
+            return yaml.safe_load(value)
         except yaml.parser.ParserError as e:
             raise ValueError(e)
     else:
@@ -410,7 +410,7 @@ class Loader(object):
             if rosparam is None:
                 import rosparam
             try:
-                data = yaml.load(text)
+                data = yaml.safe_load(text)
                 # #3162: if there is no YAML, load() will return an
                 # empty string.  We want an empty dictionary instead
                 # for our representation of empty.

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -405,7 +405,7 @@ class Loader(object):
             # - lazy import: we have to import rosparam in oder to to configure the YAML constructors
             import rosparam
             try:
-                data = rosparam.yaml_load(text)
+                data = yaml.safe_load(text)
                 # #3162: if there is no YAML, load() will return an
                 # empty string.  We want an empty dictionary instead
                 # for our representation of empty.

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -47,9 +47,6 @@ from roslaunch.core import Param, RosbinExecutable, RLException, PHASE_SETUP
 
 from rosgraph.names import make_global_ns, ns_join, PRIV_NAME, load_mappings, is_legal_name, canonicalize_name
 
-#lazy-import global for yaml and rosparam
-rosparam = None
-
 class LoadException(RLException):
     """Error loading data as specified (e.g. cannot find included files, etc...)"""
     pass
@@ -406,11 +403,9 @@ class Loader(object):
                 text = subst_function(text)
             # parse YAML text
             # - lazy import: we have to import rosparam in oder to to configure the YAML constructors
-            global rosparam
-            if rosparam is None:
-                import rosparam
+            import rosparam
             try:
-                data = yaml.safe_load(text)
+                data = rosparam.yaml_load(text)
                 # #3162: if there is no YAML, load() will return an
                 # empty string.  We want an empty dictionary instead
                 # for our representation of empty.

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -47,6 +47,9 @@ from roslaunch.core import Param, RosbinExecutable, RLException, PHASE_SETUP
 
 from rosgraph.names import make_global_ns, ns_join, PRIV_NAME, load_mappings, is_legal_name, canonicalize_name
 
+#lazy-import global for yaml and rosparam
+rosparam = None
+
 class LoadException(RLException):
     """Error loading data as specified (e.g. cannot find included files, etc...)"""
     pass
@@ -403,7 +406,9 @@ class Loader(object):
                 text = subst_function(text)
             # parse YAML text
             # - lazy import: we have to import rosparam in oder to to configure the YAML constructors
-            import rosparam
+            global rosparam
+            if rosparam is None:
+                import rosparam
             try:
                 data = yaml.safe_load(text)
                 # #3162: if there is no YAML, load() will return an

--- a/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
@@ -53,7 +53,7 @@ class TestDumpParams(unittest.TestCase):
         o, e = p.communicate()
         self.assert_(p.returncode == 0, "Return code nonzero for param dump! Code: %d" % (p.returncode))
 
-        self.assertEquals({'/noop': 'noop'}, yaml.load(o))
+        self.assertEquals({'/noop': 'noop'}, yaml.safe_load(o))
 
         p = Popen([cmd, '--dump-params', 'roslaunch', 'test-dump-rosparam.launch'], stdout = PIPE)
         o, e = p.communicate()
@@ -95,7 +95,7 @@ class TestDumpParams(unittest.TestCase):
             '/noparam1': 'value1',
             '/noparam2': 'value2',
             }
-        output_val = yaml.load(o)
+        output_val = yaml.safe_load(o)
         if not val == output_val:
             for k, v in val.items():
                 if k not in output_val:

--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -150,6 +150,7 @@ def print_params(params, ns):
         print(params)
     
 # yaml processing
+
 def load_file(filename, default_namespace=None, verbose=False):
     """
     Load the YAML document from the specified file

--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -155,7 +155,7 @@ def yaml_load(str):
     return yaml.load(str, Loader=ROSSafeLoader)
 
 def yaml_load_all(str):
-    return yaml.load_all(str, Loader(ROSSafeLoader))
+    return yaml.load_all(str, Loader=ROSSafeLoader)
 
 def load_file(filename, default_namespace=None, verbose=False):
     """

--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -185,7 +185,7 @@ def load_str(str, filename, default_namespace=None, verbose=False):
     """
     paramlist = []
     default_namespace = default_namespace or get_ros_namespace()
-    for doc in yaml.load_all(str):
+    for doc in yaml.safe_load_all(str):
         if NS in doc:
             ns = ns_join(default_namespace, doc.get(NS, None))
             if verbose:
@@ -367,7 +367,7 @@ def set_param(param, value, verbose=False):
     :param param: parameter name, ``str``
     :param value: yaml-encoded value, ``str``
     """
-    set_param_raw(param, yaml.load(value), verbose=verbose)
+    set_param_raw(param, yaml.safe_load(value), verbose=verbose)
 
 def upload_params(ns, values, verbose=False):
     """

--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -98,7 +98,8 @@ def construct_yaml_binary(loader, node):
         
 # register the (de)serializers with pyyaml
 yaml.add_representer(Binary,represent_xml_binary)
-yaml.add_constructor(u'tag:yaml.org,2002:binary', construct_yaml_binary)
+ROSSafeLoader = yaml.loader.SafeLoader
+ROSSafeLoader.add_constructor(u'tag:yaml.org,2002:binary', construct_yaml_binary)
 
 def construct_angle_radians(loader, node):
     """
@@ -150,6 +151,12 @@ def print_params(params, ns):
     
 # yaml processing
 
+def yaml_load(str):
+    return yaml.load(str, Loader=ROSSafeLoader)
+
+def yaml_load_all(str):
+    return yaml.load_all(str, Loader(ROSSafeLoader))
+
 def load_file(filename, default_namespace=None, verbose=False):
     """
     Load the YAML document from the specified file
@@ -185,7 +192,7 @@ def load_str(str, filename, default_namespace=None, verbose=False):
     """
     paramlist = []
     default_namespace = default_namespace or get_ros_namespace()
-    for doc in yaml.safe_load_all(str):
+    for doc in yaml_load_all(str):
         if NS in doc:
             ns = ns_join(default_namespace, doc.get(NS, None))
             if verbose:
@@ -367,7 +374,7 @@ def set_param(param, value, verbose=False):
     :param param: parameter name, ``str``
     :param value: yaml-encoded value, ``str``
     """
-    set_param_raw(param, yaml.safe_load(value), verbose=verbose)
+    set_param_raw(param, yaml_load(value), verbose=verbose)
 
 def upload_params(ns, values, verbose=False):
     """
@@ -631,12 +638,12 @@ def yamlmain(argv=None):
 
 # YAML configuration. Doxygen does not like these being higher up in the code
 
-yaml.add_constructor(u'!radians', construct_angle_radians)
-yaml.add_constructor(u'!degrees', construct_angle_degrees)
+ROSSafeLoader.add_constructor(u'!radians', construct_angle_radians)
+ROSSafeLoader.add_constructor(u'!degrees', construct_angle_degrees)
 
 # allow both !degrees 180, !radians 2*pi
 pattern = re.compile(r'^deg\([^\)]*\)$')
-yaml.add_implicit_resolver(u'!degrees', pattern, first="deg(")
+ROSSafeLoader.add_implicit_resolver(u'!degrees', pattern, first="deg(")
 pattern = re.compile(r'^rad\([^\)]*\)$')
-yaml.add_implicit_resolver(u'!radians', pattern, first="rad(")
+ROSSafeLoader.add_implicit_resolver(u'!radians', pattern, first="rad(")
 

--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -98,8 +98,8 @@ def construct_yaml_binary(loader, node):
         
 # register the (de)serializers with pyyaml
 yaml.add_representer(Binary,represent_xml_binary)
-ROSSafeLoader = yaml.loader.SafeLoader
-ROSSafeLoader.add_constructor(u'tag:yaml.org,2002:binary', construct_yaml_binary)
+yaml.add_constructor(u'tag:yaml.org,2002:binary', construct_yaml_binary)
+yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:binary', construct_yaml_binary)
 
 def construct_angle_radians(loader, node):
     """
@@ -150,13 +150,6 @@ def print_params(params, ns):
         print(params)
     
 # yaml processing
-
-def yaml_load(str):
-    return yaml.load(str, Loader=ROSSafeLoader)
-
-def yaml_load_all(str):
-    return yaml.load_all(str, Loader=ROSSafeLoader)
-
 def load_file(filename, default_namespace=None, verbose=False):
     """
     Load the YAML document from the specified file
@@ -192,7 +185,7 @@ def load_str(str, filename, default_namespace=None, verbose=False):
     """
     paramlist = []
     default_namespace = default_namespace or get_ros_namespace()
-    for doc in yaml_load_all(str):
+    for doc in yaml.safe_load_all(str):
         if NS in doc:
             ns = ns_join(default_namespace, doc.get(NS, None))
             if verbose:
@@ -374,7 +367,7 @@ def set_param(param, value, verbose=False):
     :param param: parameter name, ``str``
     :param value: yaml-encoded value, ``str``
     """
-    set_param_raw(param, yaml_load(value), verbose=verbose)
+    set_param_raw(param, yaml.load(value), verbose=verbose)
 
 def upload_params(ns, values, verbose=False):
     """
@@ -638,12 +631,16 @@ def yamlmain(argv=None):
 
 # YAML configuration. Doxygen does not like these being higher up in the code
 
-ROSSafeLoader.add_constructor(u'!radians', construct_angle_radians)
-ROSSafeLoader.add_constructor(u'!degrees', construct_angle_degrees)
+yaml.add_constructor(u'!radians', construct_angle_radians)
+yaml.add_constructor(u'!degrees', construct_angle_degrees)
+yaml.SafeLoader.add_constructor(u'!radians', construct_angle_radians)
+yaml.SafeLoader.add_constructor(u'!degrees', construct_angle_degrees)
 
 # allow both !degrees 180, !radians 2*pi
 pattern = re.compile(r'^deg\([^\)]*\)$')
-ROSSafeLoader.add_implicit_resolver(u'!degrees', pattern, first="deg(")
+yaml.add_implicit_resolver(u'!degrees', pattern, first="deg(")
+yaml.SafeLoader.add_implicit_resolver(u'!degrees', pattern, first="deg(")
 pattern = re.compile(r'^rad\([^\)]*\)$')
-ROSSafeLoader.add_implicit_resolver(u'!radians', pattern, first="rad(")
+yaml.add_implicit_resolver(u'!radians', pattern, first="rad(")
+yaml.SafeLoader.add_implicit_resolver(u'!radians', pattern, first="rad(")
 

--- a/tools/rosservice/src/rosservice/__init__.py
+++ b/tools/rosservice/src/rosservice/__init__.py
@@ -607,7 +607,7 @@ def _rosservice_cmd_call(argv):
         # convert empty args to YAML-empty strings
         if arg == '':
             arg = "''" 
-        service_args.append(yaml.load(arg))
+        service_args.append(yaml.safe_load(arg))
     if not service_args and has_service_args(service_name, service_class=service_class):
         if sys.stdin.isatty():
             parser.error("Please specify service arguments")
@@ -650,7 +650,7 @@ def _stdin_yaml_arg():
                 elif arg.strip() != '---':
                     buff = buff + arg
             try:
-                loaded = yaml.load(buff.rstrip())
+                loaded = yaml.safe_load(buff.rstrip())
             except Exception as e:
                 print("Invalid YAML: %s"%str(e), file=sys.stderr)
             if loaded is not None:

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1779,7 +1779,7 @@ def _rostopic_cmd_pub(argv):
     try:
         pub_args = []
         for arg in args[2:]:
-            pub_args.append(yaml.load(arg))
+            pub_args.append(yaml.safe_load(arg))
     except Exception as e:
         parser.error("Argument error: "+str(e))
 
@@ -1822,7 +1822,7 @@ def file_yaml_arg(filename):
         try:
             with open(filename, 'r') as f:
                 # load all documents
-                data = yaml.load_all(f)
+                data = yaml.safe_load_all(f)
                 for d in data:
                     yield [d]
         except yaml.YAMLError as e:
@@ -2014,7 +2014,7 @@ def stdin_yaml_arg():
 
             if arg.strip() == '---': # End of document
                 try:
-                    loaded = yaml.load(buff.rstrip())
+                    loaded = yaml.safe_load(buff.rstrip())
                 except Exception as e:
                     sys.stderr.write("Invalid YAML: %s\n"%str(e))
                 if loaded is not None:

--- a/tools/topic_tools/scripts/relay_field
+++ b/tools/topic_tools/scripts/relay_field
@@ -98,7 +98,7 @@ class RelayField(object):
         if self.input_fn is not None:
             m = self.input_fn(m)
 
-        msg_generation = yaml.load(self.expression)
+        msg_generation = yaml.safe_load(self.expression)
         pub_args = _eval_in_dict_impl(msg_generation, None, {'m': m})
 
         now = rospy.get_rostime()


### PR DESCRIPTION
Fixes #1686.

In https://github.com/yaml/pyyaml/issues/265 it's stated that `safe_load` always existed for this reason, I did a quick double check and it traces back at least to 2006, so this might even be safe to backport to older releases.