### PR TITLE
[Windows][melodic-devel] Use taskkill to terminate node process tree in LocalProcess.stop()

### DIFF
--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -471,48 +471,22 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
         # windows has no group id's :(
         try:
             # Start with SIGINT and escalate from there.
-            _logger.info("[%s] sending SIGINT to pgid [%s]", self.name, pid)
-            os.kill(pid, signal.SIGINT)
-            _logger.info("[%s] sent SIGINT to pgid [%s]", self.name, pid)
+            _logger.info("[%s] running taskkill pid tree [%s]", self.name, pid)
+            subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])
+            _logger.info("[%s] run taskkill pid tree [%s]", self.name, pid)
             timeout_t = time.time() + _TIMEOUT_SIGINT
             retcode = self.popen.poll()
             while time.time() < timeout_t and retcode is None:
                 time.sleep(0.1)
                 retcode = self.popen.poll()
-            # Escalate non-responsive process
             if retcode is None:
-                printerrlog("[%s] escalating to SIGTERM"%self.name)
-                timeout_t = time.time() + _TIMEOUT_SIGTERM
-                os.killpg(pid, signal.SIGTERM)
-                _logger.info("[%s] sent SIGTERM to pid [%s]"%(self.name, pid))
-                retcode = self.popen.poll()
-                while time.time() < timeout_t and retcode is None:
-                    time.sleep(0.2)
-                    _logger.debug('poll for retcode')
-                    retcode = self.popen.poll()
-                if retcode is None:
-                    printerrlog("[%s] escalating to SIGKILL"%self.name)
-                    errors.append("process[%s, pid %s]: required SIGKILL. May still be running."%(self.name, pid))
-                    try:
-                        os.killpg(pid, signal.SIGKILL)
-                        _logger.info("[%s] sent SIGKILL to pid [%s]"%(self.name, pid))
-                        # #2096: don't block on SIGKILL, because this results in more orphaned processes overall
-                        #self.popen.wait()
-                        #os.wait()
-                        _logger.info("process[%s]: sent SIGKILL", self.name)
-                    except OSError as e:
-                        if e.args[0] == 3:
-                            printerrlog("no [%s] process with pid [%s]"%(self.name, pid))
-                        else:
-                            printerrlog("errors shutting down [%s], see log for details"%self.name)
-                            _logger.error(traceback.format_exc())
-                else:
-                    _logger.info("process[%s]: SIGTERM killed with return value %s", self.name, retcode)
+                printerrlog("errors shutting down [%s], see log for details"%self.name)
+                _logger.error("errors shutting down [%s], see log for details"%self.name)
             else:
                 _logger.info("process[%s]: SIGINT killed with return value %s", self.name, retcode)
         finally:
             self.popen = None
-			
+
     def stop(self, errors=None):
         """
         Stop the process. Record any significant error messages in the errors parameter


### PR DESCRIPTION
There are many [restrictions](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/signal?view=vs-2019) when using `signal` on Windows. For example, `SIGTERM` is not actually generated and `SIGINT` is not supported for Win32 applications. In order to terminate the child processes from roslaunch, I proposed to use [`taskkill`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/taskkill) instead on Windows.