### PR TITLE
fix lower bound of signed int

### DIFF
--- a/test/test_rospy/test/unit/test_genmsg_py.py
+++ b/test/test_rospy/test/unit/test_genmsg_py.py
@@ -264,7 +264,7 @@ class TestGenmsgPy(unittest.TestCase):
         widths = [(8, Int8), (16, Int16), (32, Int32), (64, Int64)]
         for w, cls in widths:
             maxp = long(math.pow(2, w-1)) - 1
-            maxn = -long(math.pow(2, w-1)) + 1
+            maxn = -long(math.pow(2, w-1))
             self._test_ser_deser(cls(maxp), cls())
             self._test_ser_deser(cls(maxn), cls())
             try:


### PR DESCRIPTION
Follow up of ros/genpy#102.

Needs a new patch release of `genpy`.