### PR TITLE
Fix mac rospy polling issue

### DIFF
--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -192,7 +192,13 @@ class Poller(object):
     on multiple platforms.  NOT thread-safe.
     """
     def __init__(self):
-        if hasattr(select, 'epoll'):
+        if hasattr(select, 'kqueue'):
+            self.poller = select.kqueue()
+            self.add_fd = self.add_kqueue
+            self.remove_fd = self.remove_kqueue
+            self.error_iter = self.error_kqueue_iter
+            self.kevents = []
+        elif hasattr(select, 'epoll'):
             self.poller = select.epoll()
             self.add_fd = self.add_epoll
             self.remove_fd = self.remove_epoll
@@ -202,12 +208,6 @@ class Poller(object):
             self.add_fd = self.add_poll
             self.remove_fd = self.remove_poll
             self.error_iter = self.error_poll_iter
-        elif hasattr(select, 'kqueue'):
-            self.poller = select.kqueue()
-            self.add_fd = self.add_kqueue
-            self.remove_fd = self.remove_kqueue
-            self.error_iter = self.error_kqueue_iter
-            self.kevents = []
         else:
             #TODO: non-Noop impl for Windows
             self.poller = self.noop


### PR DESCRIPTION
the topics.py fixes a problem that has broken rospy since https://github.com/ros/ros_comm/commit/c57b1735a62422f6c9c9924cda295e065ec1db33. macOS was not using kqueue, which resulted in errors that look like: 

```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/impl/registration.py", line 276, in start
    self.run()
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/impl/registration.py", line 310, in run
    get_topic_manager().check_all()
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/topics.py", line 1203, in check_all
    t.check()
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/topics.py", line 488, in check
    fds_to_remove = list(self.connection_poll.error_iter())
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/topics.py", line 259, in error_poll_iter
    events = self.poller.poll(0)
RuntimeError: concurrent poll() invocation
```
This would happen something like 25% of the time, breaking the execution of that node instance.