### PR TITLE
[rosbag] Catch exceptions by const ref.

### DIFF
--- a/tools/rosbag/src/encrypt.cpp
+++ b/tools/rosbag/src/encrypt.cpp
@@ -99,11 +99,11 @@ EncryptorOptions parseOptions(int argc, char** argv)
     {
         po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
     }
-    catch (boost::program_options::invalid_command_line_syntax& e)
+    catch (const boost::program_options::invalid_command_line_syntax& e)
     {
         throw ros::Exception(e.what());
     }
-    catch (boost::program_options::unknown_option& e)
+    catch (const boost::program_options::unknown_option& e)
     {
         throw ros::Exception(e.what());
     }
@@ -183,12 +183,12 @@ int main(int argc, char** argv)
     {
         opts = parseOptions(argc, argv);
     }
-    catch (ros::Exception const& ex)
+    catch (const ros::Exception& ex)
     {
         ROS_ERROR("Error reading options: %s", ex.what());
         return 1;
     }
-    catch(boost::regex_error const& ex)
+    catch (const boost::regex_error& ex)
     {
         ROS_ERROR("Error reading options: %s\n", ex.what());
         return 1;

--- a/tools/rosbag/src/play.cpp
+++ b/tools/rosbag/src/play.cpp
@@ -75,10 +75,10 @@ rosbag::PlayerOptions parseOptions(int argc, char** argv) {
     try 
     {
       po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
-    } catch (boost::program_options::invalid_command_line_syntax& e)
+    } catch (const boost::program_options::invalid_command_line_syntax& e)
     {
       throw ros::Exception(e.what());
-    }  catch (boost::program_options::unknown_option& e)
+    } catch (const boost::program_options::unknown_option& e)
     {
       throw ros::Exception(e.what());
     }
@@ -174,7 +174,7 @@ int main(int argc, char** argv) {
     try {
         opts = parseOptions(argc, argv);
     }
-    catch (ros::Exception const& ex) {
+    catch (const ros::Exception& ex) {
         ROS_ERROR("Error reading options: %s", ex.what());
         return 1;
     }
@@ -184,7 +184,7 @@ int main(int argc, char** argv) {
     try {
       player.publish();
     }
-    catch (std::runtime_error& e) {
+    catch (const std::runtime_error& e) {
       ROS_FATAL("%s", e.what());
       return 1;
     }

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -141,7 +141,7 @@ void Player::publish() {
             bag->open(filename, bagmode::Read);
             bags_.push_back(bag);
         }
-        catch (BagUnindexedException ex) {
+        catch (const BagUnindexedException& ex) {
             std::cerr << "Bag file " << filename << " is unindexed.  Run rosbag reindex." << std::endl;
             return;
         }

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -80,10 +80,10 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     try 
     {
       po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
-    } catch (boost::program_options::invalid_command_line_syntax& e)
+    } catch (const boost::program_options::invalid_command_line_syntax& e)
     {
       throw ros::Exception(e.what());
-    }  catch (boost::program_options::unknown_option& e)
+    } catch (const boost::program_options::unknown_option& e)
     {
       throw ros::Exception(e.what());
     }
@@ -284,11 +284,11 @@ int main(int argc, char** argv) {
     try {
         opts = parseOptions(argc, argv);
     }
-    catch (ros::Exception const& ex) {
+    catch (const ros::Exception& ex) {
         ROS_ERROR("Error reading options: %s", ex.what());
         return 1;
     }
-    catch(boost::regex_error const& ex) {
+    catch(const boost::regex_error& ex) {
         ROS_ERROR("Error reading options: %s\n", ex.what());
         return 1;
     }

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -386,7 +386,7 @@ void Recorder::startWriting() {
     try {
         bag_.open(write_filename_, bagmode::Write);
     }
-    catch (rosbag::BagException e) {
+    catch (const rosbag::BagException& e) {
         ROS_ERROR("Error writing: %s", e.what());
         exit_code_ = 1;
         ros::shutdown();
@@ -483,7 +483,7 @@ void Recorder::doRecord() {
     {
         checkDisk();
     }
-    catch (rosbag::BagException &ex)
+    catch (const rosbag::BagException& ex)
     {
         ROS_ERROR_STREAM(ex.what());
         exit_code_ = 1;
@@ -541,7 +541,7 @@ void Recorder::doRecord() {
             if (scheduledCheckDisk() && checkLogging())
                 bag_.write(out.topic, out.time, *out.msg, out.connection_header);
         }
-        catch (rosbag::BagException &ex)
+        catch (const rosbag::BagException& ex)
         {
             ROS_ERROR_STREAM(ex.what());
             exit_code_ = 1;
@@ -574,7 +574,7 @@ void Recorder::doRecordSnapshotter() {
         try {
             bag_.open(write_filename, bagmode::Write);
         }
-        catch (rosbag::BagException ex) {
+        catch (const rosbag::BagException& ex) {
             ROS_ERROR("Error writing: %s", ex.what());
             return;
         }
@@ -692,7 +692,7 @@ bool Recorder::checkDisk() {
     {
         info = boost::filesystem::space(p);
     }
-    catch (boost::filesystem::filesystem_error &e) 
+    catch (const boost::filesystem::filesystem_error& e) 
     { 
         ROS_WARN("Failed to check filesystem stats [%s].", e.what());
         writing_enabled_ = false;


### PR DESCRIPTION
GCC9 was throwing some `catch-value` warnings at me over this.