### PR TITLE
fix escape sequences in regular expressions

### DIFF
--- a/tools/rosgraph/src/rosgraph/names.py
+++ b/tools/rosgraph/src/rosgraph/names.py
@@ -212,7 +212,7 @@ def load_mappings(argv):
 import re
 
 #~,/, or ascii char followed by (alphanumeric, _, /)
-NAME_LEGAL_CHARS_P = re.compile('^[\~\/A-Za-z][\w\/]*$')
+NAME_LEGAL_CHARS_P = re.compile(r'^[\~\/A-Za-z][\w\/]*$')
 def is_legal_name(name):
     """
     Check if name is a legal ROS name for graph resources
@@ -232,7 +232,7 @@ def is_legal_name(name):
     m = NAME_LEGAL_CHARS_P.match(name)
     return m is not None and m.group(0) == name and not '//' in name
     
-BASE_NAME_LEGAL_CHARS_P = re.compile('^[A-Za-z][\w]*$') #ascii char followed by (alphanumeric, _)
+BASE_NAME_LEGAL_CHARS_P = re.compile(r'^[A-Za-z][\w]*$') #ascii char followed by (alphanumeric, _)
 def is_legal_base_name(name):
     """
     Validates that name is a legal base name for a graph resource. A base name has
@@ -243,7 +243,7 @@ def is_legal_base_name(name):
     m = BASE_NAME_LEGAL_CHARS_P.match(name)
     return m is not None and m.group(0) == name
 
-REMAP_PATTERN = re.compile('^([\~\/A-Za-z]|_|__)[\w\/]*' + REMAP + '.*')
+REMAP_PATTERN = re.compile(r'^([\~\/A-Za-z]|_|__)[\w\/]*' + REMAP + '.*')
 
 def is_legal_remap(arg):
     """

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -110,7 +110,7 @@ try:
             log_out = ' '.join([
                 'INFO',
                 'on ' + loc,
-                '[0-9]*\.[0-9]*',
+                r'[0-9]*\.[0-9]*',
                 '[0-9]*',
                 'rosout',
                 re.escape(this_file),
@@ -118,7 +118,7 @@ try:
                 function,
                 # depending if rospy.get_name() is available
                 '(/unnamed|<unknown_node_name>)',
-                '[0-9]*\.[0-9]*',
+                r'[0-9]*\.[0-9]*',
             ])
             assert_regexp_matches(lout.getvalue().splitlines()[i], log_out)
 

--- a/tools/rosgraph/test/test_roslogging_user_logger.py
+++ b/tools/rosgraph/test/test_roslogging_user_logger.py
@@ -127,7 +127,7 @@ def test_roslogging_user_logger():
             'INFO',
             os.environ['ROS_IP'],
             msg,
-            '[0-9]*\.[0-9]*',
+            r'[0-9]*\.[0-9]*',
             '[0-9]*',
             'rosout.custom_logger_test',
             '<filename>',
@@ -135,7 +135,7 @@ def test_roslogging_user_logger():
             '<func_name>',
             # depending if rospy.get_name() is available
             '(/unnamed|<unknown_node_name>)',
-            '[0-9]*\.[0-9]*',
+            r'[0-9]*\.[0-9]*',
         ])
         assert_regexp_matches(lout.getvalue().strip(), log_expected)
 


### PR DESCRIPTION
Using backslashes as escape sequences for regular expressions requires either escaping them from Python or using raw strings. (The current code causes warnings in recent Python versions.)