### PR TITLE
[Windows][noetic] Fixing `Time jumped forward` & 100% CPU occupied issues

### DIFF
--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -594,12 +594,7 @@ void TimerManager<T, D, E>::threadFunc()
       {
         // On system time we can simply sleep for the rest of the wait time, since anything else requiring processing will
         // signal the condition variable
-        typename TimerManagerTraits<T>::time_point end_tp(
-          boost::chrono::duration_cast<typename TimerManagerTraits<T>::duration>(
-            boost::chrono::nanoseconds(sleep_end.toNSec())
-          )
-        );
-        timers_cond_.wait_until(lock, end_tp);
+        timers_cond_.wait_for(lock, boost::chrono::nanoseconds((sleep_end - current).toNSec()));
       }
     }
 

--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -46,24 +46,6 @@
 namespace ros
 {
 
-namespace {
-  template<class T>
-  class TimerManagerTraits
-  {
-  public:
-    typedef boost::chrono::system_clock::time_point time_point;
-    typedef boost::chrono::system_clock::duration duration;
-  };
-
-  template<>
-  class TimerManagerTraits<SteadyTime>
-  {
-  public:
-    typedef boost::chrono::steady_clock::time_point time_point;
-    typedef boost::chrono::steady_clock::duration duration;
-  };
-}
-
 template<class T, class D, class E>
 class TimerManager
 {


### PR DESCRIPTION
Since https://github.com/ros/ros_comm/pull/1878, on Windows it started to see `roscpp` Timer callback taking more often longer time to be scheduled and called as the symptom.

By more verbose logs, it shows the `timer_manager` sees the clock is jumping forward and it is related to that `wait_until()` is awaken earlier than expected. At the same time, I observed that 1 CPU core is 100% occupied by the node process when it is happening.

It turned out, after `wait_until()` is added, that the `time_manager` started to mix two clock domains; the ROS clocks implemented in `rostime` (`ros_walltime` and `ros_steadytime`) and the `boost` clocks (`boost::chrono::system_clock` and `boost::chrono::steady_clock`).

Why it is a problem? On Windows, the `ros_walltime` is a mix of [`QueryPerformanceCounter` + `GetSystemTimeAsFileTime`](https://github.com/ros/roscpp_core/blob/noetic-devel/rostime/src/time.cpp#L123-L179). However, `boost::chrono::system_clock` is a pure implementation of [`GetSystemTimeAsFileTime`](https://github.com/boostorg/chrono/blob/15d3e2af0e06ae4ae40bd003007040896fc72e97/include/boost/chrono/detail/inlined/win/chrono.hpp#L102). When there is a delta, it speaks different absolute wall time but `wait_until()` only understand the `boost` one.

One way to solve that is to touch `rostime` and make the implementation matched to what `roscpp` assumes under the hood. And another one is to make the `time_manager` less dependent on what's the time domain of what `rostime` speaks, which is what proposed by this pull request.

LOG:

```
SUMMARY
========

PARAMETERS
 * /ekf_localization/base_link_frame: base_link
 * /ekf_localization/frequency: 30
 * /ekf_localization/imu0: /imu/data
 * /ekf_localization/imu0_config: [False, False, Fa...
 * /ekf_localization/imu0_differential: False
 * /ekf_localization/odom0: /jackal_velocity_...
 * /ekf_localization/odom0_config: [False, False, Fa...
 * /ekf_localization/odom0_differential: False
 * /ekf_localization/odom_frame: odom
 * /ekf_localization/world_frame: odom
 * /rosdistro: melodic
 * /rosversion: 1.15.6

NODES
  /
    ekf_localization (robot_localization/ekf_localization_node)

auto-starting new master
process[master]: started with pid [39564]
ROS_MASTER_URI=http://127.0.0.1:11311
setting /run_id to 1994b29e-9bdb-11ea-8aab-9078412348d4
process[rosout-1]: started with pid [8744]
started core service [/rosout]
process[ekf_localization-2]: started with pid [26184]
[DEBUG] [1590117596.471052300]: remap: __name => ekf_localization
[DEBUG] [1590117596.471239000]: remap: __log => C:\Users\tzuhs\.ros\log\1994b29e-9bdb-11ea-8aab-9078412348d4\ekf_localization-2.log
[DEBUG] [1590117596.474459300]: determineIP: using value of ROS_IP:127.0.0.1:
[DEBUG] [1590117596.479633700]: Adding tcp socket [724] to pollset
[DEBUG] [1590117596.480007500]: UDPROS server listening on port [52554]
[DEBUG] [1590117596.483000200]: Started node [/ekf_localization], pid [26184], bound on [127.0.0.1], xmlrpc port [65330], tcpros port [65329], using [real] time
Warning: recursive print statement has occurred.  Throwing out recursive print.
[DEBUG] [1590117596.492237000]: XML-RPC call [getParam] returned an error (-1): [Parameter [/ekf_localization/diagnostic_period] is not set]
[DEBUG] [1590117596.494222800]: Publisher update for [/tf]:  already have these connections:
[DEBUG] [1590117596.497997900]: Publisher update for [/tf_static]:  already have these connections:
[DEBUG] [1590117596.500893400]: Creating intraprocess link for topic [/tf]
[DEBUG] [1590117596.505045900]: XML-RPC call [searchParam] returned an error (-1): [Cannot find parameter [tf_prefix] in an upwards search]
[DEBUG] [1590117596.510855100]: XML-RPC call [getParam] returned an error (-1): [Parameter [/ekf_localization/initial_state] is not set]
[DEBUG] [1590117596.570181900]: Received update for topic [/tf] (1 publishers)
[DEBUG] [1590117596.570498700]: Publisher update for [/tf]: http://127.0.0.1:65330/,  already have these connections: http://127.0.0.1:65330/,
[DEBUG] [1590117596.574861900]: Publisher update for [/set_pose]:  already have these connections:
[DEBUG] [1590117596.581337900]: Publisher update for [/jackal_velocity_controller/odom]:  already have these connections:
[DEBUG] [1590117596.591297300]: Publisher update for [/imu/data]:  already have these connections:
[DEBUG] [1590117596.757142100]: Accepted connection on socket [724], new socket [904]
[DEBUG] [1590117596.757638400]: Adding tcp socket [904] to pollset
[DEBUG] [1590117596.760649800]: TCPROS received a connection from [127.0.0.1:65335]
[DEBUG] [1590117596.760879800]: Async socket[904] is connected
[DEBUG] [1590117596.857840800]: Connection: Creating TransportSubscriberLink for topic [/rosout] connected to [callerid=[/rosout] address=[TCPROS connection on port 65329 to [127.0.0.1:65335 on socket 904]]]
[DEBUG] [1590117597.066987100]: Scheduling timer callback for timer [0] of period [0.033333], [0.440628] off expected
[ WARN] [1590117597.068178200]: Failed to meet update rate! Took 0.47516760000000002329
[DEBUG] [1590117597.082828000]: Time jumped forward by [0.423217] for timer of period [0.033333], resetting timer (current=1590117597.082807, next_expected=1590117596.659590)
[DEBUG] [1590117597.083181400]: Scheduling timer callback for timer [0] of period [0.033333], [0.000365] off expected
[ WARN] [1590117597.083385200]: Failed to meet update rate! Took 0.45711676700000003493
[DEBUG] [1590117597.556893600]: Scheduling timer callback for timer [0] of period [0.033333], [0.440677] off expected
[ WARN] [1590117597.558143800]: Failed to meet update rate! Took 0.47526500000000004853
[DEBUG] [1590117597.567669900]: Time jumped forward by [0.418177] for timer of period [0.033333], resetting timer (current=1590117597.567651, next_expected=1590117597.149473)
[DEBUG] [1590117597.567936400]: Scheduling timer callback for timer [0] of period [0.033333], [0.000276] off expected
[ WARN] [1590117597.568090000]: Failed to meet update rate! Took 0.45193716700000002851
[DEBUG] [1590117598.041343300]: Scheduling timer callback for timer [0] of period [0.033333], [0.440280] off expected
[ WARN] [1590117598.042985100]: Failed to meet update rate! Took 0.47527330000000000965
[DEBUG] [1590117598.053562200]: Time jumped forward by [0.419228] for timer of period [0.033333], resetting timer (current=1590117598.053545, next_expected=1590117597.634317)
[DEBUG] [1590117598.053829400]: Scheduling timer callback for timer [0] of period [0.033333], [0.000274] off expected
[ WARN] [1590117598.053985400]: Failed to meet update rate! Took 0.45298616700000005064
[DEBUG] [1590117598.528417700]: Scheduling timer callback for timer [0] of period [0.033333], [0.441509] off expected
[ WARN] [1590117598.529367200]: Failed to meet update rate! Took 0.47575740000000005248
[DEBUG] [1590117598.535718200]: Time jumped forward by [0.415487] for timer of period [0.033333], resetting timer (current=1590117598.535698, next_expected=1590117598.120212)
[DEBUG] [1590117598.535982900]: Scheduling timer callback for timer [0] of period [0.033333], [0.000276] off expected
[ WARN] [1590117598.536138900]: Failed to meet update rate! Took 0.44924826700000003443
[DEBUG] [1590117599.011722300]: Scheduling timer callback for timer [0] of period [0.033333], [0.442661] off expected
[ WARN] [1590117599.012659300]: Failed to meet update rate! Took 0.47693250000000003697
[DEBUG] [1590117599.019460100]: Time jumped forward by [0.417076] for timer of period [0.033333], resetting timer (current=1590117599.019440, next_expected=1590117598.602365)
[DEBUG] [1590117599.019734800]: Scheduling timer callback for timer [0] of period [0.033333], [0.000285] off expected
[ WARN] [1590117599.019888400]: Failed to meet update rate! Took 0.45084416700000001788
[DEBUG] [1590117599.493220600]: Scheduling timer callback for timer [0] of period [0.033333], [0.440396] off expected
[ WARN] [1590117599.494010200]: Failed to meet update rate! Took 0.47451570000000004024
[DEBUG] [1590117599.502359300]: Time jumped forward by [0.416235] for timer of period [0.033333], resetting timer (current=1590117599.502342, next_expected=1590117599.086107)
[DEBUG] [1590117599.502625900]: Scheduling timer callback for timer [0] of period [0.033333], [0.000275] off expected
[ WARN] [1590117599.502781800]: Failed to meet update rate! Took 0.44999626700000000534
[DEBUG] [1590117599.976295000]: Scheduling timer callback for timer [0] of period [0.033333], [0.440540] off expected
[ WARN] [1590117599.977529900]: Failed to meet update rate! Took 0.47511480000000000379
[DEBUG] [1590117600.004617700]: Time jumped forward by [0.435589] for timer of period [0.033333], resetting timer (current=1590117600.004598, next_expected=1590117599.569009)
[DEBUG] [1590117600.004895200]: Scheduling timer callback for timer [0] of period [0.033333], [0.000287] off expected
[ WARN] [1590117600.005051000]: Failed to meet update rate! Took 0.4693629670000000198
[DEBUG] [1590117600.478841200]: Scheduling timer callback for timer [0] of period [0.033333], [0.440870] off expected
[ WARN] [1590117600.479574700]: Failed to meet update rate! Took 0.47493720000000000381
[DEBUG] [1590117600.487667600]: Time jumped forward by [0.416384] for timer of period [0.033333], resetting timer (current=1590117600.487648, next_expected=1590117600.071265)
[DEBUG] [1590117600.488031600]: Scheduling timer callback for timer [0] of period [0.033333], [0.000373] off expected
[ WARN] [1590117600.488289700]: Failed to meet update rate! Took 0.45034496700000004044
[DEBUG] [1590117600.961295300]: Scheduling timer callback for timer [0] of period [0.033333], [0.440278] off expected
[ WARN] [1590117600.962107000]: Failed to meet update rate! Took 0.47441760000000005038
[DEBUG] [1590117600.969515500]: Time jumped forward by [0.415183] for timer of period [0.033333], resetting timer (current=1590117600.969498, next_expected=1590117600.554315)
[DEBUG] [1590117600.969788900]: Scheduling timer callback for timer [0] of period [0.033333], [0.000281] off expected
[ WARN] [1590117600.969994000]: Failed to meet update rate! Took 0.44900016700000000558
[DEBUG] [1590117601.443271000]: Scheduling timer callback for timer [0] of period [0.033333], [0.440408] off expected
[ WARN] [1590117601.444002800]: Failed to meet update rate! Took 0.47448360000000000536
[DEBUG] [1590117601.452578500]: Time jumped forward by [0.416395] for timer of period [0.033333], resetting timer (current=1590117601.452560, next_expected=1590117601.036165)
[DEBUG] [1590117601.452860100]: Scheduling timer callback for timer [0] of period [0.033333], [0.000291] off expected
[ WARN] [1590117601.453016500]: Failed to meet update rate! Took 0.45017256700000002345
[DEBUG] [1590117601.926594800]: Scheduling timer callback for timer [0] of period [0.033333], [0.440640] off expected
[ WARN] [1590117601.927584000]: Failed to meet update rate! Took 0.47497540000000004756
[DEBUG] [1590117601.945949600]: Time jumped forward by [0.426704] for timer of period [0.033333], resetting timer (current=1590117601.945930, next_expected=1590117601.519227)
[DEBUG] [1590117601.946225500]: Scheduling timer callback for timer [0] of period [0.033333], [0.000286] off expected
[ WARN] [1590117601.946414500]: Failed to meet update rate! Took 0.46050806700000002092
```