### PR TITLE
Sort printed nodes by namespace alphabetically

### DIFF
--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -267,7 +267,8 @@ class ROSLaunchConfig(object):
                 namespaces[ns] = [n]
             else:
                 namespaces[ns].append(n)
-        for k,v in namespaces.items():
+        for k in sorted(namespaces):
+            v = namespaces[k]
             summary += '  %s\n'%k + '\n'.join(sorted(['    %s'%_summary_name(n) for n in v]))
             summary += '\n'
         return summary


### PR DESCRIPTION
When roslaunch gets to the nodes printing section, have it organize the namespaces alphabetically, e.g.

```
NODES
  /
    foo ...
    znode ...
  /astuff
    anode  ...
    bnode  ...
  /astuff/lower_down_stuff
    ...
  /bnodes
...
```