### PR TITLE
[Windows][melodic-devel][roslaunch] Escape `:` when passing a path to roslaunch_add_file_check

### DIFF
--- a/tools/roslaunch/cmake/roslaunch-extras.cmake.em
+++ b/tools/roslaunch/cmake/roslaunch-extras.cmake.em
@@ -50,6 +50,8 @@ function(roslaunch_add_file_check path)
     set(testname "${testname}${_ext}")
   endif()
 
+  # escape drive and path separator
+  string(REPLACE ":" "_" testname ${testname})
   string(REPLACE "/" "_" testname ${testname})
   set(output_path ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME})
   set(cmd "${CMAKE_COMMAND} -E make_directory ${output_path}")


### PR DESCRIPTION
On Windows, when a `catkin` package uses `roslaunch_add_file_check` for checking launch file, an error will be thrown as below:
```
CMake Error: Cannot open file for write: C:/Users/alec/Documents/catkin_ws/build/JACO/ar_track_alvar/ar_track_alvar/CMakeFiles/_run_tests_ar_track_alvar_roslaunch-check_C:_Users_alec_Documents_catkin_ws_src_JACO_ar_track_alvar_ar_track_alvar_test_marker_arg_config-full.test.dir/build.make.tmp
CMake Error: : System Error: Invalid argument
CMake Error: Could not create C:/Users/alec/Documents/catkin_ws/build/JACO/ar_track_alvar/ar_track_alvar/CMakeFiles/_run_tests_ar_track_alvar_roslaunch-check_C:_Users_alec_Documents_catkin_ws_src_JACO_ar_track_alvar_ar_track_alvar_test_marker_arg_config-full.test.dir/cmake_clean.cmake
```

The root cause is that the `roslaunch_add_file_check` doesn't escape the drive separator `:` in its current implementation. To fix, I am proposing to simply add `:` into the escape logic.

FYI, this fixes https://github.com/ms-iot/ROSOnWindows/issues/93