### PR TITLE
rosgraph/network: use urlparse for parsing the port, whick makes ipv6 possible

### DIFF
--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -83,11 +83,10 @@ def parse_http_host_and_port(url):
     :returns: hostname and port number in URL or 80 (default), ``(str, int)``
     :raises: :exc:`ValueError` If the url does not validate
     """
-    assert sys.version_info >= (2, 5)
     if not url:
         raise ValueError('not a valid URL')        
     p = urlparse.urlparse(url)
-    if not p.scheme or not p.hostname: #protocol and host
+    if not p.scheme or not p.hostname:
         raise ValueError('not a valid URL')
     port = p.port if p.port else 80
     return p.hostname, port

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -83,18 +83,14 @@ def parse_http_host_and_port(url):
     :returns: hostname and port number in URL or 80 (default), ``(str, int)``
     :raises: :exc:`ValueError` If the url does not validate
     """
-    # can't use p.port because that's only available in Python 2.5
+    assert sys.version_info >= (2, 5)
     if not url:
         raise ValueError('not a valid URL')        
     p = urlparse.urlparse(url)
-    if not p[0] or not p[1]: #protocol and host
+    if not p.scheme or not p.hostname: #protocol and host
         raise ValueError('not a valid URL')
-    if ':' in p[1]:
-        hostname, port = p[1].split(':')
-        port = int(port)
-    else: 
-        hostname, port = p[1], 80
-    return hostname, port
+    port = p.port if p.port else 80
+    return p.hostname, port
     
 def _is_unix_like_platform():
     """

--- a/tools/rosgraph/test/test_network.py
+++ b/tools/rosgraph/test/test_network.py
@@ -152,6 +152,7 @@ class NetworkTest(unittest.TestCase):
         assert ('localhost', 1234) == parse_http_host_and_port('http://localhost:1234')
         assert ('localhost', 1) == parse_http_host_and_port('http://localhost:1')
         assert ('willowgarage.com', 1) == parse_http_host_and_port('http://willowgarage.com:1')
+        assert ('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210'.lower(), 81) == parse_http_host_and_port('http://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:81')
     
     def test_get_local_address(self):
         # mostly a tripwire test


### PR DESCRIPTION
This requires python 2.5.

This fixes #1694.