### PR TITLE
explicit include of socket.h to support FreeBSD

### DIFF
--- a/clients/roscpp/src/libros/network.cpp
+++ b/clients/roscpp/src/libros/network.cpp
@@ -34,6 +34,7 @@
 #include <ros/assert.h>
 #ifdef HAVE_IFADDRS_H
   #include <ifaddrs.h>
+  #include <sys/socket.h>  // supports FreeBSD, which does not include this in ifaddrs.h
 #endif
 
 #include <boost/lexical_cast.hpp>

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -42,6 +42,7 @@
 #include <boost/bind.hpp>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/socket.h>  // explicit include required for FreeBSD
 namespace ros
 {
 

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -38,6 +38,7 @@
 
 #include <ros/assert.h>
 #include <boost/bind.hpp>
+#include <sys/socket.h>  // explicit include required for FreeBSD
 
 #include <fcntl.h>
 #if defined(__APPLE__)


### PR DESCRIPTION
`network.cpp` in `roscpp` includes `ifaddrs.h`.

On Linux, `ifaddrs.h` includes `sys/socket.h`, which defines `struct sockaddr`.

On FreeBSD, `ifaddrs.h` does *not* include `sys/socket.h`, though `sys/socket.h` still defines `struct sockaddr`.

When I try to build on FreeBSD, I get a series of forward declaration of struct errors when building `network.cpp` associated with pointers to `sockaddr` structures in the code block from lines 126 to 176.

The problem is fixed by explicitly including `sys/socket.h`.

`transport_udp.cpp` and `transport_tcp.cpp` have similar issues.  Without explicitly including `sys/socket.h`, several variables and functions are undefined and result in errors during build (e.g., `AF_INIT`, `AF_INIT6`, `SOCK_DGRAM`).

See issue #1863 