### PR TITLE
Add overload of ApproximateTime::setInterMessageLowerBound() to set all topics to the same value

### DIFF
--- a/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
@@ -256,13 +256,11 @@ struct ApproximateTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
   }
 
   void setInterMessageLowerBound(int i, ros::Duration lower_bound) {
-    // For correctness we only need age_penalty > -1.0, but most likely a negative age_penalty is a mistake.
     ROS_ASSERT(lower_bound >= ros::Duration(0,0));
     inter_message_lower_bounds_[i] = lower_bound;
   }
 
   void setMaxIntervalDuration(ros::Duration max_interval_duration) {
-    // For correctness we only need age_penalty > -1.0, but most likely a negative age_penalty is a mistake.
     ROS_ASSERT(max_interval_duration >= ros::Duration(0,0));
     max_interval_duration_ = max_interval_duration;
   }

--- a/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
@@ -260,6 +260,14 @@ struct ApproximateTime : public PolicyBase<M0, M1, M2, M3, M4, M5, M6, M7, M8>
     inter_message_lower_bounds_[i] = lower_bound;
   }
 
+  void setInterMessageLowerBound(ros::Duration lower_bound) {
+    ROS_ASSERT(lower_bound >= ros::Duration(0,0));
+    for (size_t i = 0; i < inter_message_lower_bounds_.size(); i++)
+    {
+      inter_message_lower_bounds_[i] = lower_bound;
+    }
+  }
+
   void setMaxIntervalDuration(ros::Duration max_interval_duration) {
     ROS_ASSERT(max_interval_duration >= ros::Duration(0,0));
     max_interval_duration_ = max_interval_duration;

--- a/utilities/message_filters/test/test_approximate_time_policy.cpp
+++ b/utilities/message_filters/test/test_approximate_time_policy.cpp
@@ -530,7 +530,43 @@ TEST(ApproxTimeSync, RateBound) {
   ApproximateTimeSynchronizerTest sync_test2(input, output, 10);
   sync_test2.sync_.setInterMessageLowerBound(0, s*2);
   sync_test2.run();
+}
 
+
+TEST(ApproxTimeSync, RateBoundAll) {
+  // Input A:  a..b..c.
+  // Input B:  .A..B..C
+  // Output:   .a..b...
+  //           .A..B...
+  std::vector<TimeAndTopic> input;
+  std::vector<TimePair> output;
+
+  ros::Time t(0, 0);
+  ros::Duration s(1, 0);
+
+  input.push_back(TimeAndTopic(t,0));     // a
+  input.push_back(TimeAndTopic(t+s,1));   // A
+  input.push_back(TimeAndTopic(t+s*3,0)); // b
+  input.push_back(TimeAndTopic(t+s*4,1)); // B
+  input.push_back(TimeAndTopic(t+s*6,0)); // c
+  input.push_back(TimeAndTopic(t+s*7,1)); // C
+  output.push_back(TimePair(t, t+s));
+  output.push_back(TimePair(t+s*3, t+s*4));
+
+  ApproximateTimeSynchronizerTest sync_test(input, output, 10);
+  sync_test.run();
+
+  // Rate bound: 2
+  // Input A:  a..b..c.
+  // Input B:  .A..B..C
+  // Output:   .a..b..c
+  //           .A..B..C
+
+  output.push_back(TimePair(t+s*6, t+s*7));
+
+  ApproximateTimeSynchronizerTest sync_test2(input, output, 10);
+  sync_test2.sync_.setInterMessageLowerBound(s*2);
+  sync_test2.run();
 }
 
 


### PR DESCRIPTION
Add `setInterMessageLowerBound(ros::Duration)` and unit test.

Most of the time, synchronized topics have the same period and the same inter-message-lower-bound. This overload allows setting the same value for all topics in one function call.