### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(roscpp)
 
 if(NOT WIN32)

--- a/clients/rospy/CMakeLists.txt
+++ b/clients/rospy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rospy)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/ros_comm/CMakeLists.txt
+++ b/ros_comm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ros_comm)
 find_package(catkin REQUIRED)
 catkin_metapackage()

--- a/test/test_rosbag/CMakeLists.txt
+++ b/test/test_rosbag/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rosbag)
 

--- a/test/test_rosbag_storage/CMakeLists.txt
+++ b/test/test_rosbag_storage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rosbag_storage)
 

--- a/test/test_roscpp/CMakeLists.txt
+++ b/test/test_roscpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_roscpp)
 

--- a/test/test_rosgraph/CMakeLists.txt
+++ b/test/test_rosgraph/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rosgraph)
 find_package(catkin REQUIRED COMPONENTS rostest)

--- a/test/test_roslaunch/CMakeLists.txt
+++ b/test/test_roslaunch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_roslaunch)
 find_package(catkin REQUIRED COMPONENTS rostest)

--- a/test/test_roslib_comm/CMakeLists.txt
+++ b/test/test_roslib_comm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_roslib_comm)
 find_package(catkin REQUIRED COMPONENTS genmsg rosgraph_msgs std_msgs)

--- a/test/test_rosmaster/CMakeLists.txt
+++ b/test/test_rosmaster/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rosmaster)
 

--- a/test/test_rosparam/CMakeLists.txt
+++ b/test/test_rosparam/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rosparam)
 find_package(catkin REQUIRED COMPONENTS rostest)

--- a/test/test_rospy/CMakeLists.txt
+++ b/test/test_rospy/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rospy)
 find_package(catkin REQUIRED COMPONENTS genmsg rosunit rostest std_msgs test_rosmaster)

--- a/test/test_rosservice/CMakeLists.txt
+++ b/test/test_rosservice/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rosservice)
 find_package(catkin REQUIRED COMPONENTS genmsg rosunit rostest std_msgs)

--- a/test/test_rostest/CMakeLists.txt
+++ b/test/test_rostest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rostest)
 

--- a/test/test_rostopic/CMakeLists.txt
+++ b/test/test_rostopic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(test_rostopic)
 

--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosbag)
 
 if(NOT WIN32)

--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(rosbag_storage)
 

--- a/tools/rosgraph/CMakeLists.txt
+++ b/tools/rosgraph/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosgraph)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tools/roslaunch/CMakeLists.txt
+++ b/tools/roslaunch/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(roslaunch)
 find_package(catkin REQUIRED)
 catkin_package(CFG_EXTRAS roslaunch-extras.cmake)

--- a/tools/rosmaster/CMakeLists.txt
+++ b/tools/rosmaster/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosmaster)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tools/rosmsg/CMakeLists.txt
+++ b/tools/rosmsg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosmsg)
 find_package(catkin)
 catkin_package()

--- a/tools/rosnode/CMakeLists.txt
+++ b/tools/rosnode/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosnode)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tools/rosout/CMakeLists.txt
+++ b/tools/rosout/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosout)
 
 if(NOT WIN32)

--- a/tools/rosparam/CMakeLists.txt
+++ b/tools/rosparam/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosparam)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tools/rosservice/CMakeLists.txt
+++ b/tools/rosservice/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rosservice)
 find_package(catkin)
 catkin_package()

--- a/tools/rostest/CMakeLists.txt
+++ b/tools/rostest/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rostest)
 
 find_package(catkin COMPONENTS rosunit)

--- a/tools/rostopic/CMakeLists.txt
+++ b/tools/rostopic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(rostopic)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(topic_tools)
 
 if(NOT WIN32)

--- a/utilities/message_filters/CMakeLists.txt
+++ b/utilities/message_filters/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(message_filters)
 
 if(NOT WIN32)

--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 
 project(roslz4)
 

--- a/utilities/roswtf/CMakeLists.txt
+++ b/utilities/roswtf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(roswtf)
 find_package(catkin REQUIRED)
 catkin_package()

--- a/utilities/xmlrpcpp/CMakeLists.txt
+++ b/utilities/xmlrpcpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(xmlrpcpp)
 
 if(NOT WIN32)


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building this package in Debian Buster and Ubuntu Focal.

Same as ros/catkin#1052