### PR TITLE
close XMLTestRunner stream to ensure it is being written in Python 3

### DIFF
--- a/tools/rostest/src/rostest/__init__.py
+++ b/tools/rostest/src/rostest/__init__.py
@@ -143,7 +143,11 @@ def rosrun(package, test_name, test, sysargs=None):
     if text_mode:
         result = unittest.TextTestRunner(verbosity=2).run(suite)
     else:
-        result = rosunit.create_xml_runner(package, test_name, result_file).run(suite)
+        runner = rosunit.create_xml_runner(package, test_name, result_file)
+        try:
+            result = runner.run(suite)
+        finally:
+            runner.close()
     if coverage_mode:
         _stop_coverage([package])
     rosunit.print_unittest_summary(result)


### PR DESCRIPTION
Related to ros/ros#245.