### PR TITLE
Fix Python 3 mac uncaught exception

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -154,6 +154,8 @@ class TCPServer(object):
                 (client_sock, client_addr) = self.server_sock.accept()
             except socket.timeout:
                 continue
+            except ConnectionAbortedError:
+                continue
             except IOError as e:
                 (e_errno, msg) = e.args
                 if e_errno == errno.EINTR: #interrupted system call


### PR DESCRIPTION
Prevent python nodes from spamming the terminal every time a node is quit. Noted in Python 3 running on macOS. It generated errors that look like:

```
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/ros/melodic/lib/python3.7/site-packages/rospy/impl/tcpros_base.py", line 154, in run
    (client_sock, client_addr) = self.server_sock.accept()
  File "/usr/local/Cellar/python/3.7.6_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/socket.py", line 212, in accept
    fd, addr = self._accept()
ConnectionAbortedError: [Errno 53] Software caused connection abort
```

I believe this is simply cosmetic.