### PR TITLE
topic_tools/relay: fixed boost::lock exception

### DIFF
--- a/tools/topic_tools/src/relay.cpp
+++ b/tools/topic_tools/src/relay.cpp
@@ -171,13 +171,13 @@ int main(int argc, char **argv)
     g_th.unreliable().reliable(); // Prefers unreliable, but will accept reliable.
 
   pnh.param<bool>("stealth", g_stealth, false);
-  ros::Timer g_timer;
+  ros::Timer monitor_timer;
   if (g_stealth)
   {
     double monitor_rate;
     pnh.param<string>("monitor_topic", g_monitor_topic, g_input_topic);
     pnh.param<double>("monitor_rate", monitor_rate, 1.0);
-    g_timer = n.createTimer(ros::Duration(monitor_rate), &timer_cb);
+    monitor_timer = n.createTimer(ros::Duration(monitor_rate), &timer_cb);
   }
 
   subscribe();

--- a/tools/topic_tools/src/relay.cpp
+++ b/tools/topic_tools/src/relay.cpp
@@ -46,7 +46,6 @@ string g_output_topic;
 string g_monitor_topic;
 ros::Publisher g_pub;
 ros::Subscriber* g_sub;
-ros::Timer g_timer;
 bool g_lazy;
 bool g_stealth;
 ros::TransportHints g_th;
@@ -172,6 +171,7 @@ int main(int argc, char **argv)
     g_th.unreliable().reliable(); // Prefers unreliable, but will accept reliable.
 
   pnh.param<bool>("stealth", g_stealth, false);
+  ros::Timer g_timer;
   if (g_stealth)
   {
     double monitor_rate;


### PR DESCRIPTION
caused by a life time issue with global variables.