### PR TITLE
roscpp/transport_udp: zero-initialize sockaddr_in object

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -62,6 +62,8 @@ TransportUDP::TransportUDP(PollSet* poll_set, int flags, int max_datagram_size)
 , expecting_read_(false)
 , expecting_write_(false)
 , is_server_(false)
+, server_address_{}
+, local_address_{}
 , server_port_(-1)
 , local_port_(-1)
 , poll_set_(poll_set)

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -157,7 +157,7 @@ bool TransportUDP::connect(const std::string& host, int port, int connection_id)
     return false;
   }
 
-  sockaddr_in sin;
+  sockaddr_in sin = {};
   sin.sin_family = AF_INET;
   if (inet_addr(host.c_str()) == INADDR_NONE)
   {


### PR DESCRIPTION
Fixed #1736. 