### PR TITLE
Fix a bug that using a destroyed connection object.

### DIFF
--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -337,11 +337,11 @@ void Connection::drop(DropReason reason)
 
   if (did_drop)
   {
+    transport_->close();
     {
       boost::recursive_mutex::scoped_lock lock(drop_mutex_);
       drop_signal_(shared_from_this(), reason);
     }
-    transport_->close();
   }
 }
 


### PR DESCRIPTION
there is a case that accessing a connection object which was destroyed by
ConnectionManager and TransportSubscriberLink/TransportPublicationLink
while getting a close event in pollset to call Connection::drop.

Signed-off-by: Barry Xu <Barry.Xu@sony.com>