### PR TITLE
[windows][melodic-devel] Add alternative lz4 library name

### DIFF
--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -13,7 +13,7 @@ if (NOT lz4_INCLUDE_DIRS)
   message(FATAL_ERROR "lz4 includes not found")
 endif()
 
-find_library(lz4_LIBRARIES NAMES lz4)
+find_library(lz4_LIBRARIES NAMES lz4 liblz4)
 if (NOT lz4_LIBRARIES)
   message(FATAL_ERROR "lz4 library not found")
 endif()


### PR DESCRIPTION
This pull request is to add another commonly seen `lz4` library name on Windows. This change is motivated by that `CMake` fails to find `lz4`, when building it against `lz4` built from its [visual studio solution file](https://github.com/lz4/lz4/tree/dev/visual/VS2017).