### PR TITLE
[Windows][melodic-devel] workaround WSAPoll doesn't report failed connections.

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -14,6 +14,7 @@
 static int poll( struct pollfd *pfd, int nfds, int timeout)
 {
   // workaround: "Windows 8 Bugs 309411 – WSAPoll does not report failed connections"
+  // https://curl.haxx.se/mail/lib-2012-10/0038.html
   // the following logic is to use select() to check all writable socket connnection status.
   // if all the sockets to be checked are not connected, it reports SOCKET_ERROR to
   // error out, instead of going to WSAPoll() which causes infinitely wait situation.

--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -11,9 +11,56 @@
 
 #if defined(_WINDOWS)
 # include <winsock2.h>
-static inline int poll( struct pollfd *pfd, int nfds, int timeout)
+static int poll( struct pollfd *pfd, int nfds, int timeout)
 {
-  return WSAPoll(pfd, nfds, timeout);
+  // workaround: "Windows 8 Bugs 309411 – WSAPoll does not report failed connections"
+  // the following logic is to use select() to check all writable socket connnection status.
+  // if all the sockets to be checked are not connected, it reports SOCKET_ERROR to
+  // error out, instead of going to WSAPoll() which causes infinitely wait situation.
+  FD_SET writable;
+  FD_SET error;
+  FD_ZERO(&writable);
+  FD_ZERO(&error);
+  for (int i = 0; i < nfds; ++i)
+  {
+    if (pfd[i].events & POLLOUT)
+    {
+      FD_SET(pfd[i].fd, &writable);
+      FD_SET(pfd[i].fd, &error);
+    }
+  }
+
+  int connectionError = 0;
+  if (writable.fd_count > 0)
+  {
+    int result = select(0, nullptr, &writable, &error, nullptr);
+    if (SOCKET_ERROR == result)
+    {
+      return SOCKET_ERROR;
+    }
+
+    if (0 != result)
+    {
+      for (int i = 0; i < nfds; ++i)
+      {
+        if ((pfd[i].events & POLLOUT) &&
+            (FD_ISSET(pfd[i].fd, &error)))
+        {
+          connectionError++;
+        }
+      }
+    }
+  }
+
+  if (connectionError == nfds)
+  {
+    // error out if all sockets are failed to connect.
+    return SOCKET_ERROR;
+  }
+  else
+  {
+    return WSAPoll(pfd, nfds, timeout);
+  }
 }
 
 # define USE_FTIME


### PR DESCRIPTION
This fixes https://github.com/ms-iot/ROSOnWindows/issues/151

The original problem manifests as `ros::master::check()` never return back when the `master` is not running. It turns out that it is waiting for [`WSAPoll`](https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll) to be returned, which is at this below line:

https://github.com/ros/ros_comm/blob/d487d5877049d61fe2ebcc6487e9a7a72d9f0346/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp#L125

However, for a non-blocking socket which has a failed connection, `WSAPoll` exhibits a behavior which is not to signal this error for the caller, and with the infinite timeout, it just waits forever. There are many [discussions](https://www.bing.com/search?q=%22Windows+8+Bugs+309411+%E2%80%93+WSAPoll+does+not+report+failed+connections%22) about this behavior.

To workaround this issue, I am proposing for Windows platform adding a connection readiness pre-checks for writable sockets, which can be done by calling [`select`](https://docs.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-select) and it will come back with a result immediately whether it is an `connection-error` socket or `writable-ready` socket. After we have the result, we can decide to error out or go ahead with the original `WSAPoll` to finish its job.