### PR TITLE
[Windows][melodic-devel] Conditionally guard sys/socket.h for Windows.

### DIFF
--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -42,7 +42,9 @@
 #include <boost/bind.hpp>
 #include <fcntl.h>
 #include <errno.h>
-#include <sys/socket.h>  // explicit include required for FreeBSD
+#ifndef _WIN32
+  #include <sys/socket.h>  // explicit include required for FreeBSD
+#endif
 namespace ros
 {
 

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -38,7 +38,9 @@
 
 #include <ros/assert.h>
 #include <boost/bind.hpp>
-#include <sys/socket.h>  // explicit include required for FreeBSD
+#ifndef _WIN32
+  #include <sys/socket.h>  // explicit include required for FreeBSD
+#endif
 
 #include <fcntl.h>
 #if defined(__APPLE__)


### PR DESCRIPTION
A recent [merge](https://github.com/ros/ros_comm/pull/1864) results in build breaks on Windows side, and this pull request is to address this issue.