### PR TITLE
add rostopic as run_depend of rostest

### DIFF
--- a/tools/rostest/package.xml
+++ b/tools/rostest/package.xml
@@ -20,6 +20,7 @@
   <run_depend>roslaunch</run_depend>
   <run_depend>rosmaster</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>rostopic</run_depend>
   <run_depend>rosunit</run_depend>
 
   <export>


### PR DESCRIPTION
This is required to run `publishtest`.

https://github.com/ros/ros_comm/blob/melodic-devel/tools/rostest/nodes/publishtest#L63