### PR TITLE
Fix bare pointer in topic_tools::ShapeShifter

### DIFF
--- a/tools/topic_tools/src/shape_shifter.cpp
+++ b/tools/topic_tools/src/shape_shifter.cpp
@@ -38,24 +38,9 @@ using namespace topic_tools;
 
 bool ShapeShifter::uses_old_API_ = false;
 
-ShapeShifter::ShapeShifter()
-  :  typed(false),
-     msgBuf(NULL),
-     msgBufUsed(0),
-     msgBufAlloc(0)
-{ 
-}
+ShapeShifter::ShapeShifter() : typed(false) {}
 
-
-ShapeShifter::~ShapeShifter()
-{
-  if (msgBuf)
-    delete[] msgBuf;
-  
-  msgBuf = NULL;
-  msgBufAlloc = 0;
-}
-
+ShapeShifter::~ShapeShifter() {}
 
 std::string const& ShapeShifter::getDataType()          const { return datatype; }
 
@@ -88,6 +73,5 @@ ros::Publisher ShapeShifter::advertise(ros::NodeHandle& nh, const std::string& t
 
 uint32_t ShapeShifter::size() const
 {
-  return msgBufUsed;
+  return msgBuf.size();
 }
-


### PR DESCRIPTION
The copy constructor and copy assignment operator on the ShapeShifter class were wrong because the class was using a bare pointer for its internal buffer.  This was manifesting itself as double-free's for copy-assigned ShapeShifter objects.  This PR switches to using a std::vector, so the constructors are automatically handled correctly.

All the tests pass, and this has been verified to fix the issue running in a real node with the AddressSanitizer enabled.