### PR TITLE
changes between 1.15.7 (Noetic) and 1.14.5 for backporting into Melodic

### DIFF
--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -337,8 +337,8 @@ void Connection::drop(DropReason reason)
 
   if (did_drop)
   {
-    drop_signal_(shared_from_this(), reason);
     transport_->close();
+    drop_signal_(shared_from_this(), reason);
   }
 }
 

--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -198,7 +198,7 @@ void TransportSubscriberLink::enqueueMessage(const SerializedMessage& m, bool se
       if (!queue_full_)
       {
         ROS_DEBUG("Outgoing queue full for topic [%s].  "
-               "Discarding oldest message\n",
+               "Discarding oldest message",
                topic_.c_str());
       }
 

--- a/tools/rosbag/src/rosbag/migration.py
+++ b/tools/rosbag/src/rosbag/migration.py
@@ -173,7 +173,7 @@ def fixbag2(migrator, inbag, outbag, force=False):
                 new_conn_header = _migrate_connection_header(conn_header, new_msg_type)
                 rebag.write(topic, mig_msg, t, connection_header=new_conn_header, raw=True)
             else:
-                rebag.write(topic, msg, t, connection_header=connection_header, raw=True)
+                rebag.write(topic, msg, t, connection_header=conn_header, raw=True)
         rebag.close()
         bag.close()
 

--- a/tools/rosbag_storage/include/rosbag/structures.h
+++ b/tools/rosbag_storage/include/rosbag/structures.h
@@ -59,25 +59,25 @@ struct ROSBAG_STORAGE_DECL ConnectionInfo
 
 struct ChunkInfo
 {
-    ros::Time   start_time;    //! earliest timestamp of a message in the chunk
-    ros::Time   end_time;      //! latest timestamp of a message in the chunk
-    uint64_t    pos;           //! absolute byte offset of chunk record in bag file
+    ros::Time   start_time;    //!< earliest timestamp of a message in the chunk
+    ros::Time   end_time;      //!< latest timestamp of a message in the chunk
+    uint64_t    pos;           //!< absolute byte offset of chunk record in bag file
 
-    std::map<uint32_t, uint32_t> connection_counts;   //! number of messages in each connection stored in the chunk
+    std::map<uint32_t, uint32_t> connection_counts;   //!< number of messages in each connection stored in the chunk
 };
 
 struct ROSBAG_STORAGE_DECL ChunkHeader
 {
-    std::string compression;          //! chunk compression type, e.g. "none" or "bz2" (see constants.h)
-    uint32_t    compressed_size;      //! compressed size of the chunk in bytes
-    uint32_t    uncompressed_size;    //! uncompressed size of the chunk in bytes
+    std::string compression;          //!< chunk compression type, e.g. "none" or "bz2" (see constants.h)
+    uint32_t    compressed_size;      //!< compressed size of the chunk in bytes
+    uint32_t    uncompressed_size;    //!< uncompressed size of the chunk in bytes
 };
 
 struct ROSBAG_STORAGE_DECL IndexEntry
 {
-    ros::Time time;            //! timestamp of the message
-    uint64_t  chunk_pos;       //! absolute byte offset of the chunk record containing the message
-    uint32_t  offset;          //! relative byte offset of the message record (either definition or data) in the chunk
+    ros::Time time;            //!< timestamp of the message
+    uint64_t  chunk_pos;       //!< absolute byte offset of the chunk record containing the message
+    uint32_t  offset;          //!< relative byte offset of the message record (either definition or data) in the chunk
 
     bool operator<(IndexEntry const& b) const { return time < b.time; }
 };

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -218,8 +218,10 @@ def _validate_args(parser, options, args):
 
     elif len(args) == 0:
         parser.error("you must specify at least one input file")
-    elif [f for f in args if not (f == '-' or os.path.exists(f))]:
-        parser.error("The following input files do not exist: %s"%f)
+    else:
+        missing_files = [f for f in args if not (f == '-' or os.path.exists(f))]
+        if missing_files:
+            parser.error("The following input files do not exist: %s"%', '.join(missing_files))
 
     if args.count('-') > 1:
         parser.error("Only a single instance of the dash ('-') may be specified.")

--- a/tools/roslaunch/src/roslaunch/config.py
+++ b/tools/roslaunch/src/roslaunch/config.py
@@ -267,7 +267,8 @@ class ROSLaunchConfig(object):
                 namespaces[ns] = [n]
             else:
                 namespaces[ns].append(n)
-        for k,v in namespaces.items():
+        for k in sorted(namespaces):
+            v = namespaces[k]
             summary += '  %s\n'%k + '\n'.join(sorted(['    %s'%_summary_name(n) for n in v]))
             summary += '\n'
         return summary

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -153,11 +153,6 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
             env_command = 'env %s=%s' % (rosgraph.ROS_MASTER_URI, self.master_uri)
             command = '%s %s' % (env_command, command)
         try:
-            import Crypto
-        except ImportError as e:
-            _logger.error("cannot use SSH: pycrypto is not installed")
-            return None, "pycrypto is not installed"
-        try:
             import paramiko
         except ImportError as e:
             _logger.error("cannot use SSH: paramiko is not installed")

--- a/tools/topic_tools/env-hooks/20.transform.bash
+++ b/tools/topic_tools/env-hooks/20.transform.bash
@@ -34,7 +34,7 @@ function _roscomplete_rosrun_transform
 {
     if is_transform_node; then
         _roscomplete_node_transform
-    else
+    elif [[ "$_sav_transform_roscomplete_rosrun" != "_roscomplete_rosrun_transform" ]]; then
         eval "$_sav_transform_roscomplete_rosrun"
     fi
 }

--- a/utilities/roslz4/CMakeLists.txt
+++ b/utilities/roslz4/CMakeLists.txt
@@ -54,10 +54,17 @@ set_target_properties(roslz4_py PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR}/roslz4)
 if (NOT WIN32)
   set_target_properties(roslz4_py PROPERTIES OUTPUT_NAME roslz4 PREFIX "_" SUFFIX ".so")
+  if (APPLE)
+    set_target_properties(roslz4_py PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+  endif()
 else()
   set_target_properties(roslz4_py PROPERTIES OUTPUT_NAME _roslz4 SUFFIX ".pyd")
 endif()
-target_link_libraries(roslz4_py roslz4 ${catkin_LIBRARIES} ${PYTHON_LIBRARIES})
+if (NOT APPLE)
+  target_link_libraries(roslz4_py roslz4 ${catkin_LIBRARIES} ${PYTHON_LIBRARIES})
+else()
+  target_link_libraries(roslz4_py roslz4 ${catkin_LIBRARIES})
+endif()
 endif()
 
 # Install library

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcServer.h
@@ -96,8 +96,8 @@ namespace XmlRpc {
     //! Create a new connection object for processing requests from a specific client.
     virtual XmlRpcServerConnection* createConnection(int socket);
 
-    //! Count number of free file descriptors
-    int countFreeFDs();
+    //! Check if enough number of free file descriptors
+    bool enoughFreeFDs();
 
     // Whether the introspection API is supported by this server
     bool _introspectionEnabled;

--- a/utilities/xmlrpcpp/src/XmlRpcServer.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServer.cpp
@@ -197,7 +197,7 @@ XmlRpcServer::acceptConnection()
     _accept_retry_time_sec = _disp.getTime() + ACCEPT_RETRY_INTERVAL_SEC;
     return 0; // Stop monitoring this FD
   }
-  else if( countFreeFDs() < FREE_FD_BUFFER )
+  else if ( !enoughFreeFDs() )
   {
     XmlRpcSocket::close(s);
     XmlRpcUtil::error("XmlRpcServer::acceptConnection: Rejecting client, not enough free file descriptors");
@@ -216,12 +216,11 @@ XmlRpcServer::acceptConnection()
   return XmlRpcDispatch::ReadableEvent; // Continue to monitor this fd
 }
 
-int XmlRpcServer::countFreeFDs() {
-  // NOTE(austin): this function is not free, but in a few small tests it only
-  // takes about 1.2mS when querying 50k file descriptors.
+bool XmlRpcServer::enoughFreeFDs() {
+  // This function is just to check if enough FDs are there.
   //
   // If the underlying system calls here fail, this will print an error and
-  // return 0
+  // return false
 
 #if !defined(_WINDOWS)
   int free_fds = 0;
@@ -230,10 +229,9 @@ int XmlRpcServer::countFreeFDs() {
 
   // Get the current soft limit on the number of file descriptors.
   if(getrlimit(RLIMIT_NOFILE, &limit) == 0) {
-    // If we have infinite file descriptors, always return FREE_FD_BUFFER so
-    // that we never hit the low-water mark.
+    // If we have infinite file descriptors, always return true.
     if( limit.rlim_max == RLIM_INFINITY ) {
-      return FREE_FD_BUFFER;
+      return true;
     }
 
     // Poll the available file descriptors.
@@ -245,11 +243,15 @@ int XmlRpcServer::countFreeFDs() {
         if(pollfds[i].revents & POLLNVAL) {
           free_fds++;
         }
+        if (free_fds >= FREE_FD_BUFFER) {
+          // Checked enough FDs are not opened.
+          return true;
+        }
       }
     } else {
       // poll() may fail if interrupted, if the pollfds array is a bad pointer,
       // if nfds exceeds RLIMIT_NOFILE, or if the system is out of memory.
-      XmlRpcUtil::error("XmlRpcServer::countFreeFDs: poll() failed: %s",
+      XmlRpcUtil::error("XmlRpcServer::enoughFreeFDs: poll() failed: %s",
                         strerror(errno));
     }
   } else {
@@ -257,13 +259,13 @@ int XmlRpcServer::countFreeFDs() {
     // resource is invalid or the second argument is invalid. I'm not sure
     // either of these can actually fail in this code, but it's better to
     // check.
-    XmlRpcUtil::error("XmlRpcServer::countFreeFDs: Could not get open file "
+    XmlRpcUtil::error("XmlRpcServer::enoughFreeFDs: Could not get open file "
                       "limit, getrlimit() failed: %s", strerror(errno));
   }
 
-  return free_fds;
+  return false;
 #else
-  return FREE_FD_BUFFER;
+  return true;
 #endif
 }
 


### PR DESCRIPTION
The following list of changes has been integrated into ros_comm 1.15.7 (Noetic) since the last Melodic release (1.14.5).


**Backported:** (these changes are part of this PR)

* Fix brief description comments after members (#1920)

  * Improve documentation

* Remove extra \n in ROS_DEBUG (#1925)

  * Cosmetic improvement

* Check if enough FDs are free, instead counting the total free FDs (#1929)

  * Bug fix

* use undefined dynamic_lookup on OSX) (#1923)

  * Bug fix

* remove pycrypto import (not used) (#1922)

  * Bug fix

* Sort printed nodes by namespace alphabetically (#1934)

  * Cosmetic improvement

* Avoid infinite recursion in rosrun tab completion when rosbash is not installed (#1948)

  * Bug fix

* Fix bag migration failures caused by typo in connection_header assignment (#1952)

  * Bug fix

* Fix a bug that using a destroyed connection object (#1950)

  * Bug fix

* fix NameError in launch error handling (#1965)

  * Bug fix


**Not backported:**

* roslaunch-check: Search dir recursively (#1914)

  * New feature, might break existing package tests

* clear message queue on simtime jumping back (#1518)

  * ABI / behavior breaking change

* Fix negative numbers in ros statistics (#1531)

  * ABI breaking change

* Fix bare pointer in topic_tools::ShapeShifter (#1722)

  * ABI breaking change

* Add rosout integration test (#1924)

  * New test only, not necessary

* Multiple latched publishers per process on the same topic (#1544)

  * ABI breaking change

* Add option to repeat latched messages at the start of bag splits (#1850)

  * ABI breaking change

* roslaunch: Allow passing _TIMEOUT_SIGINT and _TIMEOUT_SIGTERM as parameters (#1937)

  * New feature

* Fix bug that connection drop signal related funtion throw a bad_weak (#1940)

  * ABI breaking change

* check if async socket connect is success or failure before read and write in TransportT (#1954)

  * ABI breaking change

* Fixing Windows build break (#1961)

  * Not applicable since the regression causing changes wasn't backported