### PR TITLE
Add missing comma in the list of strings

### DIFF
--- a/clients/rospy/src/rospy/__init__.py
+++ b/clients/rospy/src/rospy/__init__.py
@@ -96,7 +96,7 @@ __all__ = [
     'INFO',
     'WARN',
     'ERROR',
-    'FATAL'
+    'FATAL',
     'is_shutdown',
     'signal_shutdown',
     'get_node_uri',


### PR DESCRIPTION
The missing comma will implicitly concatenate the string "FATAL" and "is_shutdown" together.