### PR TITLE
[noetic] wrap rostest call to add `python` pointing to sys.executable in PATH

### DIFF
--- a/tools/rostest/scripts/rostest
+++ b/tools/rostest/scripts/rostest
@@ -53,9 +53,8 @@ class PythonPathOverride:
 
 
     def __enter__(self):
-
         self.dir = tempfile.TemporaryDirectory(prefix="rostest_bin_hook")
-        os.symlink(os.path.abspath(sys.executable), os.path.join(self.dir.name, "python"))
+        os.symlink(sys.executable, os.path.join(self.dir.name, "python"))
         os.environ['PATH'] = self.dir.name + ":" + os.environ['PATH']
 
     def __exit__(self, t, v, tb):

--- a/tools/rostest/scripts/rostest
+++ b/tools/rostest/scripts/rostest
@@ -33,4 +33,30 @@
 
 from rostest import rostestmain
 
-rostestmain()
+import os
+import sys
+import tempfile
+
+
+class PythonPathOverride:
+    """Replace python so test scripts with unmodified shebangs use correct python version."""
+
+    def __enter__(self):
+        # skip this hack on windows
+        if 'nt' == os.name:
+            return
+
+        self.dir = tempfile.TemporaryDirectory(prefix="rostest_bin_hook")
+        os.symlink(os.path.abspath(sys.executable), os.path.join(self.dir.name, "python"))
+        os.environ['PATH'] = self.dir.name + ":" + os.environ['PATH']
+
+    def __exit__(self, t, v, tb):
+        # skip this hack on windows
+        if 'nt' == os.name:
+            return
+
+        self.dir.cleanup()
+
+
+with PythonPathOverride():
+    rostestmain()

--- a/tools/rostest/scripts/rostest
+++ b/tools/rostest/scripts/rostest
@@ -39,14 +39,14 @@ import tempfile
 
 
 class PythonPathOverride:
-    """Replace python so test scripts with unmodified shebangs use correct python version."""
+    """Replace python so test scripts with unmodified shebangs use correct Python version."""
 
     def _skip(self):
         # skip this hack on windows
         if 'nt' == os.name:
             return True
         try:
-            # Skip pre python 3.2
+            # skip pre Python 3.2
             tempfile.TemporaryDirectory
         except AttributeError:
             return True
@@ -56,9 +56,9 @@ class PythonPathOverride:
         if self._skip():
             return
 
-        self.dir = tempfile.TemporaryDirectory(prefix="rostest_bin_hook")
-        os.symlink(sys.executable, os.path.join(self.dir.name, "python"))
-        os.environ['PATH'] = self.dir.name + ":" + os.environ['PATH']
+        self.dir = tempfile.TemporaryDirectory(prefix='rostest_bin_hook')
+        os.symlink(sys.executable, os.path.join(self.dir.name, 'python'))
+        os.environ['PATH'] = self.dir.name + os.pathsep + os.environ['PATH']
 
     def __exit__(self, t, v, tb):
         if self._skip():

--- a/tools/rostest/scripts/rostest
+++ b/tools/rostest/scripts/rostest
@@ -41,18 +41,25 @@ import tempfile
 class PythonPathOverride:
     """Replace python so test scripts with unmodified shebangs use correct python version."""
 
-    def __enter__(self):
+    def _skip(self):
         # skip this hack on windows
         if 'nt' == os.name:
-            return
+            return True
+        try:
+            tempfile.TemporaryDirectory
+        except AttributeError:
+            return True
+        return False
+
+
+    def __enter__(self):
 
         self.dir = tempfile.TemporaryDirectory(prefix="rostest_bin_hook")
         os.symlink(os.path.abspath(sys.executable), os.path.join(self.dir.name, "python"))
         os.environ['PATH'] = self.dir.name + ":" + os.environ['PATH']
 
     def __exit__(self, t, v, tb):
-        # skip this hack on windows
-        if 'nt' == os.name:
+        if self._skip():
             return
 
         self.dir.cleanup()

--- a/tools/rostest/scripts/rostest
+++ b/tools/rostest/scripts/rostest
@@ -46,13 +46,16 @@ class PythonPathOverride:
         if 'nt' == os.name:
             return True
         try:
+            # Skip pre python 3.2
             tempfile.TemporaryDirectory
         except AttributeError:
             return True
         return False
 
-
     def __enter__(self):
+        if self._skip():
+            return
+
         self.dir = tempfile.TemporaryDirectory(prefix="rostest_bin_hook")
         os.symlink(sys.executable, os.path.join(self.dir.name, "python"))
         os.environ['PATH'] = self.dir.name + ":" + os.environ['PATH']


### PR DESCRIPTION
Another possible solution to ros/ros_comm#1830. This adds a temporary directory with a symlink to python to the path variable.

This uses [`tempfile.TemporaryDirectory`](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory) which is only available in python 3.2 and above, so it must not be merged onto the `melodic-devel` branch. With this PR (and #1870) I don't see any `ros_comm` tests using Python 2, though many tests raise [`ModuleNotFoundError`](https://docs.python.org/3/library/exceptions.html#ModuleNotFoundError) when trying to import other packages.