### PR TITLE
Fix (#1516), prevent indefinitely trapping in unknown error state

### DIFF
--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -365,6 +365,7 @@ def rosnode_ping(node_name, max_count=None, verbose=False):
                     return False
                 except ValueError:
                     print("unknown network error contacting node: %s"%(str(e)))
+                    return False
             if max_count and count >= max_count:
                 break
             time.sleep(1.0)


### PR DESCRIPTION
Even with https://github.com/ros/ros_comm/pull/1517 we still observe unknown network error time out, but this time, indefinitely (https://github.com/ros/ros_comm/issues/1516#issuecomment-565846185). Adding false return on `ValueError` seems to be the only fix for now.