### PR TITLE
Allow empty machine arg in node tag.

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -388,8 +388,6 @@ class XmlLoader(loader.Loader):
                     required = self.opt_attrs(tag, context, ('machine', 'args',
                         'output', 'respawn', 'respawn_delay', 'cwd',
                         'launch-prefix', 'required'))
-            if tag.hasAttribute('machine') and not len(machine.strip()):
-                raise XmlParseException("<node> 'machine' must be non-empty: [%s]"%machine)
             if not machine and default_machine:
                 machine = default_machine.name
             # validate respawn, required

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -757,7 +757,6 @@ class TestXmlLoader(unittest.TestCase):
                  'test-node-invalid-name-1.xml',
                  'test-node-invalid-name-2.xml',
                  'test-node-invalid-name-3.xml',
-                 'test-node-invalid-machine.xml',
                  'test-node-invalid-respawn.xml',
                  'test-node-invalid-respawn-required.xml',                 
                  'test-node-invalid-required-1.xml',

--- a/tools/roslaunch/test/xml/test-node-invalid-machine.xml
+++ b/tools/roslaunch/test/xml/test-node-invalid-machine.xml
@@ -1,3 +1,0 @@
-<launch>
-  <node name="n" pkg="package" type="test_ns_invalid" machine="nonexistent" />
-</launch>

--- a/tools/roslaunch/test/xml/test-node-invalid-machine.xml
+++ b/tools/roslaunch/test/xml/test-node-invalid-machine.xml
@@ -1,3 +1,3 @@
 <launch>
-  <node name="n" pkg="package" type="test_ns_invalid" machine="" />
+  <node name="n" pkg="package" type="test_ns_invalid" machine="nonexistent" />
 </launch>


### PR DESCRIPTION
Fixes #274. Tested locally on my machine and it seems to work. Are there any integration tests that could really check the working of the machine tags?