### PR TITLE
catch polymorphic exceptions by reference

### DIFF
--- a/test/test_rosbag/test/test_bag.cpp.in
+++ b/test/test_rosbag/test/test_bag.cpp.in
@@ -170,7 +170,7 @@ TEST_F(BagTest, bag_not_open_fails) {
         b.write("/test", ros::Time::now(), foo_);
         FAIL();
     }
-    catch (rosbag::BagIOException ex) {
+    catch (rosbag::BagIOException& ex) {
         SUCCEED();
     }
 }
@@ -224,7 +224,7 @@ TEST(rosbag, append_indexed_1_2_fails) {
 
     FAIL();
   }
-  catch (rosbag::BagException ex) {
+  catch (rosbag::BagException& ex) {
     SUCCEED();
   }
 }
@@ -263,7 +263,7 @@ TEST(rosbag, write_then_read_without_read_mode_fails) {
         }
         FAIL();
     }
-    catch (rosbag::BagException ex) {
+    catch (rosbag::BagException& ex) {
         SUCCEED();
     }
 }
@@ -279,7 +279,7 @@ TEST_F(BagTest, read_then_write_without_write_mode_fails) {
         b2.write("chatter", ros::Time::now(), foo_);
         FAIL();
     }
-    catch (rosbag::BagException ex) {
+    catch (rosbag::BagException& ex) {
         SUCCEED();
     }
 }

--- a/test/test_rosbag/test/test_bag.cpp.in
+++ b/test/test_rosbag/test/test_bag.cpp.in
@@ -170,7 +170,7 @@ TEST_F(BagTest, bag_not_open_fails) {
         b.write("/test", ros::Time::now(), foo_);
         FAIL();
     }
-    catch (rosbag::BagIOException& ex) {
+    catch (const rosbag::BagIOException& ex) {
         SUCCEED();
     }
 }
@@ -224,7 +224,7 @@ TEST(rosbag, append_indexed_1_2_fails) {
 
     FAIL();
   }
-  catch (rosbag::BagException& ex) {
+  catch (const rosbag::BagException& ex) {
     SUCCEED();
   }
 }
@@ -263,7 +263,7 @@ TEST(rosbag, write_then_read_without_read_mode_fails) {
         }
         FAIL();
     }
-    catch (rosbag::BagException& ex) {
+    catch (const rosbag::BagException& ex) {
         SUCCEED();
     }
 }
@@ -279,7 +279,7 @@ TEST_F(BagTest, read_then_write_without_write_mode_fails) {
         b2.write("chatter", ros::Time::now(), foo_);
         FAIL();
     }
-    catch (rosbag::BagException& ex) {
+    catch (const rosbag::BagException& ex) {
         SUCCEED();
     }
 }

--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -319,7 +319,7 @@ void Bag::startReadingVersion102() {
         // Read the file header record, which points to the start of the topic indexes
         readFileHeaderRecord();
     }
-    catch (BagFormatException& ex) {
+    catch (const BagFormatException& ex) {
         throw BagUnindexedException();
     }
 

--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -319,7 +319,7 @@ void Bag::startReadingVersion102() {
         // Read the file header record, which points to the start of the topic indexes
         readFileHeaderRecord();
     }
-    catch (BagFormatException ex) {
+    catch (BagFormatException& ex) {
         throw BagUnindexedException();
     }
 


### PR DESCRIPTION
To avoid compiler warnings.