### PR TITLE
[roslaunch] Missing args

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -726,7 +726,7 @@ class XmlLoader(loader.Loader):
             argv = sys.argv
 
         self._launch_tag(launch, ros_config, filename)
-        self.root_context = loader.LoaderContext(get_ros_namespace(), filename)
+        self.root_context = loader.LoaderContext(get_ros_namespace(argv=argv), filename)
         loader.load_sysargs_into_context(self.root_context, argv)
 
         if len(launch.getElementsByTagName('master')) > 0:


### PR DESCRIPTION
If you don't pass the args down to the `get_ros_namespace` call, then arguments may not get used when using a non-command-line set of args. 