### PR TITLE
Fix error handling for Topic constructor

### DIFF
--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -1264,7 +1264,7 @@ class _TopicManager(object):
             rmap = self.subs
             impl_class = _SubscriberImpl
         else:
-            raise TypeError("invalid reg_type: %s"%s)
+            raise TypeError("invalid reg_type: %s"%reg_type)
         with self.lock:
             impl = rmap.get(resolved_name, None)            
             if not impl:


### PR DESCRIPTION
There is no `s` variable in scope - and we clearly wanna display `reg_type`

To reproduce:
```
rospy.topics.Topic('/topic', rospy.AnyMsg, 'aa')
```
I get
```
raise TypeError("invalid reg_type: %s"%s)
NameError: global name 's' is not defined
```