### PR TITLE
Allowed empty ssh password for remote launching

### DIFF
--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -347,7 +347,7 @@ class Machine(object):
         self.name = name
         self.env_loader = env_loader
         self.user = user or None
-        self.password = password or None
+        self.password = password
         self.address = address
         self.ssh_port = ssh_port
         self.assignable = assignable

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -186,7 +186,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         if not err_msg:
             username_str = '%s@'%username if username else ''
             try:
-                if not password: #use SSH agent
+                if password is None: #use SSH agent
                     ssh.connect(address, port, username, timeout=TIMEOUT_SSH_CONNECT, key_filename=identity_file)
                 else: #use SSH with login/pass
                     ssh.connect(address, port, username, password, timeout=TIMEOUT_SSH_CONNECT)


### PR DESCRIPTION
Bug in `roslaunch` doesn't allow to use empty ssh passwords.

E.g. If we try following machine definition:
```
<machine
  name="mmm"
  address="10.20.73.2"
  user="root"
  password=""
  timeout="10"
  env-loader="/path/to/remote-env.sh"
/>
```
Empty string is going to be replaced with `None` here: https://github.com/ros/ros_comm/blob/d39a5ec1c93ede36129b9393cf462b8cf7a83066/tools/roslaunch/src/roslaunch/core.py#L350 
(because empty strings are being treated as `False` in boolean operations).
Then, instead of authenticating using empty password, `roslauch` will attempt to use a key: https://github.com/ros/ros_comm/blob/767174722ef95249aeaced2103acb703c302d13c/tools/roslaunch/src/roslaunch/remoteprocess.py#L189 

After the change (this pull request) everything works as expected:

Case | Result
--- | ---
`password="abc"` | authentication using password
`password=""` | authentication using (empty) password
`password` attribute absent in machine definition | authentication using key