### PR TITLE
[windows] Workaround for Python 2 xmlrpc performance issues.

### DIFF
--- a/tools/roslaunch/env-hooks/10.roslaunch.bat
+++ b/tools/roslaunch/env-hooks/10.roslaunch.bat
@@ -1,5 +1,12 @@
 REM roslaunch/env-hooks/10.roslaunch.bat
 
+:: workaround Python 2 xmlrpc performance issue
+:: https://stackoverflow.com/questions/2617615/slow-python-http-server-on-localhost
+:: use IP address instead to avoid unnecessary DNS lookups.
 if "%ROS_MASTER_URI%" == "" (
-  set ROS_MASTER_URI=http://localhost:11311
+  set ROS_MASTER_URI=http://127.0.0.1:11311
+)
+
+if "%ROS_IP%" == "" (
+  set ROS_IP=127.0.0.1
 )

--- a/tools/roslaunch/env-hooks/10.roslaunch.bat
+++ b/tools/roslaunch/env-hooks/10.roslaunch.bat
@@ -7,6 +7,9 @@ if "%ROS_MASTER_URI%" == "" (
   set ROS_MASTER_URI=http://127.0.0.1:11311
 )
 
+:: it is discourage to set ROS_IP and ROS_HOSTNAME at the same time.
 if "%ROS_IP%" == "" (
-  set ROS_IP=127.0.0.1
+  if "%ROS_HOSTNAME%" == "" (
+    set ROS_IP=127.0.0.1
+  )
 )


### PR DESCRIPTION
There is a ROS performance slowness issue that we root caused to an existing issue for Python 2. One discussion can be found here: https://stackoverflow.com/questions/2617615/slow-python-http-server-on-localhost

Instead of asking Windows developers to manually override the `ROS_MASTER_URI` and `ROS_IP` to workaround it, I am proposing that, by default, make them to be IP address directly.

This fixes https://github.com/ms-iot/ROSOnWindows/issues/6.