### PR TITLE
Do not raise socket exception during shutdown

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -158,7 +158,8 @@ class TCPServer(object):
                 (e_errno, msg) = e.args
                 if e_errno == errno.EINTR: #interrupted system call
                     continue
-                raise
+                if not self.is_shutdown:
+                    raise
             if self.is_shutdown:
                 break
             try:


### PR DESCRIPTION
When using rospy with gevent, there is always socket exception raised during shutdown procedure, and it can flood logs. This simple change fixes the problem. Do this kind of exceptions have any value?