### PR TITLE
 more Python 3 compatibility - truncate(0) needs seek(0)

### DIFF
--- a/test/test_rospy/test/unit/test_rospy_msg.py
+++ b/test/test_rospy/test/unit/test_rospy_msg.py
@@ -210,6 +210,7 @@ class TestRospyMsg(unittest.TestCase):
 
         #deserialize multiple values
         b.truncate(0)
+        b.seek(0)
         for v in valids:
             b.write(v)
         rospy.msg.deserialize_messages(b, msg_queue, data_class)
@@ -223,6 +224,7 @@ class TestRospyMsg(unittest.TestCase):
         #deserialize multiple values with max_msgs
         max_msgs = 5
         b.truncate(0)
+        b.seek(0)
         for v in valids:
             b.write(v)
         rospy.msg.deserialize_messages(b, msg_queue, data_class, max_msgs=max_msgs)


### PR DESCRIPTION
Follow up of #1784.

When doing the following in Python 2 the buffer position is reset to `0` by the `truncate` call (in contrast to what you would expect from the [docs](https://docs.python.org/2/library/io.html#io.IOBase.truncate)):

```
from cStringIO import StringIO
StringIO('foo')
s.tell()  # 0
s.read(2)  # 'fo'
s.tell()  # 2
s.truncate(0)
s.tell()  # 0 **surprise**
```

In Python 3 that is not the case (matching  what the [docs](https://docs.python.org/3/library/io.html#io.IOBase.truncate) claim):

```
from io import StringIO  # same for BytesIO
s = StringIO('foo')
s.tell()  # 0
s.read(2)  # 'fo'
s.tell()  # 2
s.truncate(0)  # 0
s.tell()  # 2
```

Therefore this patch inserts some `seek(0)` calls where the tests relied on the read position to be reset.

:crossed_fingers: hopefully that isn't an issue in other code not covered by tests...