### PR TITLE
[noetic] Restrict boost dependencies to components used

### DIFF
--- a/clients/roscpp/package.xml
+++ b/clients/roscpp/package.xml
@@ -24,6 +24,9 @@
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 
   <build_depend version_gte="0.3.17">cpp_common</build_depend>
+  <build_depend>libboost-chrono-dev</build_depend>
+  <build_depend>libboost-filesystem-dev</build_depend>
+  <build_depend>libboost-system-dev</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>pkg-config</build_depend>
   <build_depend>rosconsole</build_depend>
@@ -37,6 +40,9 @@
 
   <run_depend version_gte="0.3.17">cpp_common</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>libboost-chrono-dev</run_depend>
+  <run_depend>libboost-filesystem-dev</run_depend>
+  <run_depend>libboost-system-dev</run_depend>
   <run_depend>rosconsole</run_depend>
   <run_depend>roscpp_serialization</run_depend>
   <run_depend version_gte="0.3.17">roscpp_traits</run_depend>

--- a/test/test_rosbag/package.xml
+++ b/test/test_rosbag/package.xml
@@ -23,7 +23,6 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>boost</build_depend>
   <build_depend>bzip2</build_depend>
   <build_depend>cpp_common</build_depend>
   <build_depend>message_generation</build_depend>
@@ -39,6 +38,7 @@
 
   <test_depend>genmsg</test_depend>
   <test_depend>genpy</test_depend>
+  <test_depend>libboost-dev</test_depend>
   <test_depend>message_runtime</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</test_depend>

--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT WIN32)
 endif()
 
 find_package(catkin REQUIRED COMPONENTS rosbag_storage rosconsole roscpp std_srvs topic_tools xmlrpcpp)
-find_package(Boost REQUIRED COMPONENTS date_time regex program_options filesystem)
+find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options regex thread)
 find_package(BZip2 REQUIRED)
 
 catkin_python_setup()

--- a/tools/rosbag/package.xml
+++ b/tools/rosbag/package.xml
@@ -20,7 +20,11 @@
   <author>Jeremy Leibs</author>
   <author>James Bowman</author>
 
-  <depend>boost</depend>
+  <depend>libboost-date-time-dev</depend>
+  <depend>libboost-filesystem-dev</depend>
+  <depend>libboost-program-options-dev</depend>
+  <depend>libboost-regex-dev</depend>
+  <depend>libboost-thread-dev</depend>
   <depend>rosbag_storage</depend>
   <depend>rosconsole</depend>
   <depend>roscpp</depend>

--- a/tools/rosbag_storage/CMakeLists.txt
+++ b/tools/rosbag_storage/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 
 find_package(console_bridge REQUIRED)
 find_package(catkin REQUIRED COMPONENTS cpp_common pluginlib roscpp_serialization roscpp_traits rostime roslz4 std_msgs)
-find_package(Boost REQUIRED COMPONENTS date_time filesystem program_options regex)
+find_package(Boost REQUIRED COMPONENTS filesystem)
 find_package(BZip2 REQUIRED)
 
 catkin_package(

--- a/tools/rosbag_storage/package.xml
+++ b/tools/rosbag_storage/package.xml
@@ -10,9 +10,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>boost</build_depend>
   <build_depend>bzip2</build_depend>
   <build_depend version_gte="0.3.17">cpp_common</build_depend>
+  <build_depend>libboost-filesystem-dev</build_depend>
   <build_depend>libconsole-bridge-dev</build_depend>
   <build_depend>libgpgme-dev</build_depend>
   <build_depend>libssl-dev</build_depend>
@@ -24,9 +24,9 @@
   <build_depend>roslz4</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>boost</run_depend>
   <run_depend>bzip2</run_depend>
   <run_depend version_gte="0.3.17">cpp_common</run_depend>
+  <run_depend>libboost-filesystem-dev</run_depend>
   <run_depend>libconsole-bridge-dev</run_depend>
   <run_depend>libgpgme-dev</run_depend>
   <run_depend>libssl-dev</run_depend>

--- a/tools/rosbag_storage/test/test_aes_encryptor.cpp
+++ b/tools/rosbag_storage/test/test_aes_encryptor.cpp
@@ -34,6 +34,8 @@
 
 #include <cstdio>
 
+#include <boost/filesystem.hpp>
+
 #include <gtest/gtest.h>
 
 #include <gpgme.h>

--- a/tools/rostest/CMakeLists.txt
+++ b/tools/rostest/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(rostest)
 
 find_package(catkin COMPONENTS rosunit)
-find_package(Boost COMPONENTS system thread)
+find_package(Boost COMPONENTS thread)
 
 include_directories(include ${Boost_INCLUDE_DIRS})
 

--- a/tools/rostest/package.xml
+++ b/tools/rostest/package.xml
@@ -12,10 +12,10 @@
 
   <buildtool_depend version_gte="0.7.9">catkin</buildtool_depend>
 
-  <build_depend>boost</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
   <build_depend>rosunit</build_depend>
 
-  <run_depend>boost</run_depend>
+  <run_depend>libboost-thread-dev</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>roslaunch</run_depend>
   <run_depend>rosmaster</run_depend>

--- a/utilities/message_filters/package.xml
+++ b/utilities/message_filters/package.xml
@@ -14,7 +14,7 @@
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 
-  <build_depend>boost</build_depend>
+  <build_depend>libboost-thread-dev</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rostest</build_depend>

--- a/utilities/xmlrpcpp/package.xml
+++ b/utilities/xmlrpcpp/package.xml
@@ -21,7 +21,7 @@
   <depend>cpp_common</depend>
   <depend version_gte="0.6.9">rostime</depend>
 
-  <test_depend>boost</test_depend>
+  <test_depend>libboost-thread-dev</test_depend>
 
   <export>
     <rosdoc external="http://xmlrpcpp.sourceforge.net/doc/hierarchy.html"/>

--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -17,7 +17,7 @@ if(WIN32)
 endif()
 
 # Some of the tests that follow use boost threads.
-find_package(Boost REQUIRED COMPONENTS system thread)
+find_package(Boost REQUIRED COMPONENTS thread)
 include_directories(${Boost_INCLUDE_DIRS})
 
 add_library(test_fixtures test_fixtures.cpp)


### PR DESCRIPTION
To be targeted at the noetic-devel branch

depends on https://github.com/ros/rosdistro/pull/23620 and https://github.com/ros/rosdistro/pull/23622