### PR TITLE
[roswtf] Print exception content to show better idea why loading plugin failed.

### DIFF
--- a/utilities/roswtf/src/roswtf/plugins.py
+++ b/utilities/roswtf/src/roswtf/plugins.py
@@ -89,7 +89,7 @@ def load_plugins():
             else:
                 print("Loaded plugin", p_module)
 
-        except Exception:
-            print("Unable to load plugin [%s] from package [%s]"%(p_module, pkg), file=sys.stderr)
+        except Exception as e:
+            print("Unable to load plugin [%s] from package [%s]. Exception thrown: [%s]"%(p_module, pkg, str(e)), file=sys.stderr)
     return static_plugins, online_plugins
 


### PR DESCRIPTION
# What the PR changes

Add the content exception to print when `roswtf` failed to load a plugin.

# Targeted problem
When loading a wtf plugin failed the message looks something like the following without any info about the reason it was not loaded:
```
Loaded plugin tf.tfwtf
Unable to load plugin [B_utility.roswtf.B_wtf_plugin.py] from package [B_utility].
```

# Output with the proposed change
For the same context, error message prints the exception, which helps debugging.
```
Loaded plugin tf.tfwtf
Unable to load plugin [B_utility.roswtf.B_wtf_plugin.py] from package [B_utility]. Exception: [cannot import name RemovedMsgTypeA]
```
(In my case RemovedMsgTypeA is the message type that is the package depends on but is recently removed so not found).