### PR TITLE
[kinetic] Switch to yaml.safe_load

### DIFF
--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -101,7 +101,7 @@ def load_command_line_node_params(argv):
                 src, dst = [x.strip() for x in arg.split(rosgraph.names.REMAP)]
                 if src and dst:
                     if len(src) > 1 and src[0] == '_' and src[1] != '_':
-                        mappings[src[1:]] = yaml.load(dst)
+                        mappings[src[1:]] = yaml.safe_load(dst)
         return mappings
     except Exception as e:
         raise rospy.exceptions.ROSInitException("invalid command-line parameters: %s"%(str(e)))

--- a/test/test_roslib_comm/test/test_roslib_message.py
+++ b/test/test_roslib_comm/test/test_roslib_message.py
@@ -61,7 +61,7 @@ class MessageTest(unittest.TestCase):
         def roundtrip(m):
             yaml_text = strify_message(m)
             print(yaml_text)
-            loaded = yaml.load(yaml_text) 
+            loaded = yaml.safe_load(yaml_text) 
             print("loaded", loaded)
             new_inst = m.__class__()
             if loaded is not None:

--- a/test/test_rosmaster/test/client_verification/test_slave_api.py
+++ b/test/test_rosmaster/test/client_verification/test_slave_api.py
@@ -106,7 +106,7 @@ class TestSlaveApi(unittest.TestCase):
     def load_profile(self, filename):
         import yaml
         with open(filename) as f:
-            d = yaml.load(f)
+            d = yaml.safe_load(f)
         self.required_pubs = d.get('pubs', {})
         self.required_subs = d.get('subs', {})
         

--- a/test/test_rosparam/test/check_rosparam.py
+++ b/test/test_rosparam/test/check_rosparam.py
@@ -227,7 +227,7 @@ class TestRosparam(unittest.TestCase):
         with fakestdout() as b:
             rosparam.yamlmain([cmd, 'get', "g1"])
             import yaml
-            d = yaml.load(b.getvalue())
+            d = yaml.safe_load(b.getvalue())
             self.assertEquals(d['float'], 10.0)
             self.assertEquals(d['int'], 10.0)
             self.assertEquals(d['string'], "g1-foo-value")
@@ -346,18 +346,18 @@ class TestRosparam(unittest.TestCase):
         import yaml
         with open(f_out) as b:
             with open(f) as b2:
-                self.assertEquals(yaml.load(b.read()), yaml.load(b2.read()))
+                self.assertEquals(yaml.safe_load(b.read()), yaml.safe_load(b2.read()))
 
         rosparam.yamlmain([cmd, 'dump', '-v', f_out, 'rosparam_dump'])                
         with open(f_out) as b:
             with open(f) as b2:
-                self.assertEquals(yaml.load(b.read()), yaml.load(b2.read()))
+                self.assertEquals(yaml.safe_load(b.read()), yaml.safe_load(b2.read()))
 
         # yaml file and std_out should be the same
         with fakestdout() as b:
             rosparam.yamlmain([cmd, 'dump'])
             with open(f) as b2:
-                self.assertEquals(yaml.load(b.getvalue())['rosparam_dump'], yaml.load(b2.read()))
+                self.assertEquals(yaml.safe_load(b.getvalue())['rosparam_dump'], yaml.safe_load(b2.read()))
 
     def test_fullusage(self):
         import rosparam

--- a/test/test_rosparam/test/check_rosparam_command_line_online.py
+++ b/test/test_rosparam/test/check_rosparam_command_line_online.py
@@ -120,7 +120,7 @@ class TestRosparamOnline(unittest.TestCase):
         # - dictionary
         output = Popen([cmd, 'get', "g1"], stdout=PIPE).communicate()[0]
         import yaml
-        d = yaml.load(output)
+        d = yaml.safe_load(output)
         self.assertEquals(d['float'], 10.0)
         self.assertEquals(d['int'], 10.0)
         self.assertEquals(d['string'], "g1-foo-value")

--- a/test/test_rosservice/test/check_rosservice_command_line_online.py
+++ b/test/test_rosservice/test/check_rosservice_command_line_online.py
@@ -122,7 +122,7 @@ class TestRosserviceOnline(unittest.TestCase):
             output = Popen([cmd, 'call', name, v], stdout=PIPE).communicate()[0]
             output = output.strip()
             self.assert_(output, output)
-            val = yaml.load(output)['header']
+            val = yaml.safe_load(output)['header']
             self.assertEquals('', val['frame_id'])
             self.assert_(val['seq'] >= 0)
             self.assertEquals(0, val['stamp']['secs'])
@@ -131,7 +131,7 @@ class TestRosserviceOnline(unittest.TestCase):
         # test with auto headers
         for v in ['{header: auto}', '{header: {stamp: now}}']:
             output = Popen([cmd, 'call', name, v], stdout=PIPE).communicate()[0]
-            val = yaml.load(output.strip())['header']
+            val = yaml.safe_load(output.strip())['header']
             self.assertEquals('', val['frame_id'])
             self.assert_(val['seq'] >= 0)
             self.assert_(val['stamp']['secs'] >= int(t))

--- a/test/test_rostopic/test/test_rostopic_unit.py
+++ b/test/test_rostopic/test/test_rostopic_unit.py
@@ -249,16 +249,16 @@ class TestRostopicUnit(unittest.TestCase):
         m = String('foo')
         self.assertEquals('data: "foo"', strify_message(m, field_filter=f))
         m = TVals(Time(123, 456), Duration(78, 90))
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'t': {'secs': 123, 'nsecs': 456}, 'd': {'secs': 78, 'nsecs': 90}}, v)
         m = simple_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(simple_d, v)
         m = arrays_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(arrays_d, v)
         m = embed_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(embed_d, v)
 
         f = create_field_filter(echo_nostr=True, echo_noarr=False)
@@ -267,16 +267,16 @@ class TestRostopicUnit(unittest.TestCase):
         m = String('foo')
         self.assertEquals('', strify_message(m, field_filter=f))
         m = TVals(Time(123, 456), Duration(78, 90))
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'t': {'secs': 123, 'nsecs': 456}, 'd': {'secs': 78, 'nsecs': 90}}, v)
         m = simple_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(simple_nostr, v)
         m = arrays_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(arrays_nostr, v)
         m = embed_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'simple': simple_nostr, 'arrays': arrays_nostr}, v)
 
         f = create_field_filter(echo_nostr=False, echo_noarr=True)
@@ -285,16 +285,16 @@ class TestRostopicUnit(unittest.TestCase):
         m = String('foo')
         self.assertEquals('data: "foo"', strify_message(m, field_filter=f))
         m = TVals(Time(123, 456), Duration(78, 90))
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'t': {'secs': 123, 'nsecs': 456}, 'd': {'secs': 78, 'nsecs': 90}}, v)
         m = simple_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(simple_d, v)
         m = arrays_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(None, v)
         m = embed_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'simple': simple_d, 'arrays': None}, v)
 
         f = create_field_filter(echo_nostr=True, echo_noarr=True)
@@ -303,13 +303,13 @@ class TestRostopicUnit(unittest.TestCase):
         m = String('foo')
         self.assertEquals('', strify_message(m, field_filter=f))
         m = TVals(Time(123, 456), Duration(78, 90))
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'t': {'secs': 123, 'nsecs': 456}, 'd': {'secs': 78, 'nsecs': 90}}, v)
         m = simple_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals(simple_nostr, v)
         m = embed_v
-        v = yaml.load(strify_message(m, field_filter=f))
+        v = yaml.safe_load(strify_message(m, field_filter=f))
         self.assertEquals({'simple': simple_nostr, 'arrays': None}, v)
 
     def test_create_field_filter(self):

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -930,7 +930,7 @@ class Bag(object):
                         else:
                            setattr(self, a, DictObject(b) if isinstance(b, dict) else b)
 
-            obj = DictObject(yaml.load(s))
+            obj = DictObject(yaml.safe_load(s))
             try:
                 val = eval('obj.' + key)
             except Exception as ex:

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -406,7 +406,7 @@ class Loader(object):
             if rosparam is None:
                 import rosparam
             try:
-                data = yaml.load(text)
+                data = yaml.safe_load(text)
                 # #3162: if there is no YAML, load() will return an
                 # empty string.  We want an empty dictionary instead
                 # for our representation of empty.

--- a/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_dump_params.py
@@ -53,7 +53,7 @@ class TestDumpParams(unittest.TestCase):
         o, e = p.communicate()
         self.assert_(p.returncode == 0, "Return code nonzero for param dump! Code: %d" % (p.returncode))
 
-        self.assertEquals({'/noop': 'noop'}, yaml.load(o))
+        self.assertEquals({'/noop': 'noop'}, yaml.safe_load(o))
 
         p = Popen([cmd, '--dump-params', 'roslaunch', 'test-dump-rosparam.launch'], stdout = PIPE)
         o, e = p.communicate()
@@ -95,7 +95,7 @@ class TestDumpParams(unittest.TestCase):
             '/noparam1': 'value1',
             '/noparam2': 'value2',
             }
-        output_val = yaml.load(o)
+        output_val = yaml.safe_load(o)
         if not val == output_val:
             for k, v in val.items():
                 if k not in output_val:

--- a/tools/rosparam/src/rosparam/__init__.py
+++ b/tools/rosparam/src/rosparam/__init__.py
@@ -99,6 +99,7 @@ def construct_yaml_binary(loader, node):
 # register the (de)serializers with pyyaml
 yaml.add_representer(Binary,represent_xml_binary)
 yaml.add_constructor(u'tag:yaml.org,2002:binary', construct_yaml_binary)
+yaml.SafeLoader.add_constructor(u'tag:yaml.org,2002:binary', construct_yaml_binary)
 
 def construct_angle_radians(loader, node):
     """
@@ -185,7 +186,7 @@ def load_str(str, filename, default_namespace=None, verbose=False):
     """
     paramlist = []
     default_namespace = default_namespace or get_ros_namespace()
-    for doc in yaml.load_all(str):
+    for doc in yaml.safe_load_all(str):
         if NS in doc:
             ns = ns_join(default_namespace, doc.get(NS, None))
             if verbose:
@@ -638,10 +639,14 @@ def yamlmain(argv=None):
 
 yaml.add_constructor(u'!radians', construct_angle_radians)
 yaml.add_constructor(u'!degrees', construct_angle_degrees)
+yaml.SafeLoader.add_constructor(u'!radians', construct_angle_radians)
+yaml.SafeLoader.add_constructor(u'!degrees', construct_angle_degrees)
 
 # allow both !degrees 180, !radians 2*pi
 pattern = re.compile(r'^deg\([^\)]*\)$')
 yaml.add_implicit_resolver(u'!degrees', pattern, first="deg(")
+yaml.SafeLoader.add_implicit_resolver(u'!degrees', pattern, first="deg(")
 pattern = re.compile(r'^rad\([^\)]*\)$')
 yaml.add_implicit_resolver(u'!radians', pattern, first="rad(")
+yaml.SafeLoader.add_implicit_resolver(u'!radians', pattern, first="rad(")
 

--- a/tools/rosservice/src/rosservice/__init__.py
+++ b/tools/rosservice/src/rosservice/__init__.py
@@ -604,7 +604,7 @@ def _rosservice_cmd_call(argv):
         # convert empty args to YAML-empty strings
         if arg == '':
             arg = "''" 
-        service_args.append(yaml.load(arg))
+        service_args.append(yaml.safe_load(arg))
     if not service_args and has_service_args(service_name, service_class=service_class):
         if sys.stdin.isatty():
             parser.error("Please specify service arguments")
@@ -647,7 +647,7 @@ def _stdin_yaml_arg():
                 elif arg.strip() != '---':
                     buff = buff + arg
             try:
-                loaded = yaml.load(buff.rstrip())
+                loaded = yaml.safe_load(buff.rstrip())
             except Exception as e:
                 print("Invalid YAML: %s"%str(e), file=sys.stderr)
             if loaded is not None:

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1759,7 +1759,7 @@ def _rostopic_cmd_pub(argv):
     try:
         pub_args = []
         for arg in args[2:]:
-            pub_args.append(yaml.load(arg))
+            pub_args.append(yaml.safe_load(arg))
     except Exception as e:
         parser.error("Argument error: "+str(e))
 
@@ -1802,7 +1802,7 @@ def file_yaml_arg(filename):
         try:
             with open(filename, 'r') as f:
                 # load all documents
-                data = yaml.load_all(f)
+                data = yaml.safe_load_all(f)
                 for d in data:
                     yield [d]
         except yaml.YAMLError as e:
@@ -1980,7 +1980,7 @@ def stdin_yaml_arg():
 
             if arg.strip() == '---': # End of document
                 try:
-                    loaded = yaml.load(buff.rstrip())
+                    loaded = yaml.safe_load(buff.rstrip())
                 except Exception as e:
                     sys.stderr.write("Invalid YAML: %s\n"%str(e))
                 if loaded is not None:

--- a/tools/topic_tools/scripts/relay_field
+++ b/tools/topic_tools/scripts/relay_field
@@ -98,7 +98,7 @@ class RelayField(object):
         if self.input_fn is not None:
             m = self.input_fn(m)
 
-        msg_generation = yaml.load(self.expression)
+        msg_generation = yaml.safe_load(self.expression)
         pub_args = _eval_in_dict_impl(msg_generation, None, {'m': m})
 
         now = rospy.get_rostime()


### PR DESCRIPTION
# Problem

File parsing with unsafe methods can be a threat.

`yaml.load` is recommended to be avoided in e.g. [security.openstack.org](https://security.openstack.org/guidelines/dg_avoid-dangerous-input-parsing-libraries.html).

# Potential solution

For the particular method in question (yaml.load), there's also a recommended method in the same link. So use that.

In fact in `melodic-devel` this is already done https://github.com/ros/ros_comm/pull/1688. This PR is essentially a cherry-pick of that.
