### PR TITLE
[Windows][melodic-devel] Fixed test code build errors (cpp projects).

### DIFF
--- a/test/test_roscpp/test/src/service_adv_zombie.cpp
+++ b/test/test_roscpp/test/src/service_adv_zombie.cpp
@@ -34,6 +34,9 @@
 #include <test_roscpp/TestStringString.h>
 
 #include <stdlib.h>
+#ifdef _WIN32
+# include <windows.h>
+#endif
 
 bool srvCallback(test_roscpp::TestStringString::Request &,
                  test_roscpp::TestStringString::Response &res)

--- a/utilities/xmlrpcpp/test/test_dispatch_live.cpp
+++ b/utilities/xmlrpcpp/test/test_dispatch_live.cpp
@@ -30,6 +30,8 @@
 #include <sys/types.h>
 #ifndef _WIN32
 # include <sys/socket.h>
+#else
+# include <winsock2.h>
 #endif
 
 #include <iostream>


### PR DESCRIPTION
Added missing header inclusion to fix test code build errors on Windows build. Verified in https://aka.ms/ros project.