### PR TITLE
fix flakyness of test_topic_statistics

### DIFF
--- a/test/test_rospy/test/rostest/test_topic_statistics.py
+++ b/test/test_rospy/test/rostest/test_topic_statistics.py
@@ -67,6 +67,8 @@ class TestTopicStatistics(unittest.TestCase):
         ''' return True if topic message's measured frequency
         is within some error margin of expected frequency '''
         msg = self.topic_statistic_msg_map[topic]
+        # need at least two messages to compute the period fields
+        assert msg.delivered_msgs > 1
         found_freq = 1.0 / msg.period_mean.to_sec()
         rospy.loginfo(
             "Testing {}'s found frequency {} against expected {}".format(

--- a/test/test_rospy/test/rostest/test_topic_statistics.py
+++ b/test/test_rospy/test/rostest/test_topic_statistics.py
@@ -51,7 +51,10 @@ class TestTopicStatistics(unittest.TestCase):
         self.topic_statistic_msg_map = {}
 
     def new_msg(self, msg):
-        self.topic_statistic_msg_map[msg.topic] = msg
+        # need at least two messages to compute the period fields
+        # since messages without period fields aren't useful skip them
+        if msg.delivered_msgs > 1:
+            self.topic_statistic_msg_map[msg.topic] = msg
 
     def assert_eventually(
         self, cond, timeout=rospy.Duration(5.0), interval=rospy.Duration(0.5)


### PR DESCRIPTION
Fix flaky test: e.g. http://build.ros.org/view/Ndev/job/Ndev__ros_comm__ubuntu_focal_amd64/45/testReport/__main__/TestTopicStatistics/test_frequencies/

```
float division by zero
  File "/usr/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/usr/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/tmp/ws/src/ros_comm/test/test_rospy/test/rostest/test_topic_statistics.py", line 91, in test_frequencies
    self.assertTrue(self.frequency_acceptable('/very_slow_chatter', 0.5))
  File "/tmp/ws/src/ros_comm/test/test_rospy/test/rostest/test_topic_statistics.py", line 70, in frequency_acceptable
    found_freq = 1.0 / msg.period_mean.to_sec()
```

The first commit shows that this is actually the problem: http://build.ros.org/job/Npr_db__ros_comm__debian_buster_amd64/161/testReport/__main__/TestTopicStatistics/test_frequencies/