### PR TITLE
ServiceManager::unregisterService returns result of master::execute("unregisterService")

### DIFF
--- a/clients/roscpp/src/libros/service_manager.cpp
+++ b/clients/roscpp/src/libros/service_manager.cpp
@@ -200,9 +200,7 @@ bool ServiceManager::unregisterService(const std::string& service)
            network::getHost().c_str(), connection_manager_->getTCPPort());
   args[2] = string(uri_buf);
 
-  master::execute("unregisterService", args, result, payload, false);
-
-  return true;
+  return master::execute("unregisterService", args, result, payload, false);
 }
 
 bool ServiceManager::isServiceAdvertised(const string& serv_name)


### PR DESCRIPTION
`ServiceManager::unregisterService` returns result of `master::execute("unregisterService")`

fix #1744