### PR TITLE
Wrap the rosbag filter eval in a lambda

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -302,9 +302,7 @@ def play_cmd(argv):
 
 def filter_cmd(argv):
     def expr_eval(expr):
-        def eval_fn(topic, m, t):
-            return eval(expr)
-        return eval_fn
+        return eval("lambda topic, m, t: %s" % expr)
 
     parser = optparse.OptionParser(usage="""rosbag filter [options] INBAG OUTBAG EXPRESSION
 


### PR DESCRIPTION
As proposed in #1711, and suggested here: https://stackoverflow.com/a/12467755/109517

In testing with some of our bags here, I got 978.9 kb/s and 942.9 kb/s before the change, and 1147.2 kb/s and 1126.6 kb/s after, or about 18% faster.