### PR TITLE
[Windows][melodic-devel] Skip `cat` related test cases on Windows build

### DIFF
--- a/test/test_roslaunch/test/params_basic.py
+++ b/test/test_roslaunch/test/params_basic.py
@@ -109,9 +109,13 @@ class TestParamsBasic(unittest.TestCase):
             text_data = f.read()
         with open(os.path.join(dir, 'resources', 'example.launch'), 'rb') as f:
             binary_data = f.read()
-        self.assertEquals(get_param("commandoutput"), binary_data)
+
+        # test 'command' attribute
+        if os.name != 'nt' : # skip testcase for `cat` command in Windows
+            self.assertEquals(get_param("commandoutput"), text_data)
+        # test 'textfile' attribute
         self.assertEquals(get_param("textfile"), text_data)
-        ## test 'binfile' attribute
+        # test 'binfile' attribute
         bindata = get_param("binaryfile")
         self.assertTrue(isinstance(bindata, Binary))
         self.assertEquals(bindata.data, binary_data)

--- a/test/test_roslaunch/test/params_basic.py
+++ b/test/test_roslaunch/test/params_basic.py
@@ -111,7 +111,7 @@ class TestParamsBasic(unittest.TestCase):
             binary_data = f.read()
 
         # test 'command' attribute
-        if os.name != 'nt' : # skip testcase for `cat` command in Windows
+        if os.name != 'nt':  # skip testcase for `cat` command in Windows
             self.assertEquals(get_param("commandoutput"), text_data)
         # test 'textfile' attribute
         self.assertEquals(get_param("textfile"), text_data)

--- a/test/test_roslaunch/test/params_basic.py
+++ b/test/test_roslaunch/test/params_basic.py
@@ -115,7 +115,7 @@ class TestParamsBasic(unittest.TestCase):
             self.assertEquals(get_param("commandoutput"), text_data)
         # test 'textfile' attribute
         self.assertEquals(get_param("textfile"), text_data)
-        # test 'binfile' attribute
+        ## test 'binfile' attribute
         bindata = get_param("binaryfile")
         self.assertTrue(isinstance(bindata, Binary))
         self.assertEquals(bindata.data, binary_data)

--- a/test/test_roslaunch/test/params_basic.py
+++ b/test/test_roslaunch/test/params_basic.py
@@ -112,7 +112,7 @@ class TestParamsBasic(unittest.TestCase):
 
         # test 'command' attribute
         if os.name != 'nt':  # skip testcase for `cat` command in Windows
-            self.assertEquals(get_param("commandoutput"), text_data)
+            self.assertEquals(get_param("commandoutput"), binary_data)
         # test 'textfile' attribute
         self.assertEquals(get_param("textfile"), text_data)
         ## test 'binfile' attribute

--- a/test/test_roslaunch/test/params_basic.test
+++ b/test/test_roslaunch/test/params_basic.test
@@ -60,7 +60,7 @@
   
   <param name="textfile" textfile="$(find roslaunch)/resources/example.launch" />
   <param name="binaryfile" binfile="$(find roslaunch)/resources/example.launch" />
-  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" />
+  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))" />
 
   <test test-name="params_basic" pkg="test_roslaunch" type="params_basic.py" />
 </launch>

--- a/tools/roslaunch/resources/example.launch
+++ b/tools/roslaunch/resources/example.launch
@@ -30,7 +30,7 @@
   <!-- upload the contents of a file as base64 binary as a param -->
   <param name="binaryfile" binfile="$(find roslaunch)/resources/example.launch" />
   <!-- upload the output of a command as a param. -->
-  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" />
+  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))" />
   
   <!-- Group a collection of tags. ns attribute is optional -->
   <group ns="wg"> 

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -220,7 +220,7 @@ class TestXmlLoader(unittest.TestCase):
         p = [p for p in mock.params if p.key == '/binaryfile'][0]
         self.assertEquals(Binary(contents.encode()), p.value, 1)
 
-        if os.name != 'nt': # skip testcase for `cat` command in Windows
+        if os.name != 'nt':  # skip testcase for `cat` command in Windows
             p = [p for p in mock.params if p.key == '/commandoutput'][0]
             self.assertEquals(contents, p.value, 1)
         

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -220,13 +220,9 @@ class TestXmlLoader(unittest.TestCase):
         p = [p for p in mock.params if p.key == '/binaryfile'][0]
         self.assertEquals(Binary(contents.encode()), p.value, 1)
 
-        f = open(os.path.join(get_example_path(), 'example.launch'))
-        try:
-            contents = f.read()
-        finally:
-            f.close()
-        p = [p for p in mock.params if p.key == '/commandoutput'][0]
-        self.assertEquals(contents, p.value, 1)
+        if os.name != 'nt': # skip testcase for `cat` command in Windows
+            p = [p for p in mock.params if p.key == '/commandoutput'][0]
+            self.assertEquals(contents, p.value, 1)
         
         
     def test_rosparam_valid(self):

--- a/tools/roslaunch/test/xml/test-params-valid.xml
+++ b/tools/roslaunch/test/xml/test-params-valid.xml
@@ -33,13 +33,13 @@
   <!-- upload the contents of a file as base64 binary as a param -->
   <param name="binaryfile" binfile="$(find roslaunch)/resources/example.launch" />
   <!-- upload the output of a command as a param. -->
-  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" />
+  <param name="commandoutput" command="cat &quot;$(find roslaunch)/resources/example.launch&quot;" unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))" />
 
   <!-- upload the output of a command as a param as types. -->
   <param name="commandoutputinteger" type="int" command="echo 0" />
   <param name="commandoutputdouble" type="double" command="echo 10" />
   <param name="commandoutputbool" type="bool" command="echo true" />
-  <param name="commandoutputyaml" type="yaml" command="cat &quot;$(find roslaunch)/test/params.yaml&quot;" />
+  <param name="commandoutputyaml" type="yaml" command="cat &quot;$(find roslaunch)/test/params.yaml&quot;" unless="$(eval optenv('OS', 'unknown').lower().startswith('windows'))" />
 
 
   <!-- test that we can override params -->


### PR DESCRIPTION
Skip test cases relying on `cat` on Windows build since it doesn't exist on Windows.