### PR TITLE
Fix bug that connection drop signal related funtion throw a bad_weak …

### DIFF
--- a/clients/roscpp/include/ros/transport_publisher_link.h
+++ b/clients/roscpp/include/ros/transport_publisher_link.h
@@ -32,6 +32,8 @@
 #include "publisher_link.h"
 #include "connection.h"
 
+#include <boost/signals2/connection.hpp>
+
 namespace ros
 {
 class Header;
@@ -79,6 +81,7 @@ private:
   void onRetryTimer(const ros::SteadyTimerEvent&);
 
   ConnectionPtr connection_;
+  boost::signals2::connection dropped_conn_;
 
   int32_t retry_timer_handle_;
   bool needs_retry_;

--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -93,9 +93,7 @@ boost::signals2::connection Connection::addDropListener(const DropFunc& slot)
 void Connection::removeDropListener(const boost::signals2::connection& c)
 {
   boost::recursive_mutex::scoped_lock lock(drop_mutex_);
-  if (c.connected()) {
-    c.disconnect();
-  }
+  c.disconnect();
 }
 
 void Connection::onReadable(const TransportPtr& transport)

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -340,14 +340,14 @@ bool ServiceServerLink::call(const SerializedMessage& req, SerializedMessage& re
 
   bool immediate = false;
   {
-    boost::mutex::scoped_lock lock(call_queue_mutex_);
-
     if (connection_->isDropped())
     {
       ROSCPP_LOG_DEBUG("ServiceServerLink::call called on dropped connection for service [%s]", service_name_.c_str());
       info->call_finished_ = true;
       return false;
     }
+
+    boost::mutex::scoped_lock lock(call_queue_mutex_);
 
     if (call_queue_.empty() && header_written_ && header_read_)
     {

--- a/clients/roscpp/src/libros/transport_publisher_link.cpp
+++ b/clients/roscpp/src/libros/transport_publisher_link.cpp
@@ -73,6 +73,7 @@ TransportPublisherLink::~TransportPublisherLink()
   }
 
   connection_->drop(Connection::Destructing);
+  connection_->removeDropListener(dropped_conn_);
 }
 
 bool TransportPublisherLink::initialize(const ConnectionPtr& connection)
@@ -82,7 +83,7 @@ bool TransportPublisherLink::initialize(const ConnectionPtr& connection)
   // and disconnect when this class' reference count is decremented to 0. It increments
   // then decrements the shared_from_this reference count around calls to the
   // onConnectionDropped function, preventing a coredump in the middle of execution.
-  connection_->addDropListener(Connection::DropSignal::slot_type(&TransportPublisherLink::onConnectionDropped, this, _1, _2).track(shared_from_this()));
+  dropped_conn_ = connection_->addDropListener(Connection::DropSignal::slot_type(&TransportPublisherLink::onConnectionDropped, this, _1, _2).track(shared_from_this()));
 
   if (connection_->getTransport()->requiresHeader())
   {

--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -52,6 +52,7 @@ TransportSubscriberLink::TransportSubscriberLink()
 TransportSubscriberLink::~TransportSubscriberLink()
 {
   drop();
+  connection_->removeDropListener(dropped_conn_);
 }
 
 bool TransportSubscriberLink::initialize(const ConnectionPtr& connection)


### PR DESCRIPTION
fix exception which is mentioned in #1939

TransportSubscriberLink::onConnectionDropped throws a bad_weak exception
while call shared_from_this() if TransportSubscriberLink already destroyed