### PR TITLE
[noetic] Avoid infinite recursion in rosrun tab completion when rosbash is not installed

### DIFF
--- a/tools/topic_tools/env-hooks/20.transform.bash
+++ b/tools/topic_tools/env-hooks/20.transform.bash
@@ -34,7 +34,8 @@ function _roscomplete_rosrun_transform
 {
     if is_transform_node; then
         _roscomplete_node_transform
-    else
+    elif [[ "$_sav_transform_roscomplete_rosrun" != "_roscomplete_rosrun_transform" ]]; then
+
         eval "$_sav_transform_roscomplete_rosrun"
     fi
 }

--- a/tools/topic_tools/env-hooks/20.transform.bash
+++ b/tools/topic_tools/env-hooks/20.transform.bash
@@ -35,7 +35,6 @@ function _roscomplete_rosrun_transform
     if is_transform_node; then
         _roscomplete_node_transform
     elif [[ "$_sav_transform_roscomplete_rosrun" != "_roscomplete_rosrun_transform" ]]; then
-
         eval "$_sav_transform_roscomplete_rosrun"
     fi
 }


### PR DESCRIPTION
If tab completion on the first argument to `rosrun` is attempted but `rosbash` is not installed then `$_sav_transform_roscomplete_rosrun` is set to `_roscomplete_rosrun_transform`, which when passed to `eval` causes the same function to be called again. This infinite recursion ends in when stack overflow causes `bash` itself to segfault. This is not an issue if `rosbash` installed because [it changes the completion of rosrun to `_roscomplete_exe`](https://github.com/ros/ros/blob/18f4c451402041f80cbd6e669c5ad519c0b9651f/tools/rosbash/rosbash#L1012).

To reproduce type  `rosrun rqt[tab]` in a container that does not have `rosbash` installed.

```console
sloretz@nxt:~/ws/noetic$ rosrun rqtSegmentation fault (core dumped)
Singularity>
```

This is probably also an issue in melodic and earlier, but I have not tested that.