### PR TITLE
talker.py no longer exists under rospy package

### DIFF
--- a/tools/roslaunch/resources/example-min.launch
+++ b/tools/roslaunch/resources/example-min.launch
@@ -1,4 +1,4 @@
 <launch>
   <!-- $(anon talker) creates an anonymous name for this node -->
-  <node name="$(anon talker)" pkg="rospy" type="talker.py" />
+  <node name="$(anon talker)" pkg="rospy_tutorials" type="talker.py" />
 </launch>


### PR DESCRIPTION
it exists in kinetic, but dropped for melodic
```
/opt/ros/kinetic/share/rospy/talker.py
/opt/ros/melodic/share/rospy_tutorials/001_talker_listener/talker.py
```
we will install `taker.py` under `rospy` or use it within different package, i.e. `rospy_tutorials`
```
$ find | grep talker
./clients/rospy/test_nodes/talker.py
./test/test_rospy/nodes/freq_talker
./test/test_rospy/nodes/talker.py
./test/test_rospy/nodes/talker
./test/test_rostest/test_nodes/talker.py
./utilities/roswtf/test_nodes/talker.py
./tools/roslaunch/test_nodes/talker.py
./tools/rostopic/test_nodes/talker.py
./tools/rostest/test_nodes/talker.py
./tools/rosnode/test_nodes/talker.py
```