### PR TITLE
Remove extra \n in ROS_DEBUG.

### DIFF
--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -198,7 +198,7 @@ void TransportSubscriberLink::enqueueMessage(const SerializedMessage& m, bool se
       if (!queue_full_)
       {
         ROS_DEBUG("Outgoing queue full for topic [%s].  "
-               "Discarding oldest message\n",
+               "Discarding oldest message",
                topic_.c_str());
       }
 


### PR DESCRIPTION
The extra \n was creating empty line each time the debug output was hit.