### PR TITLE
[windows][melodic] portable duration cast patch to #1878

### DIFF
--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -52,6 +52,7 @@ namespace {
   {
   public:
     typedef boost::chrono::system_clock::time_point time_point;
+    typedef boost::chrono::system_clock::duration duration;
   };
 
   template<>
@@ -59,6 +60,7 @@ namespace {
   {
   public:
     typedef boost::chrono::steady_clock::time_point time_point;
+    typedef boost::chrono::steady_clock::duration duration;
   };
 }
 
@@ -592,7 +594,11 @@ void TimerManager<T, D, E>::threadFunc()
       {
         // On system time we can simply sleep for the rest of the wait time, since anything else requiring processing will
         // signal the condition variable
-        typename TimerManagerTraits<T>::time_point end_tp(boost::chrono::nanoseconds(sleep_end.toNSec()));
+        typename TimerManagerTraits<T>::time_point end_tp(
+          boost::chrono::duration_cast<typename TimerManagerTraits<T>::duration>(
+            boost::chrono::nanoseconds(sleep_end.toNSec())
+          )
+        );
         timers_cond_.wait_until(lock, end_tp);
       }
     }


### PR DESCRIPTION
This is a patch to #1878, where it introduces a usage of converting a `nanoseconds` into `time_point`. However for Linux and Windows, the supported precision is different. On Windows, the problem will manifest as a compile error:

```
wall_timer.cpp
C:\catkin_ws\src\ros_comm\clients\roscpp\include\ros/timer_manager.h(595): error C2664: 'boost::chrono::time_point<boost::chrono::system_clock,boost::chrono::system_clock::duration>::time_point(boost::chrono::time_point<boost::chrono::system_clock,boost::chrono::system_clock::duration> &&)': cannot convert argument 1 from 'boost::chrono::nanoseconds' to 'const boost::chrono::duration<int_least64_t,boost::ratio<1,10000000>> &'
C:\catkin_ws\src\ros_comm\clients\roscpp\include\ros/timer_manager.h(595): note: Reason: cannot convert from 'boost::chrono::nanoseconds' to 'const boost::chrono::duration<int_least64_t,boost::ratio<1,10000000>>'
C:\catkin_ws\src\ros_comm\clients\roscpp\include\ros/timer_manager.h(595): note: No user-defined-conversion operator available that can perform this conversion, or the operator cannot be called
C:\opt\rosdeps\x64\include\boost-1_66\boost/chrono/time_point.hpp(173): note: see declaration of 'boost::chrono::time_point<boost::chrono::system_clock,boost::chrono::system_clock::duration>::time_point'
C:\catkin_ws\src\ros_comm\clients\roscpp\include\ros/timer_manager.h(500): note: while compiling class template member function 'void ros::TimerManager<ros::WallTime,ros::WallDuration,ros::WallTimerEvent>::threadFunc(void)'
C:\catkin_ws\src\ros_comm\clients\roscpp\include\ros/timer_manager.h(343): note: see reference to function template instantiation 'void ros::TimerManager<ros::WallTime,ros::WallDuration,ros::WallTimerEvent>::threadFunc(void)' being compiled
C:\catkin_ws\src\ros_comm\clients\roscpp\include\ros/timer_manager.h(232): note: while compiling class template member function 'ros::TimerManager<ros::WallTime,ros::WallDuration,ros::WallTimerEvent>::TimerManager(void)'
C:\catkin_ws\src\ros_comm\clients\roscpp\include\ros/timer_manager.h(117): note: see reference to function template instantiation 'ros::TimerManager<ros::WallTime,ros::WallDuration,ros::WallTimerEvent>::TimerManager(void)' being compiled
C:\catkin_ws\src\ros_comm\clients\roscpp\src\libros\wall_timer.cpp(59): note: see reference to class template instantiation 'ros::TimerManager<ros::WallTime,ros::WallDuration,ros::WallTimerEvent>' being compiled
```

I am proposing to cast the nanosecond to the platform supported precision.