### PR TITLE
CMP0093 in findBoost changes how Boost_VERSION is reported

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -26,10 +26,10 @@ find_package(Boost REQUIRED COMPONENTS chrono filesystem system)
 
 # Make sure we use CLOCK_MONOTONIC for the condition variable wait_for if not Apple.
 if(NOT APPLE AND NOT WIN32)
-  if(Boost_VERSION LESS 106100)
+  if(Boost_VERSION_MACRO LESS 106100)
     message(FATAL_ERROR "${PROJECT_NAME} requires Boost 1.61 or above.")
   endif()
-  if(Boost_VERSION LESS 106700)
+  if(Boost_VERSION_MACRO LESS 106700)
     # CLOCK_MONOTONIC became the default in Boost 1.67:
     # https://github.com/boostorg/thread/commit/1e84b978b2bb0aae830cc14533dea3b7ddda5cde
     add_definitions(-DBOOST_THREAD_HAS_CONDATTR_SET_CLOCK_MONOTONIC)


### PR DESCRIPTION
This should fix the Boost version checks for the newer version of Boost.

Newer version (1.71+) report Boost_VERSION in x.y.z format, the older policy reported the Boost_VERSION_MACRO.  Set the check to always use the Boost_VERSION_MACRO

See https://cmake.org/cmake/help/v3.15/policy/CMP0093.html?highlight=cmp0093

This should fix issue https://github.com/ros/ros_comm/issues/1880

Tested using Boost version 1.71 and 1.67 on Ubuntu focal