### PR TITLE
[Windows][melodic] Python 3 compatibility.

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -44,6 +44,7 @@ The common entry point for most libraries is the L{XmlRpcNode} class.
 
 import errno
 import logging
+import os
 import select
 import socket
 
@@ -129,14 +130,18 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
             logger = logging.getLogger('xmlrpc')
             if logger:
                 logger.error(traceback.format_exc())
-    
-class ForkingXMLRPCServer(socketserver.ForkingMixIn, SimpleXMLRPCServer):
-    """
-    Adds ThreadingMixin to SimpleXMLRPCServer to support multiple concurrent
-    requests via forking. Also makes logging toggleable.      
-    """
-    def __init__(self, addr, request_handler=SilenceableXMLRPCRequestHandler, log_requests=1):
-        SimpleXMLRPCServer.__init__(self, addr, request_handler, log_requests)
+
+
+# ForkingMixIn and the Forking classes mentioned below are only available on POSIX 
+# platforms that support fork().
+if hasattr(os, "fork"):
+    class ForkingXMLRPCServer(socketserver.ForkingMixIn, SimpleXMLRPCServer):
+        """
+        Adds ThreadingMixin to SimpleXMLRPCServer to support multiple concurrent
+        requests via forking. Also makes logging toggleable.      
+        """
+        def __init__(self, addr, request_handler=SilenceableXMLRPCRequestHandler, log_requests=1):
+            SimpleXMLRPCServer.__init__(self, addr, request_handler, log_requests)
     
 
 class XmlRpcHandler(object):

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -44,7 +44,6 @@ The common entry point for most libraries is the L{XmlRpcNode} class.
 
 import errno
 import logging
-import os
 import select
 import socket
 
@@ -132,9 +131,8 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
                 logger.error(traceback.format_exc())
 
 
-# ForkingMixIn and the Forking classes mentioned below are only available on POSIX 
-# platforms that support fork().
-if hasattr(os, "fork"):
+# ForkingMixIn and the Forking classes mentioned below are only available on POSIX platforms.
+if hasattr(socketserver, "ForkingMixIn"):
     class ForkingXMLRPCServer(socketserver.ForkingMixIn, SimpleXMLRPCServer):
         """
         Adds ThreadingMixin to SimpleXMLRPCServer to support multiple concurrent


### PR DESCRIPTION
On Python3 & Windows, the code path of [`socketserver.ForkingMixIn`](https://docs.python.org/3.7/library/socketserver.html#socketserver.ForkingMixIn) will be exercised and reported as an exception (shown below) because it is not available on Windows.

```
(py37) c:\workspace\conda_ros>roscore
Traceback (most recent call last):
  File "C:\workspace\conda_ros\install_isolated\bin\roscore", line 36, in <module>
    from rosmaster.master_api import NUM_WORKERS
  File "C:\workspace\conda_ros\install_isolated\lib\site-packages\rosmaster\__init__.py", line 35, in <module>
    from .main import rosmaster_main
  File "C:\workspace\conda_ros\install_isolated\lib\site-packages\rosmaster\main.py", line 43, in <module>
    import rosmaster.master
  File "C:\workspace\conda_ros\install_isolated\lib\site-packages\rosmaster\master.py", line 45, in <module>
    import rosgraph.xmlrpc
  File "C:\workspace\conda_ros\install_isolated\lib\site-packages\rosgraph\xmlrpc.py", line 133, in <module>
    class ForkingXMLRPCServer(socketserver.ForkingMixIn, SimpleXMLRPCServer):
AttributeError: module 'socketserver' has no attribute 'ForkingMixIn'
```

In this pull request, I am proposing to use conditional check for it.