### PR TITLE
Added possibility to pass rospy.Duration as timeout to wait_for_service and wait_for_message.

### DIFF
--- a/clients/roscpp/include/ros/service.h
+++ b/clients/roscpp/include/ros/service.h
@@ -97,6 +97,7 @@ bool call(const std::string& service_name, Service& service)
  * \param service_name Name of the service to wait for.
  * \param timeout The amount of time to wait for, in milliseconds.  If timeout is -1,
  * waits until the node is shutdown
+ * \note rospy wait_for_service() has timeout in seconds.
  * \return true on success, false otherwise
  */
 ROSCPP_DECL bool waitForService(const std::string& service_name, int32_t timeout);

--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -398,8 +398,8 @@ def wait_for_message(topic, topic_type, timeout=None):
     @type  topic: str
     @param topic_type: topic type
     @type  topic_type: L{rospy.Message} class
-    @param timeout: timeout time in seconds
-    @type  timeout: double
+    @param timeout: timeout time in seconds or ROS Duration
+    @type  timeout: double|rospy.Duration
     @return: Message
     @rtype: L{rospy.Message}
     @raise ROSException: if specified timeout is exceeded
@@ -410,6 +410,8 @@ def wait_for_message(topic, topic_type, timeout=None):
     try:
         s = rospy.topics.Subscriber(topic, topic_type, wfm.cb)
         if timeout is not None:
+            if isinstance(timeout, rospy.Duration):
+                timeout = timeout.to_sec()
             timeout_t = time.time() + timeout
             while not rospy.core.is_shutdown() and wfm.msg is None:
                 rospy.rostime.wallsleep(0.01)

--- a/clients/rospy/src/rospy/impl/tcpros_service.py
+++ b/clients/rospy/src/rospy/impl/tcpros_service.py
@@ -89,7 +89,7 @@ def wait_for_service(service, timeout=None):
     possible. For timeout=0 uses cases, just call the service without
     waiting.
     @type  timeout: double|rospy.Duration
-    @note  roscpp waitForService() has timeout specified in milisecs.
+    @note  roscpp waitForService() has timeout specified in millisecs.
     @raise ROSException: if specified timeout is exceeded
     @raise ROSInterruptException: if shutdown interrupts wait
     """

--- a/clients/rospy/src/rospy/impl/tcpros_service.py
+++ b/clients/rospy/src/rospy/impl/tcpros_service.py
@@ -83,12 +83,13 @@ def wait_for_service(service, timeout=None):
     service already running.
     @param service: name of service
     @type  service: str
-    @param timeout: timeout time in seconds, None for no
+    @param timeout: timeout time in seconds or Duration, None for no
     timeout. NOTE: timeout=0 is invalid as wait_for_service actually
     contacts the service, so non-blocking behavior is not
     possible. For timeout=0 uses cases, just call the service without
     waiting.
-    @type  timeout: double
+    @type  timeout: double|rospy.Duration
+    @note  roscpp waitForService() has timeout specified in milisecs.
     @raise ROSException: if specified timeout is exceeded
     @raise ROSInterruptException: if shutdown interrupts wait
     """
@@ -118,6 +119,8 @@ def wait_for_service(service, timeout=None):
         finally:
             if s is not None:
                 s.close()
+    if timeout is not None and isinstance(timeout, rospy.Duration):
+        timeout = timeout.to_sec()
     if timeout == 0.:
         raise ValueError("timeout must be non-zero")
     resolved_name = rospy.names.resolve_name(service)


### PR DESCRIPTION
Fixes https://github.com/ros/ros_comm/issues/1658.