### PR TITLE
Fix #923 (use undefined dynamic_lookup on OSX)

### DIFF
--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -54,10 +54,17 @@ set_target_properties(roslz4_py PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/roslz4)
 if (NOT WIN32)
   set_target_properties(roslz4_py PROPERTIES OUTPUT_NAME roslz4 PREFIX "_" SUFFIX ".so")
+  if (APPLE)
+    set_target_properties(roslz4_py PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  endif()
 else()
   set_target_properties(roslz4_py PROPERTIES OUTPUT_NAME _roslz4 SUFFIX ".pyd")
 endif()
-target_link_libraries(roslz4_py roslz4 ${catkin_LIBRARIES} ${PYTHON_LIBRARIES})
+if (NOT APPLE)
+  target_link_libraries(roslz4_py roslz4 ${catkin_LIBRARIES} ${PYTHON_LIBRARIES})
+else()
+  target_link_libraries(roslz4_py roslz4 ${catkin_LIBRARIES})
+endif()
 endif()
 
 # Install library


### PR DESCRIPTION
See https://github.com/conda-forge/ros-roslz4-feedstock/pull/3 and https://gitter.im/RoboStack/Lobby?at=5e830ffdbd09254f83ea7d4c and https://blog.tim-smith.us/2015/09/python-extension-modules-os-x/ for details.