### PR TITLE
rosbag_storage:  use find_library for abs path of crypto and gpgme libraries

### DIFF
--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -29,7 +29,9 @@ set(AES_ENCRYPT_SOURCE "")
 set(AES_ENCRYPT_LIBRARIES "")
 if(NOT WIN32)
   set(AES_ENCRYPT_SOURCE "src/aes_encryptor.cpp" "src/gpgme_utils.cpp")
-  set(AES_ENCRYPT_LIBRARIES "crypto" "gpgme")
+  find_library(AES_ENCRYPT_LIBRARIES 
+    NAMES "crypto" "gpgme"
+    PATHS /usr/local/lib)
 endif()
 
 add_library(rosbag_storage

--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -29,9 +29,13 @@ set(AES_ENCRYPT_SOURCE "")
 set(AES_ENCRYPT_LIBRARIES "")
 if(NOT WIN32)
   set(AES_ENCRYPT_SOURCE "src/aes_encryptor.cpp" "src/gpgme_utils.cpp")
-  find_library(AES_ENCRYPT_LIBRARIES 
-    NAMES "crypto" "gpgme"
+  find_library(GPGME_LIBRARY
+    NAMES "gpgme"
     PATHS /usr/local/lib)
+  find_library(CRYPTO_LIBRARY
+    NAMES "crypto"
+    PATHS /usr/local/lib)
+  set(AES_ENCRYPT_LIBRARIES ${GPGME_LIBRARY} ${CRYPTO_LIBRARY})
 endif()
 
 add_library(rosbag_storage


### PR DESCRIPTION
On FreeBSD, `/usr/local/lib` is not in the default search path for the linker.

This results in the error `ld: cannot find -lgpgme` when building `rosbag_storage`, though `libgpgme.so` is present in `/usr/local/lib`.

The existing code sets `AES_ENCRYPT_LIBRARIES` to contain the library names (`crypto` and `gpgme`) and relies on the linker to find them.

This PR uses the `find_library` function to append `/usr/local/lib` to the default linker search path and set `AES_ENCRYPT_LIBRARIES` to the absolute paths of the `crypto` and `gpgme` libraries.

This is related to issue #1866.