### PR TITLE
Be able to have separate logger call rospy.loginfo and still get proper file and line number

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -162,6 +162,11 @@ def _base_logger(msg, *args, **kwargs):
     level = kwargs.pop('logger_level', None)
     once = kwargs.pop('logger_once', False)
     throttle_identical = kwargs.pop('logger_throttle_identical', False)
+    num_frames_back = kwargs.get('num_frames_back', 2)
+    frame = inspect.currentframe()
+    for _ in range(num_frames_back):
+        if frame.f_back is not None:
+            frame = frame.f_back
 
     rospy_logger = logging.getLogger('rosout')
     if name:
@@ -169,22 +174,22 @@ def _base_logger(msg, *args, **kwargs):
     logfunc = getattr(rospy_logger, level)
 
     if once:
-        caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
+        caller_id = _frame_to_caller_id(frame)
         if _logging_once(caller_id):
-            logfunc(msg, *args)
+            logfunc(msg, *args, **kwargs)
     elif throttle_identical:
-        caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
+        caller_id = _frame_to_caller_id(frame)
         throttle_elapsed = False
         if throttle is not None:
             throttle_elapsed = _logging_throttle(caller_id, throttle)
         if _logging_identical(caller_id, msg) or throttle_elapsed:
-            logfunc(msg, *args)
+            logfunc(msg, *args, **kwargs)
     elif throttle:
-        caller_id = _frame_to_caller_id(inspect.currentframe().f_back.f_back)
+        caller_id = _frame_to_caller_id(frame)
         if _logging_throttle(caller_id, throttle):
-            logfunc(msg, *args)
+            logfunc(msg, *args, **kwargs)
     else:
-        logfunc(msg, *args)
+        logfunc(msg, *args, **kwargs)
 
 
 def logdebug(msg, *args, **kwargs):

--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -93,6 +93,11 @@ class RospyLogger(logging.getLoggerClass()):
             return co.co_filename, f.f_lineno, func_name
 
     # TODO(lucasw) does LoggerAdapter help here?
+    def debug(self, msg, *args, **kwargs):
+        # bypass this parameter around the parent class
+        self.num_frames_back = kwargs.pop('num_frames_back', 3)
+        super(RospyLogger, self).debug(msg, *args, **kwargs)
+
     def info(self, msg, *args, **kwargs):
         # bypass this parameter around the parent class
         self.num_frames_back = kwargs.pop('num_frames_back', 3)
@@ -105,6 +110,11 @@ class RospyLogger(logging.getLoggerClass()):
     def error(self, msg, *args, **kwargs):
         self.num_frames_back = kwargs.pop('num_frames_back', 3)
         super(RospyLogger, self).error(msg, *args, **kwargs)
+
+    def critical(self, msg, *args, **kwargs):
+        # bypass this parameter around the parent class
+        self.num_frames_back = kwargs.pop('num_frames_back', 3)
+        super(RospyLogger, self).critical(msg, *args, **kwargs)
 
 logging.setLoggerClass(RospyLogger)
 


### PR DESCRIPTION
I have a custom python logger that calls rospy.loginfo after doing custom operations with arguments, but anything that calls it sees the file and line number of the logger file rather than the original calling file and line number in the regular rosout.

I've modified a couple files here to make a parameter out of how far back to go with `inspect`, it works but it would be better not to modify ros_comm- inherit from it- or modify it in a better way?

This is a simple example of using it:

```
#!/usr/bin/env python
import rospy


class CustomLogger:
    def __init__(self):
        pass

    def debug(self, msg, special_kv={}):
        # do other stuff with special key values and msg, put them into a database, the cloud, etc.
        # ...
        rospy.logdebug(msg + " " + str(special_kv), num_frames_back=4)

    def info(self, msg, special_kv={}):
        rospy.loginfo(msg + " " + str(special_kv), num_frames_back=4)

    def warn(self, msg, special_kv={}):
        rospy.logwarn(msg + " " + str(special_kv), num_frames_back=4)

    def error(self, msg, special_kv={}):
        rospy.logerror(msg + " " + str(special_kv), num_frames_back=4)

    def fatal(self, msg, special_kv={}):
        rospy.logfatal(msg + " " + str(special_kv), num_frames_back=4)

if __name__ == '__main__':
    rospy.init_node('test_log')
    custom_logger = CustomLogger()

    for i in range(10):
        rospy.loginfo_once('test once ' + str(i))
        rospy.loginfo_throttle(1, 'test throttle ' + str(i))
        rospy.sleep(0.5)
        # custom_logger.info_once("custom message1", {"foo": "bar", "num": 2})

    rospy.logdebug('test0')
    custom_logger.debug("custom message0", {"foo": "bar", "num": 2})
    rospy.loginfo('test1')
    custom_logger.info("custom message1", {"foo": "bar", "num": 2})
    rospy.logwarn('test2')
    custom_logger.warn("custom message2", {"foo": "bar"})
    rospy.logwarn('test3')
    custom_logger.warn("custom message3", {"foo": "bar"})
    rospy.logfatal('test4')
    custom_logger.fatal("custom message4", {"foo": "bar"})
```
