### PR TITLE
Make log config from rosgraph optional

### DIFF
--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -154,10 +154,14 @@ def configure_logging(logname, level=logging.INFO, filename=None, env=None):
     if not config_file:
         # search for logging config file in ROS_HOME, ROS_ETC_DIR or relative
         # to the rosgraph package directory.
-        rosgraph_d = rospkg.RosPack().get_path('rosgraph')
-        for config_dir in [os.path.join(rospkg.get_ros_home(), 'config'),
-                           rospkg.get_etc_ros_dir(),
-                           os.path.join(rosgraph_d, 'conf')]:
+        config_dirs = [os.path.join(rospkg.get_ros_home(), 'config'),
+                       rospkg.get_etc_ros_dir()]
+        try:
+            config_dirs.append(os.path.join(
+                rospkg.RosPack().get_path('rosgraph'), 'conf'))
+        except rospkg.common.ResourceNotFound:
+            pass
+        for config_dir in config_dirs:
             for extension in ('conf', 'yaml'):
                 f = os.path.join(config_dir,
                                  'python_logging{}{}'.format(os.path.extsep,


### PR DESCRIPTION
Hi,

I'm trying to run ``rospy`` in a pure Python environment.
Currently ``rospy.init_node()`` always fails because ``rospkg.RosPack().get_path('rosgraph')`` fails in a pure Python environment(see below).

This PR enables that ``init_node`` does not fail even when rosgraph cannot be found by rospkg.

Thank you.
```
>>> rospy.init_node('test')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/otamachan/proj/rospy/venv/lib/python3.6/site-packages/rospy/client.py", line 309, in init_node
    rospy.core.configure_logging(resolved_node_name)
  File "/home/otamachan/proj/rospy/venv/lib/python3.6/site-packages/rospy/core.py", line 405, in configure_logging
    _log_filename = rosgraph.roslogging.configure_logging('rospy', level, filename=filename)
  File "/home/otamachan/proj/rospy/venv/lib/python3.6/site-packages/rosgraph/roslogging.py", line 156, in configure_logging
    rosgraph_d = rospkg.RosPack().get_path('rosgraph')
  File "/home/otamachan/proj/rospy/venv/lib/python3.6/site-packages/rospkg/rospack.py", line 203, in get_path
    raise ResourceNotFound(name, ros_paths=self._ros_paths)
rospkg.common.ResourceNotFound: rosgraph
```