### PR TITLE
[windows][melodic] use c++11 std::snprintf

### DIFF
--- a/clients/roscpp/src/libros/file_log.cpp
+++ b/clients/roscpp/src/libros/file_log.cpp
@@ -34,14 +34,6 @@
 
 #include <boost/filesystem.hpp>
 
-#ifdef _MSC_VER
-  #ifdef snprintf
-    #undef snprintf
-  #endif
-  #define snprintf _snprintf_s
-#endif
-
-
 namespace fs = boost::filesystem;
 
 namespace ros
@@ -112,7 +104,7 @@ void init(const M_string& remappings)
       }
 
       char pid_str[100];
-      snprintf(pid_str, sizeof(pid_str), "%d", pid);
+      std::snprintf(pid_str, sizeof(pid_str), "%d", pid);
       log_file_name += std::string("_") + std::string(pid_str) + std::string(".log");
     }
 

--- a/clients/roscpp/src/libros/service_manager.cpp
+++ b/clients/roscpp/src/libros/service_manager.cpp
@@ -146,7 +146,7 @@ bool ServiceManager::advertiseService(const AdvertiseServiceOptions& ops)
   args[0] = this_node::getName();
   args[1] = ops.service;
   char uri_buf[1024];
-  snprintf(uri_buf, sizeof(uri_buf), "rosrpc://%s:%d",
+  std::snprintf(uri_buf, sizeof(uri_buf), "rosrpc://%s:%d",
            network::getHost().c_str(), connection_manager_->getTCPPort());
   args[2] = string(uri_buf);
   args[3] = xmlrpc_manager_->getServerURI();
@@ -196,7 +196,7 @@ bool ServiceManager::unregisterService(const std::string& service)
   args[0] = this_node::getName();
   args[1] = service;
   char uri_buf[1024];
-  snprintf(uri_buf, sizeof(uri_buf), "rosrpc://%s:%d",
+  std::snprintf(uri_buf, sizeof(uri_buf), "rosrpc://%s:%d",
            network::getHost().c_str(), connection_manager_->getTCPPort());
   args[2] = string(uri_buf);
 

--- a/clients/roscpp/src/libros/this_node.cpp
+++ b/clients/roscpp/src/libros/this_node.cpp
@@ -31,13 +31,6 @@
 #include "ros/topic_manager.h"
 #include "ros/init.h"
 
-#ifdef _MSC_VER
-  #ifdef snprintf
-    #undef snprintf
-  #endif
-  #define snprintf _snprintf_s
-#endif
-
 namespace ros
 {
 
@@ -172,7 +165,7 @@ void ThisNode::init(const std::string& name, const M_string& remappings, uint32_
   if (options & init_options::AnonymousName && !disable_anon)
   {
     char buf[200];
-    snprintf(buf, sizeof(buf), "_%llu", (unsigned long long)WallTime::now().toNSec());
+    std::snprintf(buf, sizeof(buf), "_%llu", (unsigned long long)WallTime::now().toNSec());
     name_ += buf;
   }
 

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcUtil.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcUtil.h
@@ -14,8 +14,6 @@
 #include "xmlrpcpp/XmlRpcDecl.h"
 
 #if defined(_MSC_VER)
-# define snprintf	    _snprintf_s
-# define vsnprintf    _vsnprintf_s
 # define strcasecmp	  _stricmp
 # define strncasecmp	_strnicmp
 #elif defined(__BORLANDC__)

--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -327,12 +327,12 @@ XmlRpcClient::generateHeader(size_t length) const
   header += _host;
 
   char buff[40];
-  snprintf(buff,40,":%d\r\n", _port);
+  std::snprintf(buff,40,":%d\r\n", _port);
 
   header += buff;
   header += "Content-Type: text/xml\r\nContent-length: ";
 
-  snprintf(buff,40,"%zu\r\n\r\n", length);
+  std::snprintf(buff,40,"%zu\r\n\r\n", length);
 
   return header + buff;
 }

--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -375,11 +375,7 @@ std::string
 XmlRpcSocket::getErrorMsg(int error)
 {
   char err[60];
-#ifdef _MSC_VER
-  strerror_s(err,60,error);
-#else
-  snprintf(err,sizeof(err),"%s",strerror(error));
-#endif
+  std::snprintf(err,sizeof(err),"%s",strerror(error));
   return std::string(err);
 }
 

--- a/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
@@ -84,7 +84,7 @@ void XmlRpcUtil::log(int level, const char* fmt, ...)
     va_list va;
     char buf[1024];
     va_start( va, fmt);
-    vsnprintf(buf,sizeof(buf)-1,fmt,va);
+    std::vsnprintf(buf,sizeof(buf)-1,fmt,va);
     va_end(va);
     buf[sizeof(buf)-1] = 0;
     XmlRpcLogHandler::getLogHandler()->log(level, buf);
@@ -97,7 +97,7 @@ void XmlRpcUtil::error(const char* fmt, ...)
   va_list va;
   va_start(va, fmt);
   char buf[1024];
-  vsnprintf(buf,sizeof(buf)-1,fmt,va);
+  std::vsnprintf(buf,sizeof(buf)-1,fmt,va);
   va_end(va);
   buf[sizeof(buf)-1] = 0;
   XmlRpcErrorHandler::getErrorHandler()->error(buf);

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -324,7 +324,7 @@ namespace XmlRpc {
   std::string XmlRpcValue::intToXml() const
   {
     char buf[256];
-    snprintf(buf, sizeof(buf)-1, "%d", _value.asInt);
+    std::snprintf(buf, sizeof(buf)-1, "%d", _value.asInt);
     buf[sizeof(buf)-1] = 0;
     std::string xml = VALUE_TAG;
     xml += I4_TAG;
@@ -434,7 +434,7 @@ namespace XmlRpc {
   {
     struct tm* t = _value.asTime;
     char buf[20];
-    snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d", 
+    std::snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d", 
       t->tm_year,t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
     buf[sizeof(buf)-1] = 0;
 
@@ -610,7 +610,7 @@ namespace XmlRpc {
         {
           struct tm* t = _value.asTime;
           char buf[20];
-          snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d", 
+          std::snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d", 
             t->tm_year,t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
           buf[sizeof(buf)-1] = 0;
           os << buf;

--- a/utilities/xmlrpcpp/test/mock_socket.cpp
+++ b/utilities/xmlrpcpp/test/mock_socket.cpp
@@ -49,11 +49,7 @@ std::string XmlRpcSocket::getErrorMsg() {
 // NOTE(austin): this matches the default implementation.
 std::string XmlRpcSocket::getErrorMsg(int error) {
   char err[60];
-#ifdef _MSC_VER
-  strerror_s(err, 60, error);
-#else
-  snprintf(err, sizeof(err), "%s", strerror(error));
-#endif
+  std::snprintf(err, sizeof(err), "%s", strerror(error));
   return std::string(err);
 }
 


### PR DESCRIPTION
This pull request is in favor of `C++11` `std::snprintf` usage and to remove MSVC specific CRT functions [`_snprintf_s`](https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-s-snprintf-s-l-snwprintf-s-snwprintf-s-l?view=vs-2019).

This change is motivated by a name conflicts against `Boost`. Beginning from `Boost v1.69`, a new addition [`system_category_win32.hpp`](https://github.com/boostorg/system/blob/develop/include/boost/system/detail/system_category_win32.hpp) is added to `Boost.System`, and in this header, [it](https://github.com/boostorg/system/blob/3a4fff686e81320d346304b978f866c4136bd863/include/boost/system/detail/system_category_win32.hpp#L52) refers to `std::snprintf` in a code path. And because `snprintf` has been redefined as `_snprintf_s` in many places in `ros_comm`, it subsequently replaces `std::snprintf` with `std::_snprintf_s` and results in compiler errors. 