### PR TITLE
Fixing zip python3 error

### DIFF
--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -279,7 +279,7 @@ class ApproximateTimeSynchronizer(TimeSynchronizer):
                 return
             topic_stamps = sorted(topic_stamps, key=lambda x: x[1])
             stamps.append(topic_stamps)
-        for vv in itertools.product(*[zip(*s)[0] for s in stamps]):
+        for vv in itertools.product(*[next(iter(zip(*s))) for s in stamps]):
             vv = list(vv)
             # insert the new message
             if my_queue_index is not None:


### PR DESCRIPTION
zip returns an iterator in Python3 where as it returns list in Python2. 
Thus changing it to be compatible with both Python2 and Python3.

Useful resources - https://stackoverflow.com/questions/27431390/typeerror-zip-object-is-not-subscriptable