### PR TITLE
trim stdout lines to less than 80 characters

### DIFF
--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -40,6 +40,8 @@
   #include <sys/select.h>
 #endif
 
+#include <sys/ioctl.h>
+
 #include <boost/format.hpp>
 
 #include "rosgraph_msgs/Clock.h"
@@ -379,22 +381,28 @@ void Player::printTime()
 {
     if (!options_.quiet) {
 
+        // get terminal size
+        struct winsize wsize;
+        ioctl(STDOUT_FILENO, TIOCGWINSZ, &wsize);
+        // clear line with empty characters
+        printf("\r%*c\r", wsize.ws_col, '\0');
+
         ros::Time current_time = time_publisher_.getTime();
         ros::Duration d = current_time - start_time_;
 
 
         if (paused_)
         {
-            printf("\r [PAUSED ]  Bag Time: %13.6f   Duration: %.6f / %.6f               \r", time_publisher_.getTime().toSec(), d.toSec(), bag_length_.toSec());
+            printf("[PAUSED ]  Bag Time: %13.6f   Duration: %.6f / %.6f", time_publisher_.getTime().toSec(), d.toSec(), bag_length_.toSec());
         }
         else if (delayed_)
         {
             ros::Duration time_since_rate = std::max(ros::Time::now() - last_rate_control_, ros::Duration(0));
-            printf("\r [DELAYED]  Bag Time: %13.6f   Duration: %.6f / %.6f   Delay: %.2f \r", time_publisher_.getTime().toSec(), d.toSec(), bag_length_.toSec(), time_since_rate.toSec());
+            printf("[DELAYED]  Bag Time: %13.6f   Duration: %.6f / %.6f   Delay: %.2f", time_publisher_.getTime().toSec(), d.toSec(), bag_length_.toSec(), time_since_rate.toSec());
         }
         else
         {
-            printf("\r [RUNNING]  Bag Time: %13.6f   Duration: %.6f / %.6f               \r", time_publisher_.getTime().toSec(), d.toSec(), bag_length_.toSec());
+            printf("[RUNNING]  Bag Time: %13.6f   Duration: %.6f / %.6f", time_publisher_.getTime().toSec(), d.toSec(), bag_length_.toSec());
         }
         fflush(stdout);
     }


### PR DESCRIPTION
The stdout output from `rosbag play` (.e.g. ` [RUNNING]  Bag Time: 1555604159.419860   Duration: 2.043711 / 81.562797`) is typically longer than 80 characters since it adds unnecessary whitespace at the end. For standard sized terminals widths (80 characters), this leads to a new line for every printout and thus spams the terminal.

This PR simply removes the padded whitespace and should fix the issue (unless you have log files that are longer than 99999 seconds).