### PR TITLE
install talker.py/listener.py under rospy/test_nodes

### DIFF
--- a/clients/rospy/CMakeLists.txt
+++ b/clients/rospy/CMakeLists.txt
@@ -12,3 +12,7 @@ catkin_install_python(PROGRAMS
   rosbuild/scripts/gensrv_py.py
   rosbuild/scripts/genutil.py
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/rosbuild/scripts)
+catkin_install_python(PROGRAMS
+  test_nodes/talker.py
+  test_nodes/listener.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test_nodes/)


### PR DESCRIPTION
since launch files under https://github.com/ros/ros_comm/tree/1.14.3/tools/roslaunch/resources uses a lot of
```
    <node name="talker1" pkg="rospy" type="talker.py">
```
scripts, I think we should install talker.py/listener.py under rospy package directory