### PR TITLE
[Windows][melodic-devel] Fixed test code when running Python scripts and rosrun.

### DIFF
--- a/tools/rosmsg/test/test_rosmsg_command_line.py
+++ b/tools/rosmsg/test/test_rosmsg_command_line.py
@@ -53,7 +53,7 @@ class TestRosmsg(unittest.TestCase):
         sub = ['show', 'md5', 'package', 'packages', 'list']
         
         for cmd in ['rosmsg', 'rossrv']:
-            glob_cmd=[os.path.join(_SCRIPT_FOLDER, cmd)]
+            glob_cmd=[sys.executable, os.path.join(_SCRIPT_FOLDER, cmd)]
             output = Popen(glob_cmd, stdout=PIPE, env=self.new_environ).communicate()[0].decode()
             self.assert_('Commands' in output)
             output = Popen(glob_cmd+['-h'], stdout=PIPE, env=self.new_environ).communicate()[0].decode()
@@ -92,14 +92,14 @@ class TestRosmsg(unittest.TestCase):
 
     def test_cmd_list(self):
         # - multi-line
-        output1 = Popen([os.path.join(_SCRIPT_FOLDER,'rosmsg'), 'list'], stdout=PIPE).communicate()[0].decode()
+        output1 = Popen([sys.executable, os.path.join(_SCRIPT_FOLDER,'rosmsg'), 'list'], stdout=PIPE).communicate()[0].decode()
         l1 = [x.strip() for x in output1.split('\n') if x.strip()]
         for p in ['std_msgs/String', 'test_rosmaster/Floats']:
             self.assert_(p in l1)
         for p in ['std_srvs/Empty', 'roscpp/Empty']:
             self.assert_(p not in l1)
 
-        output1 = Popen([os.path.join(_SCRIPT_FOLDER,'rossrv'), 'list'], stdout=PIPE).communicate()[0].decode()
+        output1 = Popen([sys.executable, os.path.join(_SCRIPT_FOLDER,'rossrv'), 'list'], stdout=PIPE).communicate()[0].decode()
         l1 = [x.strip() for x in output1.split('\n') if x.strip()]
         for p in ['std_srvs/Empty', 'roscpp/Empty']:
             self.assert_(p in l1)

--- a/tools/rosmsg/test/test_rosmsgproto_command_line.py
+++ b/tools/rosmsg/test/test_rosmsgproto_command_line.py
@@ -49,7 +49,7 @@ import rosmsg
 
 from nose.plugins.skip import SkipTest
 
-ROSMSGPROTO_FN = [os.path.join(os.getcwd(), '../scripts/rosmsg-proto')]
+ROSMSGPROTO_FN = [sys.executable, os.path.join(os.getcwd(), '../scripts/rosmsg-proto')]
 _NO_DICT = True
 if "OrderedDict" in collections.__dict__:
     _NO_DICT = False

--- a/tools/topic_tools/test/args.py
+++ b/tools/topic_tools/test/args.py
@@ -38,13 +38,15 @@ PKG = 'topic_tools'
 
 import unittest
 import os
+import sys
 from subprocess import call
 
+rosrun_script = 'rosrun.bat' if sys.platform == 'win32' else 'rosrun'
 
 class TopicToolsTestCase(unittest.TestCase):
 
     def test_drop_invalid(self):
-        cmd = ['rosrun', 'topic_tools', 'drop']
+        cmd = [rosrun_script, 'topic_tools', 'drop']
         self.assertNotEquals(0, call(cmd))
         self.assertNotEquals(0, call(cmd + ['//', '1', '2', 'output']))
         self.assertNotEquals(0, call(cmd + ['input', '1', '2', 'output', 'extra']))
@@ -52,17 +54,17 @@ class TopicToolsTestCase(unittest.TestCase):
         self.assertNotEquals(0, call(cmd + ['input', '1', '0', 'output']))
 
     def test_mux_invalid(self):
-        cmd = ['rosrun', 'topic_tools', 'mux']
+        cmd = [rosrun_script, 'topic_tools', 'mux']
         self.assertNotEquals(0, call(cmd))
         self.assertNotEquals(0, call(cmd + ['//', 'input']))
 
     def test_switch_mux_invalid(self):
-        cmd = ['rosrun', 'topic_tools', 'switch_mux']
+        cmd = [rosrun_script, 'topic_tools', 'switch_mux']
         self.assertNotEquals(0, call(cmd))
         self.assertNotEquals(0, call(cmd + ['//', 'input']))
 
     def test_relay_invalid(self):
-        cmd = ['rosrun', 'topic_tools', 'relay']
+        cmd = [rosrun_script, 'topic_tools', 'relay']
         self.assertNotEquals(0, call(cmd))
         self.assertNotEquals(0, call(cmd + ['//', 'input']))
 


### PR DESCRIPTION
* On platforms without shebang support, Python executable needs to be added explicitly to run scripts.
* On Windows, `rosrun.bat` needs to be called explicitly from the test code.