### PR TITLE
rostest: fixed missing reload() function in python 3

### DIFF
--- a/tools/rostest/src/rostest/__init__.py
+++ b/tools/rostest/src/rostest/__init__.py
@@ -45,6 +45,11 @@ import rosunit
 
 import rosgraph
 
+try:
+    from importlib import reload
+except ImportError:
+    pass
+
 XML_OUTPUT_FLAG = '--gtest_output=xml:' #use gtest-compatible flag
 
 _GLOBAL_CALLER_ID = '/script'


### PR DESCRIPTION
Executing rostest on noetic produces the following errors:
`  File "/opt/ros/noetic/lib/python3/dist-packages/rostest/__init__.py", line 136, in rosrun
    _start_coverage([package])
  File "/opt/ros/noetic/lib/python3/dist-packages/rostest/__init__.py", line 216, in _start_coverage
    reload(sys.modules[package])
NameError: name 'reload' is not defined
`

Given that `reload` has been removed from the standard library and is now present in `importlib` this pull request should fix this issue.