### PR TITLE
Fix throttle publish first message

### DIFF
--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -98,6 +98,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest(test/shapeshifter.test)
   add_rostest(test/throttle.test)
+  add_rostest(test/throttle_first.test)
   add_rostest(test/throttle_simtime.test)
   add_rostest(test/throttle_simtime_loop.test)
   add_rostest(test/drop.test)

--- a/tools/topic_tools/test/throttle_first.test
+++ b/tools/topic_tools/test/throttle_first.test
@@ -1,0 +1,17 @@
+<launch>
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub"
+        args="pub -r 10.0 input std_msgs/String chatter"/>
+
+  <node pkg="topic_tools" type="throttle" name="throttle"
+        args="messages input 0.001"/>
+
+  <test test-name="throttle_publishtest" pkg="rostest" type="publishtest">
+    <rosparam>
+      topics:
+        - name: input
+          timeout: 2.0
+        - name: input_throttle
+          timeout: 2.0
+    </rosparam>
+  </test>
+</launch>


### PR DESCRIPTION
The `throttle` node from `topic_tools` fails to publish the first message because it doesn't wait for the subscribers.

Technically, it doesn't have to wait for the subscribers, but it should at least wait some time for them. I've added a `1.0s` wait time, which seems reasonable to me, but I'm happy to make that a param if that makes more sense. I'm open to discuss that part of this change.

The use case is illustrated in a new `rostest`, that basically tries to only publish the first message, by using a very low frequency with `throttle messages`.