### PR TITLE
roslaunch-check: Search dir recursively

### DIFF
--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -53,6 +53,7 @@ def check_roslaunch_file(roslaunch_file, use_test_depends=False, ignore_unset_ar
 def check_roslaunch_dir(roslaunch_dir, use_test_depends=False, ignore_unset_args=False):
     roslaunch_files = []
     for dirpath, dirnames, filenames in os.walk(roslaunch_dir):
+        dirnames[:] = [d for d in dirnames if not d.startswith(".")]
         for filename in fnmatch.filter(filenames, "*.launch"):
             roslaunch_files.append(os.path.join(dirpath, filename))
     error_msgs = []

--- a/tools/roslaunch/scripts/roslaunch-check
+++ b/tools/roslaunch/scripts/roslaunch-check
@@ -33,6 +33,7 @@
 
 from __future__ import print_function
 
+import fnmatch
 import os
 import sys
 
@@ -50,12 +51,13 @@ def check_roslaunch_file(roslaunch_file, use_test_depends=False, ignore_unset_ar
         return "[%s]:\n\t%s"%(roslaunch_file,error_msg)
 
 def check_roslaunch_dir(roslaunch_dir, use_test_depends=False, ignore_unset_args=False):
+    roslaunch_files = []
+    for dirpath, dirnames, filenames in os.walk(roslaunch_dir):
+        for filename in fnmatch.filter(filenames, "*.launch"):
+            roslaunch_files.append(os.path.join(dirpath, filename))
     error_msgs = []
-    for f in os.listdir(roslaunch_dir):
-        if f.endswith('.launch'):
-            roslaunch_file = os.path.join(roslaunch_dir, f)
-            if os.path.isfile(roslaunch_file):
-                error_msgs.append(check_roslaunch_file(roslaunch_file, use_test_depends=use_test_depends, ignore_unset_args=ignore_unset_args))
+    for roslaunch_file in roslaunch_files:
+        error_msgs.append(check_roslaunch_file(roslaunch_file, use_test_depends=use_test_depends, ignore_unset_args=ignore_unset_args))
     # error message has to be XML attr safe
     return '\n'.join([e for e in error_msgs if e])
 


### PR DESCRIPTION
Hi! What do yall think about something like this?

This will simply check all .launch files in the directory you pass, including
subdirectories. I recently set up roslaunch-check on a CI server, and
missed having a feature like this.

However, the directory you pass must still be a ROS package
or a subdirectory of a ROS package. If you have, say, a dir
containing many packages, and you want to check every launch
file in every package in that dir, then you'll need to invoke
roslaunch-check once for each package.