### PR TITLE
[noetic] Fixing Windows build break.

### DIFF
--- a/clients/roscpp/src/libros/io.cpp
+++ b/clients/roscpp/src/libros/io.cpp
@@ -416,9 +416,9 @@ int is_async_connected(socket_fd_t &socket, int &err) {
                (!FD_ISSET(socket, &wfds) && FD_ISSET(socket, &exceptfds)));
     if (FD_ISSET(socket, &exceptfds)) {
       // an error occurred during connection
-      int errinfo;
+      int errinfo = 0;
       socklen_t errlen = sizeof(int);
-      if (getsockopt(socket, SOL_SOCKET, SO_ERROR, &errinfo, &errlen) == -1)
+      if (getsockopt(socket, SOL_SOCKET, SO_ERROR, reinterpret_cast<char*>(&errinfo), &errlen) == -1)
       {
         // getsockopt() error
         ROSCPP_CONN_LOG_DEBUG("getsockopt() on socket[%d] failed with error [%s]",


### PR DESCRIPTION
Fixed Windows build break after https://github.com/ros/ros_comm/pull/1954.


```
error C2664: 'int getsockopt(SOCKET,int,int,char *,int *)': cannot convert argument 4 from 'int *' to 'char *'
```