### PR TITLE
roswtf: do not try to run online checks if there are no roslaunch uris

### DIFF
--- a/utilities/roswtf/src/roswtf/roslaunchwtf.py
+++ b/utilities/roswtf/src/roswtf/roslaunchwtf.py
@@ -293,6 +293,8 @@ def _load_online_ctx(ctx):
     
 def wtf_check_online(ctx):
     _load_online_ctx(ctx)
+    if not ctx.roslaunch_uris:
+        return
     for r in online_roslaunch_warnings:
         warning_rule(r, r[0](ctx), ctx)
     for r in online_roslaunch_errors:


### PR DESCRIPTION
If there are no roslaunch uris, roswtf aborts checks with a traceback:

```
Traceback (most recent call last):
  File "/opt/ros/melodic/lib/python2.7/dist-packages/roswtf/__init__.py", line 220, in _roswtf_main
    roswtf.roslaunchwtf.wtf_check_online(ctx)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/roswtf/roslaunchwtf.py", line 297, in wtf_check_online
    warning_rule(r, r[0](ctx), ctx)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/roswtf/roslaunchwtf.py", line 202, in roslaunch_respawn_check
    for uri in ctx.roslaunch_uris:
TypeError: 'NoneType' object is not iterable
'NoneType' object is not iterable
```

So do not try to run online checks if there are no roslaunch_uris to fix this.