### PR TITLE
Bug: roslib not being imported

### DIFF
--- a/tools/rosbag/scripts/fix_msg_defs.py
+++ b/tools/rosbag/scripts/fix_msg_defs.py
@@ -35,6 +35,7 @@ from __future__ import print_function
 
 import sys
 import rosbag.migration
+import roslib
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:

--- a/tools/rosbag/scripts/fix_msg_defs.py
+++ b/tools/rosbag/scripts/fix_msg_defs.py
@@ -35,7 +35,7 @@ from __future__ import print_function
 
 import sys
 import rosbag.migration
-import roslib
+import roslib.message
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:


### PR DESCRIPTION
Case: Running fix_msg_defs.py script and the message type is not found.
Symptom: Script fails with the error message:
```
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/rosbag/fix_msg_defs.py", line 64, in <module>
    systype = roslib.message.get_message_class(msg[0])
NameError: name 'roslib' is not defined
```
Location: [line 64 of fix_msg_defs.py](https://github.com/ros/ros_comm/blob/d487d5877049d61fe2ebcc6487e9a7a72d9f0346/tools/rosbag/scripts/fix_msg_defs.py#L64) in rosbag/scripts.
Solution: Import roslib.message

I currently run into this issue when attempting to process ros messages that have had the comments stripped out of them. Importing roslib.message fixes the issue.