### PR TITLE
rospy: fix tcp reconnect case

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -586,6 +586,14 @@ class TCPROSTransport(Transport):
                 #
                 # no reconnection as error is not 1.-4.
                 self.close()
+            else:
+                try:
+                    self.socket.shutdown(socket.SHUT_RDWR)
+                except:
+                    pass
+                finally:
+                    self.socket.close()
+                self.socket = None
             raise TransportInitError(str(e)) #re-raise i/o error
                 
     def _validate_header(self, header):


### PR DESCRIPTION
If we hit one of the cases where we get an exception during the
connection sequence and a reconnection is desired then we need to close
the socket and set it to None. This will allow the connect loop in
robust_connect_subscriber() to continue for another iteration. Without
these changes the connect loop would exit because conn.socket was not
None and then enter the receive loop without successfully having
negotiated a connection.

This can cause a deadlock between a publisher and subscriber if the
connection was established but the ros header was not written out. This
will leave the publisher trying to receive the ros header from the
subscriber and the subscriber waiting to receive a message from the
publisher. When this case is hit, for whatever reason, it's best to just
close the current connection and establish a new connection.