### PR TITLE
Fix base64 decode error on ARM platforms

### DIFF
--- a/utilities/xmlrpcpp/libb64/include/b64/cdecode.h
+++ b/utilities/xmlrpcpp/libb64/include/b64/cdecode.h
@@ -21,7 +21,7 @@ typedef struct
 
 void base64_init_decodestate(base64_decodestate* state_in);
 
-int base64_decode_value(signed char value_in);
+int base64_decode_value(char value_in);
 
 int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
 

--- a/utilities/xmlrpcpp/libb64/src/cdecode.c
+++ b/utilities/xmlrpcpp/libb64/src/cdecode.c
@@ -7,7 +7,7 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include <b64/cdecode.h>
 
-int base64_decode_value(signed char value_in)
+int base64_decode_value(char value_in)
 {
 	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 	static const char decoding_size = sizeof(decoding);
@@ -26,7 +26,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 {
 	const char* codechar = code_in;
 	char* plainchar = plaintext_out;
-	signed char fragment;
+	char fragment;
 	
 	if(length_in == 0) {
     return 0;

--- a/utilities/xmlrpcpp/libb64/src/cdecode.c
+++ b/utilities/xmlrpcpp/libb64/src/cdecode.c
@@ -9,10 +9,11 @@ For details, see http://sourceforge.net/projects/libb64
 
 int base64_decode_value(char value_in)
 {
-	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
+	static const signed char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 	static const char decoding_size = sizeof(decoding);
+	if (value_in < 43) return -1;
 	value_in -= 43;
-	if (value_in < 0 || value_in >= decoding_size) return -1;
+	if (value_in >= decoding_size) return -1;
 	return decoding[(int)value_in];
 }
 
@@ -26,7 +27,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 {
 	const char* codechar = code_in;
 	char* plainchar = plaintext_out;
-	char fragment;
+	int fragment;
 	
 	if(length_in == 0) {
     return 0;
@@ -46,7 +47,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = 0; // no state to save; use default value
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar    = (fragment & 0x03f) << 2;
 			//lint -fallthrough
@@ -58,7 +59,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x030) >> 4;
 			*plainchar    = (fragment & 0x00f) << 4;
@@ -71,7 +72,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x03c) >> 2;
 			*plainchar    = (fragment & 0x003) << 6;
@@ -84,7 +85,7 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++   |= (fragment & 0x03f);
 		}


### PR DESCRIPTION
I had the same problem as reported in #1768 when compiling the released version 1.14.3 of ros_comm on a Raspberry Pi 4 with gcc. Also here `char` seems to be an unsigned type and base64 decoding was broken. I assume this is the case on all ARM platforms.

I found this patch in the upstream bugtracker at https://sourceforge.net/p/libb64/bugs/2/ created in 2012 by Jakub Wilk. The last proposed patch that I applied here was submitted by Jonathan Wakely in 2016.

Only when I wanted to open a pull request here I realized that #1769 already addressed the topic. Jonathan's patch leaves the API as-is (`char`) and eliminates the implicit conversions between signed and unsigned types. For example, `static const char decoding[]` should not have negative values on implementations where `char` is unsigned.

The current patch (#1769) also solves the problem, but still produces sign conversion warnings on Raspbian 10 with gcc 8.3.0 and command line, while the new patch does not:

```sh
pi@raspberrypi:/home/pi/ros_ws/src/ros_comm/xmlrpcpp/libb64/src $ lsb_release -a
No LSB modules are available.
Distributor ID:	Raspbian
Description:	Raspbian GNU/Linux 10 (buster)
Release:	10
Codename:	buster
pi@raspberrypi:/home/pi/ros_ws/src/ros_comm/xmlrpcpp/libb64/src $ gcc --version
gcc (Raspbian 8.3.0-6+rpi1) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

pi@raspberrypi:/home/pi/ros_ws/src/ros_comm/xmlrpcpp/libb64/src $ gcc -Wall -Wextra -Werror -Wsign-conversion -pedantic -I../include -c cdecode.c
cdecode.c: In function ‘base64_decode_value’:
cdecode.c:12:37: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                     ^
cdecode.c:12:40: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                        ^
cdecode.c:12:43: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                           ^
cdecode.c:12:79: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                               ^
cdecode.c:12:82: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                  ^
cdecode.c:12:85: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                     ^
cdecode.c:12:88: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-2’ to ‘254’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                        ^
cdecode.c:12:91: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                           ^
cdecode.c:12:94: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                              ^
cdecode.c:12:97: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                                 ^
cdecode.c:12:168: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                                                                                                        ^
cdecode.c:12:171: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                                                                                                           ^
cdecode.c:12:174: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                                                                                                              ^
cdecode.c:12:177: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                                                                                                                 ^
cdecode.c:12:180: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                                                                                                                    ^
cdecode.c:12:183: error: unsigned conversion from ‘int’ to ‘char’ changes value from ‘-1’ to ‘255’ [-Werror=sign-conversion]
  static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
                                                                                                                                                                                       ^
cdecode.c: In function ‘base64_decode_block’:
cdecode.c:49:42: error: conversion to ‘signed char’ from ‘char’ may change the sign of the result [-Werror=sign-conversion]
     fragment = (char)base64_decode_value(*codechar++);
                                          ^~~~~~~~~~~
cdecode.c:49:16: error: conversion to ‘signed char’ from ‘char’ may change the sign of the result [-Werror=sign-conversion]
     fragment = (char)base64_decode_value(*codechar++);
                ^
cdecode.c:61:42: error: conversion to ‘signed char’ from ‘char’ may change the sign of the result [-Werror=sign-conversion]
     fragment = (char)base64_decode_value(*codechar++);
                                          ^~~~~~~~~~~
cdecode.c:61:16: error: conversion to ‘signed char’ from ‘char’ may change the sign of the result [-Werror=sign-conversion]
     fragment = (char)base64_decode_value(*codechar++);
                ^
cdecode.c:74:42: error: conversion to ‘signed char’ from ‘char’ may change the sign of the result [-Werror=sign-conversion]
     fragment = (char)base64_decode_value(*codechar++);
                                          ^~~~~~~~~~~
cdecode.c:74:16: error: conversion to ‘signed char’ from ‘char’ may change the sign of the result [-Werror=sign-conversion]
     fragment = (char)base64_decode_value(*codechar++);
                ^
cdecode.c:87:42: error: conversion to ‘signed char’ from ‘char’ may change the sign of the result [-Werror=sign-conversion]
     fragment = (char)base64_decode_value(*codechar++);
                                          ^~~~~~~~~~~
cdecode.c:87:16: error: conversion to ‘signed char’ from ‘char’ may change the sign of the result [-Werror=sign-conversion]
     fragment = (char)base64_decode_value(*codechar++);
```

I leave it to the maintainers to decide whether to keep the current patch by @randoms or apply this patch provided by Jakub Wilk and Jonathan Wakely instead.