### PR TITLE
preformance: improve performance of writes

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -49,6 +49,7 @@ import sys
 import threading
 import time
 import yaml
+import enum
 
 from Cryptodome.Cipher import AES
 from Cryptodome.Random import get_random_bytes
@@ -65,10 +66,12 @@ import genpy
 import genpy.dynamic
 import genpy.message
 
-import roslib.names # still needed for roslib.names.canonicalize_name()
+import roslib.names  # still needed for roslib.names.canonicalize_name()
 import rospy
+
 try:
     import roslz4
+
     found_lz4 = True
 except ImportError:
     rospy.logwarn(
@@ -76,58 +79,82 @@ except ImportError:
         'LZ4 compression will not be available.')
     found_lz4 = False
 
+
+class RosBagAction(enum.Enum):
+    """
+    Enum for actions performed on the rosbag that change the position in the batch.
+    """
+    Create = 1
+    Write = 2
+    Reindex = 3
+    Flush = 4
+
+
 class ROSBagException(Exception):
     """
     Base class for exceptions in rosbag.
     """
+
     def __init__(self, value=None):
         self.value = value
-        #fix for #1209. needed in Python 2.7.
+        # fix for #1209. needed in Python 2.7.
         # For details: https://stackoverflow.com/questions/41808912/cannot-unpickle-exception-subclass
         self.args = (value,)
 
     def __str__(self):
         return self.value
 
+
 class ROSBagFormatException(ROSBagException):
     """
     Exceptions for errors relating to the bag file format.
     """
+
     def __init__(self, value):
         ROSBagException.__init__(self, value)
+
 
 class ROSBagUnindexedException(ROSBagException):
     """
     Exception for unindexed bags.
     """
+
     def __init__(self, *args):
-        #*args needed for #1209
+        # *args needed for #1209
         ROSBagException.__init__(self, 'Unindexed bag')
+
 
 class ROSBagEncryptNotSupportedException(ROSBagException):
     """
     Exception raised when encryption is not supported.
     """
+
     def __init__(self, value):
         ROSBagException.__init__(self, value)
+
 
 class ROSBagEncryptException(ROSBagException):
     """
     Exception raised when encryption or decryption failed.
     """
+
     def __init__(self, value):
         ROSBagException.__init__(self, value)
+
 
 class Compression:
     """
     Allowable compression types
     """
     NONE = 'none'
-    BZ2  = 'bz2'
-    LZ4  = 'lz4'
+    BZ2 = 'bz2'
+    LZ4 = 'lz4'
+
 
 BagMessage = collections.namedtuple('BagMessage', 'topic message timestamp')
-BagMessageWithConnectionHeader = collections.namedtuple('BagMessageWithConnectionHeader', 'topic message timestamp connection_header')
+BagMessageWithConnectionHeader = collections.namedtuple('BagMessageWithConnectionHeader',
+                                                        'topic message timestamp connection_header')
+
 
 class _ROSBagEncryptor(object):
     """
@@ -138,10 +165,12 @@ class _ROSBagEncryptor(object):
     def __init__(self):
         pass
 
+
 class _ROSBagNoEncryptor(_ROSBagEncryptor):
     """
     Class for unencrypted bags.
     """
+
     def __init__(self):
         super(_ROSBagNoEncryptor, self).__init__()
 
@@ -171,6 +200,7 @@ class _ROSBagNoEncryptor(_ROSBagEncryptor):
 
     def get_info_str(self):
         return ''
+
 
 class _ROSBagAesCbcEncryptor(_ROSBagEncryptor):
     """
@@ -374,34 +404,43 @@ class _ROSBagAesCbcEncryptor(_ROSBagEncryptor):
         header = cipher.decrypt(encrypted_header)
         return _remove_padding(header)
 
+
 def _add_padding(input_bytes):
     # Add PKCS#7 padding to input string
     padding_num = AES.block_size - len(input_bytes) % AES.block_size
     return input_bytes + bytes((padding_num,) * padding_num)
 
+
 def _remove_padding(input_str):
     # Remove PKCS#7 padding from input string
     return input_str[:-ord(input_str[len(input_str) - 1:])]
+
 
 def _encrypt_string_gpg(key_user, input):
     gpg = gnupg.GPG()
     enc_data = gpg.encrypt(input, [key_user], always_trust=True)
     if not enc_data.ok:
-        raise ROSBagEncryptException('Failed to encrypt bag: {}.  Have you installed a required public key?'.format(enc_data.status))
+        raise ROSBagEncryptException(
+            'Failed to encrypt bag: {}.  Have you installed a required public key?'.format(enc_data.status))
     return str(enc_data)
+
 
 def _decrypt_string_gpg(input, passphrase=None):
     gpg = gnupg.GPG()
     dec_data = gpg.decrypt(input, passphrase=passphrase)
     if not dec_data.ok:
-        raise ROSBagEncryptException('Failed to decrypt bag: {}.  Have you installed a required private key?'.format(dec_data.status))
+        raise ROSBagEncryptException(
+            'Failed to decrypt bag: {}.  Have you installed a required private key?'.format(dec_data.status))
     return dec_data.data
+
 
 class Bag(object):
     """
     Bag serialize messages to and from a single file on disk using the bag format.
     """
-    def __init__(self, f, mode='r', compression=Compression.NONE, chunk_threshold=768 * 1024, allow_unindexed=False, options=None, skip_index=False):
+
+    def __init__(self, f, mode='r', compression=Compression.NONE, chunk_threshold=768 * 1024, allow_unindexed=False,
+                 options=None, skip_index=False):
         """
         Open a bag file.  The mode can be 'r', 'w', or 'a' for reading (default),
         writing or appending.  The file will be created if it doesn't exist
@@ -428,40 +467,42 @@ class Bag(object):
         """
         if options is not None:
             if type(options) is not dict:
-                raise ValueError('options must be of type dict')                
+                raise ValueError('options must be of type dict')
             if 'compression' in options:
                 compression = options['compression']
             if 'chunk_threshold' in options:
                 chunk_threshold = options['chunk_threshold']
 
-        self._file     = None
+        self._file = None
         self._filename = None
-        self._version  = None
+        self._version = None
 
         allowed_compressions = [Compression.NONE, Compression.BZ2]
         if found_lz4:
             allowed_compressions.append(Compression.LZ4)
         if compression not in allowed_compressions:
-            raise ValueError('compression must be one of: %s' % ', '.join(allowed_compressions))  
-        self._compression = compression      
+            raise ValueError('compression must be one of: %s' % ', '.join(allowed_compressions))
+        self._compression = compression
 
         if chunk_threshold < 0:
-            raise ValueError('chunk_threshold must be greater than or equal to zero')        
+            raise ValueError('chunk_threshold must be greater than or equal to zero')
         self._chunk_threshold = chunk_threshold
 
         self._skip_index = skip_index
 
-        self._reader          = None
+        self._reader = None
+
+        self._last_action = RosBagAction.Create
 
         self._file_header_pos = None
-        self._index_data_pos  = 0       # (1.2+)
+        self._index_data_pos = 0  # (1.2+)
 
         self._clear_index()
 
-        self._buffer = StringIO()        
+        self._buffer = StringIO()
 
         self._curr_compression = Compression.NONE
-        
+
         self._encryptor = _ROSBagNoEncryptor()
 
         self._open(f, mode, allow_unindexed)
@@ -473,25 +514,25 @@ class Bag(object):
 
     def __enter__(self):
         return self
-        
+
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
     @property
     def options(self):
         """Get the options."""
-        return { 'compression' : self._compression, 'chunk_threshold' : self._chunk_threshold }
-    
+        return {'compression': self._compression, 'chunk_threshold': self._chunk_threshold}
+
     @property
     def filename(self):
         """Get the filename."""
         return self._filename
-    
+
     @property
     def version(self):
         """Get the version."""
         return self._version
-    
+
     @property
     def mode(self):
         """Get the mode."""
@@ -502,7 +543,7 @@ class Bag(object):
         """Get the size in bytes."""
         if not self._file:
             raise ValueError('I/O operation on closed bag')
-        
+
         pos = self._file.tell()
         self._file.seek(0, os.SEEK_END)
         size = self._file.tell()
@@ -510,30 +551,30 @@ class Bag(object):
         return size
 
     # compression
-        
+
     def _get_compression(self):
         """Get the compression method to use for writing."""
         return self._compression
-    
+
     def _set_compression(self, compression):
         """Set the compression method to use for writing."""
         allowed_compressions = [Compression.NONE, Compression.BZ2]
         if found_lz4:
             allowed_compressions.append(Compression.LZ4)
         if compression not in allowed_compressions:
-            raise ValueError('compression must be one of: %s' % ', '.join(allowed_compressions))        
-        
+            raise ValueError('compression must be one of: %s' % ', '.join(allowed_compressions))
+
         self.flush()
         self._compression = compression
-        
+
     compression = property(_get_compression, _set_compression)
-    
+
     # chunk_threshold
-    
+
     def _get_chunk_threshold(self):
         """Get the chunk threshold to use for writing."""
         return self._chunk_threshold
-    
+
     def _set_chunk_threshold(self, chunk_threshold):
         """Set the chunk threshold to use for writing."""
         if chunk_threshold < 0:
@@ -541,10 +582,11 @@ class Bag(object):
 
         self.flush()
         self._chunk_threshold = chunk_threshold
-        
+
     chunk_threshold = property(_get_chunk_threshold, _set_chunk_threshold)
 
-    def read_messages(self, topics=None, start_time=None, end_time=None, connection_filter=None, raw=False, return_connection_header=False):
+    def read_messages(self, topics=None, start_time=None, end_time=None, connection_filter=None, raw=False,
+                      return_connection_header=False):
         """
         Read messages from the bag, optionally filtered by topic, timestamp and connection details.
         @param topics: list of topics or a single topic. if an empty list is given all topics will be read [optional]
@@ -562,23 +604,27 @@ class Bag(object):
         """
         self.flush()
 
+
         if topics and type(topics) is str:
             topics = [topics]
-        
-        return self._reader.read_messages(topics, start_time, end_time, connection_filter, raw, return_connection_header)
+
+        return self._reader.read_messages(topics, start_time, end_time, connection_filter, raw,
+                                          return_connection_header)
 
     def flush(self):
         """
         Write the open chunk to disk so subsequent reads will read all messages.
-        @raise ValueError: if bag is closed 
+        @raise ValueError: if bag is closed
         """
         if not self._file:
             raise ValueError('I/O operation on closed bag')
 
         if self._chunk_open:
             self._stop_writing_chunk()
+            self._last_action = RosBagAction.Flush
 
-    def write(self, topic, msg, t=None, raw=False, connection_header=None):
+    # @profile
+    def write(self, topic, msg, t=None, index=True, raw=False, connection_header=None):
         """
         Write a message to the bag.
         @param topic: name of topic
@@ -603,7 +649,9 @@ class Bag(object):
             t = genpy.Time.from_sec(time.time())
 
         # Seek to end (in case previous operation was a read)
-        self._file.seek(0, os.SEEK_END)
+        if self._last_action != RosBagAction.Write:
+            self._file.seek(0, os.SEEK_END)
+            self._last_action = RosBagAction.Write
 
         # Open a chunk, if needed
         if not self._chunk_open:
@@ -632,11 +680,13 @@ class Bag(object):
                     except Exception:
                         pytype = None
                 if pytype is None:
-                    raise ROSBagException('cannot locate message class and no message class provided for [%s]' % msg_type)
-    
+                    raise ROSBagException(
+                        'cannot locate message class and no message class provided for [%s]' % msg_type)
+
                 if pytype._md5sum != md5sum:
-                    print('WARNING: md5sum of loaded type [%s] does not match that specified' % msg_type, file=sys.stderr)
-                    #raise ROSBagException('md5sum of loaded type does not match that of data being recorded')
+                    print('WARNING: md5sum of loaded type [%s] does not match that specified' % msg_type,
+                          file=sys.stderr)
+                    # raise ROSBagException('md5sum of loaded type does not match that of data being recorded')
 
                 header = connection_header if connection_header is not None else {
                     'topic': topic,
@@ -662,15 +712,15 @@ class Bag(object):
         # Create an index entry
         index_entry = _IndexEntry200(t, self._curr_chunk_info.pos, self._get_chunk_offset())
 
-        # Update the indexes and current chunk info 
+        # Update the indexes and current chunk info
         if conn_id not in self._curr_chunk_connection_indexes:
             # This is the first message on this connection in the chunk
             self._curr_chunk_connection_indexes[conn_id] = [index_entry]
             self._curr_chunk_info.connection_counts[conn_id] = 1
         else:
             curr_chunk_connection_index = self._curr_chunk_connection_indexes[conn_id]
+            # Test if we're writing chronologically.  Can skip binary search if so.
             if index_entry >= curr_chunk_connection_index[-1]:
-                # Test if we're writing chronologically.  Can skip binary search if so.
                 curr_chunk_connection_index.append(index_entry)
             else:
                 bisect.insort_right(curr_chunk_connection_index, index_entry)
@@ -697,7 +747,7 @@ class Bag(object):
 
         # Write message data record
         self._write_message_data_record(conn_id, t, serialized_bytes)
-        
+
         # Check if we want to stop this chunk
         chunk_size = self._get_chunk_offset()
         if chunk_size > self._chunk_threshold:
@@ -708,6 +758,7 @@ class Bag(object):
         Reindexes the bag file.  Yields position of each chunk for progress.
         """
         self._clear_index()
+        self._last_action = RosBagAction.Reindex
         return self._reader.reindex()
 
     def close(self):
@@ -717,9 +768,9 @@ class Bag(object):
         if self._file:
             if self._mode in 'wa':
                 self._stop_writing()
-            
+
             self._close_file()
-            
+
     def get_compression_info(self):
         """
         Returns information about the compression of the bag
@@ -728,16 +779,16 @@ class Bag(object):
             no compression is used then uncompressed and compressed data will be equal.
         @rtype: generator of CompressionTuple of (str, int, int)
         """
-        
+
         compression = self.compression
         uncompressed = 0
         compressed = 0
-        
+
         if self._chunk_headers:
             compression_counts = {}
             compression_uncompressed = {}
             compression_compressed = {}
-            
+
             # the rest of this is determine which compression algorithm is dominant and
             # to add up the uncompressed and compressed Bytes
             for chunk_header in self._chunk_headers.values():
@@ -747,22 +798,24 @@ class Bag(object):
                     compression_uncompressed[chunk_header.compression] = 0
                 if chunk_header.compression not in compression_compressed:
                     compression_compressed[chunk_header.compression] = 0
-                    
+
                 compression_counts[chunk_header.compression] += 1
                 compression_uncompressed[chunk_header.compression] += chunk_header.uncompressed_size
                 uncompressed += chunk_header.uncompressed_size
                 compression_compressed[chunk_header.compression] += chunk_header.compressed_size
                 compressed += chunk_header.compressed_size
-                
+
             chunk_count = len(self._chunk_headers)
 
-            main_compression_count, main_compression = sorted([(v, k) for k, v in compression_counts.items()], reverse=True)[0]
+            main_compression_count, main_compression = \
+            sorted([(v, k) for k, v in compression_counts.items()], reverse=True)[0]
             compression = str(main_compression)
 
         return collections.namedtuple("CompressionTuple", ["compression",
                                                            "uncompressed", "compressed"])(compression=compression,
-                                                                                          uncompressed=uncompressed, compressed=compressed)
-    
+                                                                                          uncompressed=uncompressed,
+                                                                                          compressed=compressed)
+
     def get_message_count(self, topic_filters=None):
         """
         Returns the number of messages in the bag. Can be filtered by Topic
@@ -771,9 +824,9 @@ class Bag(object):
         @return: The number of messages in the bag, optionally filtered by topic
         @rtype: int
         """
-        
+
         num_messages = 0
-        
+
         if topic_filters is not None:
             info = self.get_type_and_topic_info(topic_filters=topic_filters)
             for topic in info.topics.values():
@@ -785,16 +838,16 @@ class Bag(object):
                         num_messages += counts
             else:
                 num_messages = sum([len(index) for index in self._connection_indexes.values()])
-            
+
         return num_messages
-    
+
     def get_start_time(self):
         """
         Returns the start time of the bag.
         @return: a timestamp of the start of the bag
         @rtype: float, timestamp in seconds, includes fractions of a second
         """
-        
+
         if self._chunks:
             start_stamp = self._chunks[0].start_time.to_sec()
         else:
@@ -802,16 +855,16 @@ class Bag(object):
                 raise ROSBagException('Bag contains no message')
             start_stamps = [index[0].time.to_sec() for index in self._connection_indexes.values() if index]
             start_stamp = min(start_stamps) if start_stamps else 0
-        
+
         return start_stamp
-    
+
     def get_end_time(self):
         """
         Returns the end time of the bag.
         @return: a timestamp of the end of the bag
         @rtype: float, timestamp in seconds, includes fractions of a second
         """
-        
+
         if self._chunks:
             end_stamp = self._chunks[-1].end_time.to_sec()
         else:
@@ -819,19 +872,19 @@ class Bag(object):
                 raise ROSBagException('Bag contains no message')
             end_stamps = [index[-1].time.to_sec() for index in self._connection_indexes.values() if index]
             end_stamp = max(end_stamps) if end_stamps else 0
-        
+
         return end_stamp
-    
+
     def get_type_and_topic_info(self, topic_filters=None):
         """
         Coallates info about the type and topics in the bag.
-        
+
         Note, it would be nice to filter by type as well, but there appear to be some limitations in the current architecture
         that prevent that from working when more than one message type is written on the same topic.
-        
+
         @param topic_filters: specify one or more topic to filter by.
         @type topic_filters: either a single str or a list of str.
-        @return: generator of TypesAndTopicsTuple(types{key:type name, val: md5hash}, 
+        @return: generator of TypesAndTopicsTuple(types{key:type name, val: md5hash},
             topics{type: msg type (Ex. "std_msgs/String"),
                 message_count: the number of messages of the particular type,
                 connections: the number of connections,
@@ -839,43 +892,43 @@ class Bag(object):
                 key: type name,
                 val: md5hash}) describing the types of messages present
             and information about the topics
-        @rtype: TypesAndTopicsTuple(dict(str, str), 
+        @rtype: TypesAndTopicsTuple(dict(str, str),
             TopicTuple(str, int, int, float, str, str))
         """
-        
+
         datatypes = set()
         datatype_infos = []
-        
+
         for connection in self._connections.values():
             if connection.datatype in datatypes:
                 continue
-            
+
             datatype_infos.append((connection.datatype, connection.md5sum, connection.msg_def))
             datatypes.add(connection.datatype)
-            
+
         topics = []
         # load our list of topics and optionally filter
         if topic_filters is not None:
             if not isinstance(topic_filters, list):
                 topic_filters = [topic_filters]
-                
+
             topics = topic_filters
         else:
             topics = [c.topic for c in self._get_connections()]
-            
+
         topics = sorted(set(topics))
-            
+
         topic_datatypes = {}
         topic_conn_counts = {}
         topic_msg_counts = {}
         topic_freqs_median = {}
-        
+
         for topic in topics:
             connections = list(self._get_connections(topic))
-            
+
             if not connections:
                 continue
-                
+
             topic_datatypes[topic] = connections[0].datatype
             topic_conn_counts[topic] = len(connections)
 
@@ -883,7 +936,7 @@ class Bag(object):
             for connection in connections:
                 for chunk in self._chunks:
                     msg_count += chunk.connection_counts.get(connection.id, 0)
-                    
+
             topic_msg_counts[topic] = msg_count
 
             if self._connection_indexes_read:
@@ -894,22 +947,22 @@ class Bag(object):
                     if med_period > 0.0:
                         topic_freqs_median[topic] = 1.0 / med_period
 
-        # process datatypes       
+        # process datatypes
         types = {}
         for datatype, md5sum, msg_def in sorted(datatype_infos):
             types[datatype] = md5sum
-            
+
         # process topics
         topics_t = {}
         TopicTuple = collections.namedtuple("TopicTuple", ["msg_type", "message_count", "connections", "frequency"])
         for topic in sorted(topic_datatypes.keys()):
             topic_msg_count = topic_msg_counts[topic]
             frequency = topic_freqs_median[topic] if topic in topic_freqs_median else None
-            topics_t[topic] = TopicTuple(msg_type=topic_datatypes[topic], 
-                                            message_count=topic_msg_count,
-                                            connections=topic_conn_counts[topic], 
-                                            frequency=frequency)
-            
+            topics_t[topic] = TopicTuple(msg_type=topic_datatypes[topic],
+                                         message_count=topic_msg_count,
+                                         connections=topic_conn_counts[topic],
+                                         frequency=frequency)
+
         return collections.namedtuple("TypesAndTopicsTuple", ["msg_types", "topics"])(msg_types=types, topics=topics_t)
 
     def set_encryptor(self, encryptor=None, param=None):
@@ -942,33 +995,33 @@ class Bag(object):
                 rows.append(('size', _human_readable_size(self.size)))
             else:
                 if self._chunks:
-                    start_stamp = self._chunks[ 0].start_time.to_sec()
-                    end_stamp   = self._chunks[-1].end_time.to_sec()
+                    start_stamp = self._chunks[0].start_time.to_sec()
+                    end_stamp = self._chunks[-1].end_time.to_sec()
                 else:
                     start_stamps = [index[0].time.to_sec() for index in self._connection_indexes.values() if index]
                     start_stamp = min(start_stamps) if start_stamps else 0
                     end_stamps = [index[-1].time.to_sec() for index in self._connection_indexes.values() if index]
                     end_stamp = max(end_stamps) if end_stamps else 0
-    
+
                 # Show duration
                 duration = end_stamp - start_stamp
                 dur_secs = duration % 60
                 dur_mins = int(duration / 60)
-                dur_hrs  = int(dur_mins / 60)
+                dur_hrs = int(dur_mins / 60)
                 if dur_hrs > 0:
                     dur_mins = dur_mins % 60
                     duration_str = '%dhr %d:%02ds (%ds)' % (dur_hrs, dur_mins, dur_secs, duration)
                 elif dur_mins > 0:
                     duration_str = '%d:%02ds (%ds)' % (dur_mins, dur_secs, duration)
                 else:
-                    duration_str = '%.1fs' % duration   
+                    duration_str = '%.1fs' % duration
 
                 rows.append(('duration', duration_str))
-        
+
                 # Show start and end times
                 rows.append(('start', '%s (%.2f)' % (_time_to_str(start_stamp), start_stamp)))
-                rows.append(('end',   '%s (%.2f)' % (_time_to_str(end_stamp),   end_stamp)))
-    
+                rows.append(('end', '%s (%.2f)' % (_time_to_str(end_stamp), end_stamp)))
+
                 rows.append(('size', _human_readable_size(self.size)))
 
                 if self._chunks:
@@ -984,9 +1037,9 @@ class Bag(object):
                 if len(self._chunk_headers) == 0:
                     rows.append(('compression', 'none'))
                 else:
-                    compression_counts       = {}
+                    compression_counts = {}
                     compression_uncompressed = {}
-                    compression_compressed   = {}
+                    compression_compressed = {}
                     for chunk_header in self._chunk_headers.values():
                         if chunk_header.compression not in compression_counts:
                             compression_counts[chunk_header.compression] = 1
@@ -996,39 +1049,45 @@ class Bag(object):
                             compression_counts[chunk_header.compression] += 1
                             compression_uncompressed[chunk_header.compression] += chunk_header.uncompressed_size
                             compression_compressed[chunk_header.compression] += chunk_header.compressed_size
-    
+
                     chunk_count = len(self._chunk_headers)
-    
+
                     compressions = []
                     for count, compression in reversed(sorted([(v, k) for k, v in compression_counts.items()])):
                         if compression != Compression.NONE:
-                            fraction = (100.0 * compression_compressed[compression]) / compression_uncompressed[compression]
-                            compressions.append('%s [%d/%d chunks; %.2f%%]' % (compression, count, chunk_count, fraction))
+                            fraction = (100.0 * compression_compressed[compression]) / compression_uncompressed[
+                                compression]
+                            compressions.append(
+                                '%s [%d/%d chunks; %.2f%%]' % (compression, count, chunk_count, fraction))
                         else:
                             compressions.append('%s [%d/%d chunks]' % (compression, count, chunk_count))
                     rows.append(('compression', ', '.join(compressions)))
-    
-                    all_uncompressed = (sum([count for c, count in compression_counts.items() if c != Compression.NONE]) == 0)
-                    if not all_uncompressed:    
+
+                    all_uncompressed = (
+                                sum([count for c, count in compression_counts.items() if c != Compression.NONE]) == 0)
+                    if not all_uncompressed:
                         total_uncompressed_size = sum((h.uncompressed_size for h in self._chunk_headers.values()))
-                        total_compressed_size   = sum((h.compressed_size   for h in self._chunk_headers.values()))
-                        
+                        total_compressed_size = sum((h.compressed_size for h in self._chunk_headers.values()))
+
                         total_uncompressed_size_str = _human_readable_size(total_uncompressed_size)
-                        total_compressed_size_str   = _human_readable_size(total_compressed_size)
+                        total_compressed_size_str = _human_readable_size(total_compressed_size)
                         total_size_str_length = max([len(total_uncompressed_size_str), len(total_compressed_size_str)])
 
                         if duration > 0:
                             uncompressed_rate_str = _human_readable_size(total_uncompressed_size / duration)
-                            compressed_rate_str   = _human_readable_size(total_compressed_size / duration)
+                            compressed_rate_str = _human_readable_size(total_compressed_size / duration)
                             rate_str_length = max([len(uncompressed_rate_str), len(compressed_rate_str)])
 
                             rows.append(('uncompressed', '%*s @ %*s/s' %
-                                         (total_size_str_length, total_uncompressed_size_str, rate_str_length, uncompressed_rate_str)))
-                            rows.append(('compressed',   '%*s @ %*s/s (%.2f%%)' %
-                                         (total_size_str_length, total_compressed_size_str,   rate_str_length, compressed_rate_str, (100.0 * total_compressed_size) / total_uncompressed_size)))
+                                         (total_size_str_length, total_uncompressed_size_str, rate_str_length,
+                                          uncompressed_rate_str)))
+                            rows.append(('compressed', '%*s @ %*s/s (%.2f%%)' %
+                                         (total_size_str_length, total_compressed_size_str, rate_str_length,
+                                          compressed_rate_str,
+                                          (100.0 * total_compressed_size) / total_uncompressed_size)))
                         else:
                             rows.append(('uncompressed', '%*s' % (total_size_str_length, total_uncompressed_size_str)))
-                            rows.append(('compressed',   '%*s' % (total_size_str_length, total_compressed_size_str)))
+                            rows.append(('compressed', '%*s' % (total_size_str_length, total_compressed_size_str)))
 
                 self._encryptor.add_info_rows(rows)
 
@@ -1039,11 +1098,11 @@ class Bag(object):
                         continue
                     datatype_infos.append((connection.datatype, connection.md5sum, connection.msg_def))
                     datatypes.add(connection.datatype)
-                    
+
                 topics = sorted(set([c.topic for c in self._get_connections()]))
-                topic_datatypes    = {}
-                topic_conn_counts  = {}
-                topic_msg_counts   = {}
+                topic_datatypes = {}
+                topic_conn_counts = {}
+                topic_msg_counts = {}
                 topic_freqs_median = {}
                 for topic in topics:
                     connections = list(self._get_connections(topic))
@@ -1069,24 +1128,27 @@ class Bag(object):
                                 topic_freqs_median[topic] = 1.0 / med_period
 
                 topics = sorted(topic_datatypes.keys())
-                max_topic_len       = max([len(topic) for topic in topics])
-                max_datatype_len    = max([len(datatype) for datatype in datatypes])
-                max_msg_count_len   = max([len('%d' % msg_count) for msg_count in topic_msg_counts.values()])
-                max_freq_median_len = max([len(_human_readable_frequency(freq)) for freq in topic_freqs_median.values()]) if len(topic_freqs_median) > 0 else 0
+                max_topic_len = max([len(topic) for topic in topics])
+                max_datatype_len = max([len(datatype) for datatype in datatypes])
+                max_msg_count_len = max([len('%d' % msg_count) for msg_count in topic_msg_counts.values()])
+                max_freq_median_len = max(
+                    [len(_human_readable_frequency(freq)) for freq in topic_freqs_median.values()]) if len(
+                    topic_freqs_median) > 0 else 0
 
-                # Show datatypes       
+                # Show datatypes
                 for i, (datatype, md5sum, msg_def) in enumerate(sorted(datatype_infos)):
                     s = '%-*s [%s]' % (max_datatype_len, datatype, md5sum)
                     if i == 0:
                         rows.append(('types', s))
                     else:
                         rows.append(('', s))
-                    
+
                 # Show topics
                 for i, topic in enumerate(topics):
                     topic_msg_count = topic_msg_counts[topic]
-                    
-                    s = '%-*s   %*d %s' % (max_topic_len, topic, max_msg_count_len, topic_msg_count, 'msgs' if topic_msg_count > 1 else 'msg ')
+
+                    s = '%-*s   %*d %s' % (
+                    max_topic_len, topic, max_msg_count_len, topic_msg_count, 'msgs' if topic_msg_count > 1 else 'msg ')
                     if topic in topic_freqs_median:
                         s += ' @ %*s' % (max_freq_median_len, _human_readable_frequency(topic_freqs_median[topic]))
                     else:
@@ -1095,12 +1157,12 @@ class Bag(object):
                     s += ' : %-*s' % (max_datatype_len, topic_datatypes[topic])
                     if topic_conn_counts[topic] > 1:
                         s += ' (%d connections)' % topic_conn_counts[topic]
-        
+
                     if i == 0:
                         rows.append(('topics', s))
                     else:
                         rows.append(('', s))
-        
+
         except Exception as ex:
             raise
 
@@ -1132,14 +1194,14 @@ class Bag(object):
                 s += 'indexed: False\n'
             else:
                 if self._chunks:
-                    start_stamp = self._chunks[ 0].start_time.to_sec()
-                    end_stamp   = self._chunks[-1].end_time.to_sec()
+                    start_stamp = self._chunks[0].start_time.to_sec()
+                    end_stamp = self._chunks[-1].end_time.to_sec()
                 else:
                     start_stamps = [index[0].time.to_sec() for index in self._connection_indexes.values() if index]
                     start_stamp = min(start_stamps) if start_stamps else 0
                     end_stamps = [index[-1].time.to_sec() for index in self._connection_indexes.values() if index]
                     end_stamp = max(end_stamps) if end_stamps else 0
-                
+
                 duration = end_stamp - start_stamp
                 s += 'duration: %.6f\n' % duration
                 s += 'start: %.6f\n' % start_stamp
@@ -1159,9 +1221,9 @@ class Bag(object):
                 if len(self._chunk_headers) == 0:
                     s += 'compression: none\n'
                 else:
-                    compression_counts       = {}
+                    compression_counts = {}
                     compression_uncompressed = {}
-                    compression_compressed   = {}
+                    compression_compressed = {}
                     for chunk_header in self._chunk_headers.values():
                         if chunk_header.compression not in compression_counts:
                             compression_counts[chunk_header.compression] = 1
@@ -1171,14 +1233,16 @@ class Bag(object):
                             compression_counts[chunk_header.compression] += 1
                             compression_uncompressed[chunk_header.compression] += chunk_header.uncompressed_size
                             compression_compressed[chunk_header.compression] += chunk_header.compressed_size
-    
+
                     chunk_count = len(self._chunk_headers)
-    
-                    main_compression_count, main_compression = list(reversed(sorted([(v, k) for k, v in compression_counts.items()])))[0]
+
+                    main_compression_count, main_compression = \
+                    list(reversed(sorted([(v, k) for k, v in compression_counts.items()])))[0]
                     s += 'compression: %s\n' % str(main_compression)
-    
-                    all_uncompressed = (sum([count for c, count in compression_counts.items() if c != Compression.NONE]) == 0)
-                    if not all_uncompressed:    
+
+                    all_uncompressed = (
+                                sum([count for c, count in compression_counts.items() if c != Compression.NONE]) == 0)
+                    if not all_uncompressed:
                         s += 'uncompressed: %d\n' % sum((h.uncompressed_size for h in self._chunk_headers.values()))
                         s += 'compressed: %d\n' % sum((h.compressed_size for h in self._chunk_headers.values()))
 
@@ -1191,11 +1255,11 @@ class Bag(object):
                         continue
                     datatype_infos.append((connection.datatype, connection.md5sum, connection.msg_def))
                     datatypes.add(connection.datatype)
-                    
+
                 topics = sorted(set([c.topic for c in self._get_connections()]))
-                topic_datatypes    = {}
-                topic_conn_counts  = {}
-                topic_msg_counts   = {}
+                topic_datatypes = {}
+                topic_conn_counts = {}
+                topic_msg_counts = {}
                 topic_freqs_median = {}
                 for topic in topics:
                     connections = list(self._get_connections(topic))
@@ -1218,26 +1282,28 @@ class Bag(object):
                                 topic_freqs_median[topic] = 1.0 / med_period
 
                 topics = sorted(topic_datatypes.keys())
-                max_topic_len       = max([len(topic) for topic in topics])
-                max_datatype_len    = max([len(datatype) for datatype in datatypes])
-                max_msg_count_len   = max([len('%d' % msg_count) for msg_count in topic_msg_counts.values()])
-                max_freq_median_len = max([len(_human_readable_frequency(freq)) for freq in topic_freqs_median.values()]) if len(topic_freqs_median) > 0 else 0
+                max_topic_len = max([len(topic) for topic in topics])
+                max_datatype_len = max([len(datatype) for datatype in datatypes])
+                max_msg_count_len = max([len('%d' % msg_count) for msg_count in topic_msg_counts.values()])
+                max_freq_median_len = max(
+                    [len(_human_readable_frequency(freq)) for freq in topic_freqs_median.values()]) if len(
+                    topic_freqs_median) > 0 else 0
 
-                # Show datatypes       
+                # Show datatypes
                 s += 'types:\n'
                 for i, (datatype, md5sum, msg_def) in enumerate(sorted(datatype_infos)):
                     s += '    - type: %s\n' % datatype
                     s += '      md5: %s\n' % md5sum
-                    
+
                 # Show topics
                 s += 'topics:\n'
                 for i, topic in enumerate(topics):
                     topic_msg_count = topic_msg_counts[topic]
-                    
+
                     s += '    - topic: %s\n' % topic
                     s += '      type: %s\n' % topic_datatypes[topic]
                     s += '      messages: %d\n' % topic_msg_count
-                        
+
                     if topic_conn_counts[topic] > 1:
                         s += '      connections: %d\n' % topic_conn_counts[topic]
 
@@ -1246,14 +1312,14 @@ class Bag(object):
 
             if not key:
                 return s
-            
+
             class DictObject(object):
                 def __init__(self, d):
                     for a, b in d.items():
                         if isinstance(b, (list, tuple)):
-                           setattr(self, a, [DictObject(x) if isinstance(x, dict) else x for x in b])
+                            setattr(self, a, [DictObject(x) if isinstance(x, dict) else x for x in b])
                         else:
-                           setattr(self, a, DictObject(b) if isinstance(b, dict) else b)
+                            setattr(self, a, DictObject(b) if isinstance(b, dict) else b)
 
             obj = DictObject(yaml.safe_load(s))
             try:
@@ -1344,7 +1410,8 @@ class Bag(object):
         """
         Yield index entries on the given connections in the given time range in reverse order.
         """
-        for entry, _ in _mergesort((reversed(index) for index in self._get_indexes(connections)), key=lambda entry: -entry.time.to_sec()):
+        for entry, _ in _mergesort((reversed(index) for index in self._get_indexes(connections)),
+                                   key=lambda entry: -entry.time.to_sec()):
             if end_time and entry.time > end_time:
                 continue
             if start_time and entry.time < start_time:
@@ -1369,7 +1436,7 @@ class Bag(object):
                     first_entry = index_entry
 
         return first_entry
-    
+
     def _get_entry_after(self, t, connections=None):
         """
         Return the first index entry after the given time on the given connections
@@ -1381,7 +1448,7 @@ class Bag(object):
         first_entry = None
 
         for index in indexes:
-            i = bisect.bisect_right(index, entry) 
+            i = bisect.bisect_right(index, entry)
             if i <= len(index) - 1:
                 index_entry = index[i]
                 if first_entry is None or index_entry < first_entry:
@@ -1405,28 +1472,31 @@ class Bag(object):
 
     def _clear_index(self):
         self._connection_indexes_read = False
-        self._connection_indexes      = {}    # id    -> IndexEntry[] (1.2+)
+        self._connection_indexes = {}  # id    -> IndexEntry[] (1.2+)
 
-        self._topic_connections  = {}    # topic -> connection_id
-        self._connections        = {}    # id -> ConnectionInfo
-        self._connection_count   = 0     # (2.0)
-        self._chunk_count        = 0     # (2.0)
-        self._chunks             = []    # ChunkInfo[] (2.0)
-        self._chunk_headers      = {}    # chunk_pos -> ChunkHeader (2.0)
+        self._topic_connections = {}  # topic -> connection_id
+        self._connections = {}  # id -> ConnectionInfo
+        self._connection_count = 0  # (2.0)
+        self._chunk_count = 0  # (2.0)
+        self._chunks = []  # ChunkInfo[] (2.0)
+        self._chunk_headers = {}  # chunk_pos -> ChunkHeader (2.0)
 
-        self._chunk_open                    = False
-        self._curr_chunk_info               = None
-        self._curr_chunk_data_pos           = None
+        self._chunk_open = False
+        self._curr_chunk_info = None
+        self._curr_chunk_data_pos = None
         self._curr_chunk_connection_indexes = {}
-    
+
     def _open(self, f, mode, allow_unindexed):
         if not f:
             raise ValueError('filename (or stream) is invalid')
 
         try:
-            if   mode == 'r': self._open_read(f, allow_unindexed)
-            elif mode == 'w': self._open_write(f)
-            elif mode == 'a': self._open_append(f, allow_unindexed)
+            if mode == 'r':
+                self._open_read(f, allow_unindexed)
+            elif mode == 'w':
+                self._open_write(f)
+            elif mode == 'a':
+                self._open_append(f, allow_unindexed)
             else:
                 raise ValueError('mode "%s" is invalid' % mode)
             if 'b' not in self._file.mode and not isinstance('', bytes):
@@ -1443,11 +1513,11 @@ class Bag(object):
 
     def _open_read(self, f, allow_unindexed):
         if self._is_file(f):
-            self._file     = f
+            self._file = f
             self._filename = None
         else:
-            self._file     = open(f, 'rb')
-            self._filename = f        
+            self._file = open(f, 'rb')
+            self._filename = f
 
         self._mode = 'r'
 
@@ -1471,10 +1541,10 @@ class Bag(object):
 
     def _open_write(self, f):
         if self._is_file(f):
-            self._file     = f
+            self._file = f
             self._filename = None
         else:
-            self._file     = open(f, 'w+b')
+            self._file = open(f, 'w+b')
             self._filename = f
 
         self._mode = 'w'
@@ -1490,9 +1560,9 @@ class Bag(object):
 
     def _open_append(self, f, allow_unindexed):
         if self._is_file(f):
-            self._file     = f
+            self._file = f
             self._filename = None
-        else:        
+        else:
             try:
                 # Test if the file already exists
                 open(f, 'r').close()
@@ -1502,7 +1572,7 @@ class Bag(object):
             except IOError:
                 # File doesn't exist: open in write mode
                 self._file = open(f, 'w+b')
-        
+
             self._filename = f
 
         self._mode = 'a'
@@ -1548,7 +1618,7 @@ class Bag(object):
                 header = _read_header(self._file)
                 op = _read_uint8_field(header, 'op')
                 self._file.seek(first_record_pos)
-    
+
                 if op == _OP_FILE_HEADER:
                     self._reader = _BagReader102_Indexed(self)
                 else:
@@ -1563,18 +1633,18 @@ class Bag(object):
         version_line = self._file.readline().rstrip().decode()
         if len(version_line) == 0:
             raise ROSBagException('empty file')
-        
+
         matches = re.match("#ROS(.*) V(\d).(\d)", version_line)
         if matches is None or len(matches.groups()) != 3:
             raise ROSBagException('This does not appear to be a bag file')
-        
+
         version_type, major_version_str, minor_version_str = matches.groups()
 
         version = int(major_version_str) * 100 + int(minor_version_str)
-        
+
         return version
 
-    def _start_writing(self):        
+    def _start_writing(self):
         version = _VERSION + '\n'
         version = version.encode()
         self._file.write(version)
@@ -1616,7 +1686,7 @@ class Bag(object):
         # Truncate the file to chop off the index
         self._file.truncate(self._index_data_pos)
         self._reader.index_data_pos = 0
-    
+
         # Rewrite the file header, clearing the index position (so we know if the index is invalid)
         self._file.seek(self._file_header_pos);
         self._write_file_header_record(0, 0, 0)
@@ -1630,7 +1700,7 @@ class Bag(object):
         self._curr_chunk_data_pos = self._file.tell()
         self._set_compression_mode(self._compression)
         self._chunk_open = True
-    
+
     def _get_chunk_offset(self):
         if self._compression == Compression.NONE:
             return self._file.tell() - self._curr_chunk_data_pos
@@ -1670,7 +1740,7 @@ class Bag(object):
         # Flush the compressor, if needed
         if self._curr_compression != Compression.NONE:
             self._output_file.flush()
-        
+
         # Create the compressor
         if compression == Compression.BZ2:
             self._output_file = _CompressorFileFacade(self._file, bz2.BZ2Compressor())
@@ -1685,9 +1755,9 @@ class Bag(object):
 
     def _write_file_header_record(self, index_pos, connection_count, chunk_count):
         header = {
-            'op':          _pack_uint8(_OP_FILE_HEADER),
-            'index_pos':   _pack_uint64(index_pos),
-            'conn_count':  _pack_uint32(connection_count),
+            'op': _pack_uint8(_OP_FILE_HEADER),
+            'index_pos': _pack_uint64(index_pos),
+            'conn_count': _pack_uint32(connection_count),
             'chunk_count': _pack_uint32(chunk_count)
         }
         self._encryptor.add_fields_to_file_header(header)
@@ -1695,9 +1765,9 @@ class Bag(object):
 
     def _write_connection_record(self, connection_info, encrypt):
         header = {
-            'op':    _pack_uint8(_OP_CONNECTION),
+            'op': _pack_uint8(_OP_CONNECTION),
             'topic': connection_info.topic,
-            'conn':  _pack_uint32(connection_info.id)
+            'conn': _pack_uint32(connection_info.id)
         }
         if encrypt:
             self._encryptor.write_encrypted_header(_write_header, self._output_file, header)
@@ -1711,7 +1781,7 @@ class Bag(object):
 
     def _write_message_data_record(self, connection_id, t, serialized_bytes):
         header = {
-            'op':   _pack_uint8(_OP_MSG_DATA),
+            'op': _pack_uint8(_OP_MSG_DATA),
             'conn': _pack_uint32(connection_id),
             'time': _pack_time(t)
         }
@@ -1719,41 +1789,41 @@ class Bag(object):
 
     def _write_chunk_header(self, chunk_header):
         header = {
-            'op':          _pack_uint8(_OP_CHUNK),
+            'op': _pack_uint8(_OP_CHUNK),
             'compression': chunk_header.compression,
-            'size':        _pack_uint32(chunk_header.uncompressed_size)
+            'size': _pack_uint32(chunk_header.uncompressed_size)
         }
         _write_header(self._file, header)
 
         self._file.write(_pack_uint32(chunk_header.compressed_size))
 
-    def _write_connection_index_record(self, connection_id, entries):        
+    def _write_connection_index_record(self, connection_id, entries):
         header = {
-            'op':    _pack_uint8(_OP_INDEX_DATA),
-            'conn':  _pack_uint32(connection_id),
-            'ver':   _pack_uint32(_INDEX_VERSION),
+            'op': _pack_uint8(_OP_INDEX_DATA),
+            'conn': _pack_uint32(connection_id),
+            'ver': _pack_uint32(_INDEX_VERSION),
             'count': _pack_uint32(len(entries))
         }
 
         buffer = self._buffer
         buffer.seek(0)
-        buffer.truncate(0)            
+        buffer.truncate(0)
         for entry in entries:
-            buffer.write(_pack_time  (entry.time))
+            buffer.write(_pack_time(entry.time))
             buffer.write(_pack_uint32(entry.offset))
-            
-        _write_record(self._file, header, buffer.getvalue())            
+
+        _write_record(self._file, header, buffer.getvalue())
 
     def _write_chunk_info_record(self, chunk_info):
         header = {
-            'op':         _pack_uint8 (_OP_CHUNK_INFO),
-            'ver':        _pack_uint32(_CHUNK_INDEX_VERSION),
-            'chunk_pos':  _pack_uint64(chunk_info.pos),
+            'op': _pack_uint8(_OP_CHUNK_INFO),
+            'ver': _pack_uint32(_CHUNK_INDEX_VERSION),
+            'chunk_pos': _pack_uint64(chunk_info.pos),
             'start_time': _pack_time(chunk_info.start_time),
-            'end_time':   _pack_time(chunk_info.end_time),
-            'count':      _pack_uint32(len(chunk_info.connection_counts))
+            'end_time': _pack_time(chunk_info.end_time),
+            'count': _pack_uint32(len(chunk_info.connection_counts))
         }
-        
+
         buffer = self._buffer
         buffer.seek(0)
         buffer.truncate(0)
@@ -1761,83 +1831,91 @@ class Bag(object):
             buffer.write(_pack_uint32(connection_id))
             buffer.write(_pack_uint32(count))
 
-        _write_record(self._file, header, buffer.getvalue())    
+        _write_record(self._file, header, buffer.getvalue())
 
-### Implementation ###
+    ### Implementation ###
 
-_message_types = {}   # md5sum -> type
 
-_OP_MSG_DEF     = 0x01
-_OP_MSG_DATA    = 0x02
+_message_types = {}  # md5sum -> type
+
+_OP_MSG_DEF = 0x01
+_OP_MSG_DATA = 0x02
 _OP_FILE_HEADER = 0x03
-_OP_INDEX_DATA  = 0x04
-_OP_CHUNK       = 0x05
-_OP_CHUNK_INFO  = 0x06
-_OP_CONNECTION  = 0x07
+_OP_INDEX_DATA = 0x04
+_OP_CHUNK = 0x05
+_OP_CHUNK_INFO = 0x06
+_OP_CONNECTION = 0x07
 
 _OP_CODES = {
-    _OP_MSG_DEF:     'MSG_DEF',
-    _OP_MSG_DATA:    'MSG_DATA',
+    _OP_MSG_DEF: 'MSG_DEF',
+    _OP_MSG_DATA: 'MSG_DATA',
     _OP_FILE_HEADER: 'FILE_HEADER',
-    _OP_INDEX_DATA:  'INDEX_DATA',
-    _OP_CHUNK:       'CHUNK',
-    _OP_CHUNK_INFO:  'CHUNK_INFO',
-    _OP_CONNECTION:  'CONNECTION'
+    _OP_INDEX_DATA: 'INDEX_DATA',
+    _OP_CHUNK: 'CHUNK',
+    _OP_CHUNK_INFO: 'CHUNK_INFO',
+    _OP_CONNECTION: 'CONNECTION'
 }
 
-_VERSION             = '#ROSBAG V2.0'
-_FILE_HEADER_LENGTH  = 4096
-_INDEX_VERSION       = 1
+_VERSION = '#ROSBAG V2.0'
+_FILE_HEADER_LENGTH = 4096
+_INDEX_VERSION = 1
 _CHUNK_INDEX_VERSION = 1
+
 
 class _ConnectionInfo(object):
     def __init__(self, id, topic, header):
         try:
             datatype = _read_str_field(header, 'type')
-            md5sum   = _read_str_field(header, 'md5sum')
-            msg_def  = _read_str_field(header, 'message_definition')
+            md5sum = _read_str_field(header, 'md5sum')
+            msg_def = _read_str_field(header, 'message_definition')
         except KeyError as ex:
             raise ROSBagFormatException('connection header field %s not found' % str(ex))
 
-        self.id       = id
-        self.topic    = topic
+        self.id = id
+        self.topic = topic
         self.datatype = datatype
-        self.md5sum   = md5sum
-        self.msg_def  = msg_def
-        self.header   = header
+        self.md5sum = md5sum
+        self.msg_def = msg_def
+        self.header = header
 
     def __str__(self):
         return '%d on %s: %s' % (self.id, self.topic, str(self.header))
 
+
 class _ChunkInfo(object):
     def __init__(self, pos, start_time, end_time):
-        self.pos        = pos
+        self.pos = pos
         self.start_time = start_time
-        self.end_time   = end_time
-        
+        self.end_time = end_time
+
         self.connection_counts = {}
 
     def __str__(self):
-        s  = 'chunk_pos:   %d\n' % self.pos
+        s = 'chunk_pos:   %d\n' % self.pos
         s += 'start_time:  %s\n' % str(self.start_time)
         s += 'end_time:    %s\n' % str(self.end_time)
         s += 'connections: %d\n' % len(self.connection_counts)
-        s += '\n'.join(['  - [%4d] %d' % (connection_id, count) for connection_id, count in self.connection_counts.items()])
+        s += '\n'.join(
+            ['  - [%4d] %d' % (connection_id, count) for connection_id, count in self.connection_counts.items()])
         return s
+
 
 class _ChunkHeader(object):
     def __init__(self, compression, compressed_size, uncompressed_size, data_pos=0):
-        self.compression       = compression
-        self.compressed_size   = compressed_size
+        self.compression = compression
+        self.compressed_size = compressed_size
         self.uncompressed_size = uncompressed_size
-        self.data_pos          = data_pos
+        self.data_pos = data_pos
 
     def __str__(self):
         if self.uncompressed_size > 0:
             ratio = 100 * (float(self.compressed_size) / self.uncompressed_size)
-            return 'compression: %s, size: %d, uncompressed: %d (%.2f%%)' % (self.compression, self.compressed_size, self.uncompressed_size, ratio)
+            return 'compression: %s, size: %d, uncompressed: %d (%.2f%%)' % (
+            self.compression, self.compressed_size, self.uncompressed_size, ratio)
         else:
-            return 'compression: %s, size: %d, uncompressed: %d' % (self.compression, self.compressed_size, self.uncompressed_size)
+            return 'compression: %s, size: %d, uncompressed: %d' % (
+            self.compression, self.compressed_size, self.uncompressed_size)
+
 
 class ComparableMixin(object):
     __slots__ = []
@@ -1868,6 +1946,7 @@ class ComparableMixin(object):
     def __ne__(self, other):
         return self._compare(other, lambda s, o: s != o)
 
+
 class _IndexEntry(ComparableMixin):
     __slots__ = ['time']
 
@@ -1877,27 +1956,29 @@ class _IndexEntry(ComparableMixin):
     def _cmpkey(self):
         return self.time
 
+
 class _IndexEntry102(_IndexEntry):
     __slots__ = ['offset']
 
     def __init__(self, time, offset):
-        self.time   = time
+        self.time = time
         self.offset = offset
-        
+
     @property
     def position(self):
         return self.offset
-        
+
     def __str__(self):
         return '%d.%d: %d' % (self.time.secs, self.time.nsecs, self.offset)
+
 
 class _IndexEntry200(_IndexEntry):
     __slots__ = ['chunk_pos', 'offset']
 
     def __init__(self, time, chunk_pos, offset):
-        self.time      = time
+        self.time = time
         self.chunk_pos = chunk_pos
-        self.offset    = offset
+        self.offset = offset
 
     @property
     def position(self):
@@ -1905,17 +1986,21 @@ class _IndexEntry200(_IndexEntry):
 
     def __str__(self):
         return '%d.%d: %d+%d' % (self.time.secs, self.time.nsecs, self.chunk_pos, self.offset)
-    
+
+
 def _get_message_type(info):
     message_type = _message_types.get(info.md5sum)
     if message_type is None:
         try:
             message_type = genpy.dynamic.generate_dynamic(info.datatype, info.msg_def)[info.datatype]
             if (message_type._md5sum != info.md5sum):
-                print('WARNING: For type [%s] stored md5sum [%s] does not match message definition [%s].\n  Try: "rosrun rosbag fix_msg_defs.py old_bag new_bag."'%(info.datatype, info.md5sum, message_type._md5sum), file=sys.stderr)
+                print(
+                    'WARNING: For type [%s] stored md5sum [%s] does not match message definition [%s].\n  Try: "rosrun rosbag fix_msg_defs.py old_bag new_bag."' % (
+                    info.datatype, info.md5sum, message_type._md5sum), file=sys.stderr)
         except genmsg.InvalidMsgSpec:
             message_type = genpy.dynamic.generate_dynamic(info.datatype, "")[info.datatype]
-            print('WARNING: For type [%s] stored md5sum [%s] has invalid message definition."'%(info.datatype, info.md5sum), file=sys.stderr)
+            print('WARNING: For type [%s] stored md5sum [%s] has invalid message definition."' % (
+            info.datatype, info.md5sum), file=sys.stderr)
         except genmsg.MsgGenerationException as ex:
             raise ROSBagException('Error generating datatype %s: %s' % (info.datatype, str(ex)))
 
@@ -1923,36 +2008,65 @@ def _get_message_type(info):
 
     return message_type
 
-def _read_uint8 (f): return _unpack_uint8 (f.read(1))
+
+def _read_uint8(f): return _unpack_uint8(f.read(1))
+
+
 def _read_uint32(f): return _unpack_uint32(f.read(4))
+
+
 def _read_uint64(f): return _unpack_uint64(f.read(8))
-def _read_time  (f): return _unpack_time  (f.read(8))
+
+
+def _read_time(f): return _unpack_time(f.read(8))
+
 
 def _decode_bytes(v):  return v
+
+
 def _decode_str(v):    return v if type(v) is str else v.decode()
+
+
 def _unpack_uint8(v):  return struct.unpack('<B', v)[0]
+
+
 def _unpack_uint32(v): return struct.unpack('<L', v)[0]
+
+
 def _unpack_uint64(v): return struct.unpack('<Q', v)[0]
+
+
 def _unpack_time(v):   return rospy.Time(*struct.unpack('<LL', v))
 
+
 def _pack_uint8(v):  return struct.pack('<B', v)
+
+
 def _pack_uint32(v): return struct.pack('<L', v)
+
+
 def _pack_uint64(v): return struct.pack('<Q', v)
+
+
 def _pack_time(v):   return _pack_uint32(v.secs) + _pack_uint32(v.nsecs)
+
 
 def _read(f, size):
     data = f.read(size)
     if len(data) != size:
-        raise ROSBagException('expecting %d bytes, read %d' % (size, len(data)))   
+        raise ROSBagException('expecting %d bytes, read %d' % (size, len(data)))
     return data
+
 
 def _skip_record(f):
     _skip_sized(f)  # skip header
     _skip_sized(f)  # skip data
 
+
 def _skip_sized(f):
     size = _read_uint32(f)
     f.seek(size, os.SEEK_CUR)
+
 
 def _read_sized(f):
     try:
@@ -1961,29 +2075,43 @@ def _read_sized(f):
         raise ROSBagFormatException('error unpacking uint32: %s' % str(ex))
     return _read(f, size)
 
+
 def _write_sized(f, v):
     if not isinstance(v, bytes):
         v = v.encode()
     f.write(_pack_uint32(len(v)))
     f.write(v)
 
+
 def _read_field(header, field, unpack_fn):
     if field not in header:
         raise ROSBagFormatException('expected "%s" field in record' % field)
-    
+
     try:
         value = unpack_fn(header[field])
     except Exception as ex:
         raise ROSBagFormatException('error reading field "%s": %s' % (field, str(ex)))
-    
+
     return value
 
-def _read_bytes_field (header, field): return _read_field(header, field, _decode_bytes)
-def _read_str_field   (header, field): return _read_field(header, field, _decode_str)
-def _read_uint8_field (header, field): return _read_field(header, field, _unpack_uint8)
+
+def _read_bytes_field(header, field): return _read_field(header, field, _decode_bytes)
+
+
+def _read_str_field(header, field): return _read_field(header, field, _decode_str)
+
+
+def _read_uint8_field(header, field): return _read_field(header, field, _unpack_uint8)
+
+
 def _read_uint32_field(header, field): return _read_field(header, field, _unpack_uint32)
+
+
 def _read_uint64_field(header, field): return _read_field(header, field, _unpack_uint64)
-def _read_time_field  (header, field): return _read_field(header, field, _unpack_time)
+
+
+def _read_time_field(header, field): return _read_field(header, field, _unpack_time)
+
 
 def _write_record(f, header, data='', padded_size=None):
     header_str = _write_header(f, header)
@@ -1997,6 +2125,7 @@ def _write_record(f, header, data='', padded_size=None):
 
     _write_sized(f, data)
 
+
 def _write_header(f, header):
     header_str = b''
     equal = b'='
@@ -2009,6 +2138,7 @@ def _write_header(f, header):
     _write_sized(f, header_str)
     return header_str
 
+
 def _read_header(f, req_op=None):
     bag_pos = f.tell()
 
@@ -2020,14 +2150,15 @@ def _read_header(f, req_op=None):
 
     return _build_header_from_str(header, req_op)
 
+
 def _build_header_from_str(header, req_op):
     # Parse header into a dict
     header_dict = {}
     while header != b'':
         # Read size
         if len(header) < 4:
-            raise ROSBagFormatException('Error reading header field')           
-        (size,) = struct.unpack('<L', header[:4])                          # @todo reindex: catch struct.error
+            raise ROSBagFormatException('Error reading header field')
+        (size,) = struct.unpack('<L', header[:4])  # @todo reindex: catch struct.error
         header = header[4:]
 
         # Read bytes
@@ -2038,8 +2169,8 @@ def _build_header_from_str(header, req_op):
             raise ROSBagFormatException('Error reading header field')
 
         name = name.decode()
-        header_dict[name] = value                                          # @todo reindex: raise exception on empty name
-        
+        header_dict[name] = value  # @todo reindex: raise exception on empty name
+
         header = header[size:]
 
     # Check the op code of the header, if supplied
@@ -2050,12 +2181,14 @@ def _build_header_from_str(header, req_op):
 
     return header_dict
 
+
 def _peek_next_header_op(f):
     pos = f.tell()
     header = _read_header(f)
     op = _read_uint8_field(header, 'op')
     f.seek(pos)
     return op
+
 
 def _read_record_data(f):
     try:
@@ -2065,10 +2198,11 @@ def _read_record_data(f):
 
     return record_data
 
+
 class _BagReader(object):
     def __init__(self, bag):
         self.bag = bag
-        
+
     def start_reading(self):
         raise NotImplementedError()
 
@@ -2078,22 +2212,24 @@ class _BagReader(object):
     def reindex(self):
         raise NotImplementedError()
 
+
 class _BagReader102_Unindexed(_BagReader):
     """
     Support class for reading unindexed v1.2 bag files.
     """
+
     def __init__(self, bag):
         _BagReader.__init__(self, bag)
-        
+
     def start_reading(self):
         self.bag._file_header_pos = self.bag._file.tell()
 
     def reindex(self):
         """Generates all bag index information by rereading the message records."""
         f = self.bag._file
-        
+
         total_bytes = self.bag.size
-        
+
         # Re-read the file header to get to the start of the first message
         self.bag._file.seek(self.bag._file_header_pos)
 
@@ -2102,23 +2238,23 @@ class _BagReader102_Unindexed(_BagReader):
         # Read message definition and data records
         while offset < total_bytes:
             yield offset
-            
+
             op = _peek_next_header_op(f)
 
             if op == _OP_MSG_DEF:
                 connection_info = self.read_message_definition_record()
-    
+
                 if connection_info.topic not in self.bag._topic_connections:
                     self.bag._topic_connections[connection_info.topic] = connection_info.id
-                    self.bag._connections[connection_info.id]          = connection_info
-                    self.bag._connection_indexes[connection_info.id]   = []
+                    self.bag._connections[connection_info.id] = connection_info
+                    self.bag._connection_indexes[connection_info.id] = []
 
             elif op == _OP_MSG_DATA:
                 # Read the topic and timestamp from the header
                 header = _read_header(f)
-                
+
                 topic = _read_str_field(header, 'topic')
-                secs  = _read_uint32_field(header, 'sec')
+                secs = _read_uint32_field(header, 'sec')
                 nsecs = _read_uint32_field(header, 'nsec')
                 t = genpy.Time(secs, nsecs)
 
@@ -2134,7 +2270,7 @@ class _BagReader102_Unindexed(_BagReader):
 
                 # Insert the message entry (in order) into the connection index
                 bisect.insort_right(self.bag._connection_indexes[connection_id], _IndexEntry102(t, offset))
-            
+
             offset = f.tell()
 
     def read_messages(self, topics, start_time, end_time, topic_filter, raw, return_connection_header=False):
@@ -2146,7 +2282,7 @@ class _BagReader102_Unindexed(_BagReader):
             # Read MSG_DEF records
             while True:
                 position = f.tell()
-                
+
                 try:
                     header = _read_header(f)
                 except Exception:
@@ -2157,7 +2293,7 @@ class _BagReader102_Unindexed(_BagReader):
                     break
 
                 connection_info = self.read_message_definition_record(header)
-                
+
                 if connection_info.topic not in self.bag._topic_connections:
                     self.bag._topic_connections[connection_info.topic] = connection_info.id
 
@@ -2168,28 +2304,29 @@ class _BagReader102_Unindexed(_BagReader):
                 raise ROSBagFormatException('Expecting OP_MSG_DATA, got %d' % op)
 
             topic = _read_str_field(header, 'topic')
-            
+
             if topic not in self.bag._topic_connections:
                 datatype = _read_str_field(header, 'type')
                 self._create_connection_info_for_datatype(topic, datatype)
 
             connection_id = self.bag._topic_connections[topic]
             info = self.bag._connections[connection_id]
-    
+
             # Get the message type
             try:
                 msg_type = _get_message_type(info)
             except KeyError:
-                raise ROSBagException('Cannot deserialize messages of type [%s].  Message was not preceeded in bagfile by definition' % info.datatype)
+                raise ROSBagException(
+                    'Cannot deserialize messages of type [%s].  Message was not preceeded in bagfile by definition' % info.datatype)
 
             # Get the timestamp
-            secs  = _read_uint32_field(header, 'sec')
+            secs = _read_uint32_field(header, 'sec')
             nsecs = _read_uint32_field(header, 'nsec')
             t = genpy.Time(secs, nsecs)
 
             # Read the message content
             data = _read_record_data(f)
-            
+
             if raw:
                 msg = (info.datatype, data, info.md5sum, position, msg_type)
             else:
@@ -2207,12 +2344,13 @@ class _BagReader102_Unindexed(_BagReader):
     def _create_connection_info_for_datatype(self, topic, datatype):
         for c in self.bag._connections.values():
             if c.datatype == datatype:
-                connection_id     = len(self.bag._connections)
-                connection_header = { 'topic' : topic, 'type' : c.header['type'], 'md5sum' : c.header['md5sum'], 'message_definition' : c.header['message_definition'] }
-                connection_info   = _ConnectionInfo(connection_id, topic, connection_header)
+                connection_id = len(self.bag._connections)
+                connection_header = {'topic': topic, 'type': c.header['type'], 'md5sum': c.header['md5sum'],
+                                     'message_definition': c.header['message_definition']}
+                connection_info = _ConnectionInfo(connection_id, topic, connection_header)
 
-                self.bag._topic_connections[topic]          = connection_id
-                self.bag._connections[connection_id]        = connection_info
+                self.bag._topic_connections[topic] = connection_id
+                self.bag._connections[connection_id] = connection_info
                 self.bag._connection_indexes[connection_id] = []
                 return
 
@@ -2222,23 +2360,25 @@ class _BagReader102_Unindexed(_BagReader):
         if not header:
             header = _read_header(self.bag._file, _OP_MSG_DEF)
 
-        topic    = _read_str_field(header, 'topic')
+        topic = _read_str_field(header, 'topic')
         datatype = _read_str_field(header, 'type')
-        md5sum   = _read_str_field(header, 'md5')
-        msg_def  = _read_str_field(header, 'def')
+        md5sum = _read_str_field(header, 'md5')
+        msg_def = _read_str_field(header, 'def')
 
         _skip_sized(self.bag._file)  # skip the record data
 
-        connection_header = { 'topic' : topic, 'type' : datatype, 'md5sum' : md5sum, 'message_definition' : msg_def }
+        connection_header = {'topic': topic, 'type': datatype, 'md5sum': md5sum, 'message_definition': msg_def}
 
         id = len(self.bag._connections)
 
         return _ConnectionInfo(id, topic, connection_header)
 
+
 class _BagReader102_Indexed(_BagReader102_Unindexed):
     """
     Support class for reading indexed v1.2 bag files.
     """
+
     def __init__(self, bag):
         _BagReader.__init__(self, bag)
 
@@ -2250,9 +2390,9 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
     def reindex(self):
         """Generates all bag index information by rereading the message records."""
         f = self.bag._file
-        
+
         total_bytes = self.bag.size
-        
+
         # Re-read the file header to get to the start of the first message
         self.bag._file.seek(self.bag._file_header_pos)
         self.read_file_header_record()
@@ -2262,12 +2402,12 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
         # Read message definition and data records
         while offset < total_bytes:
             yield offset
-            
+
             op = _peek_next_header_op(f)
 
             if op == _OP_MSG_DEF:
                 connection_info = self.read_message_definition_record()
-    
+
                 if connection_info.topic not in self.bag._topic_connections:
                     self.bag._topic_connections[connection_info.topic] = connection_info.id
                     self.bag._connections[connection_info.id] = connection_info
@@ -2276,9 +2416,9 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
             elif op == _OP_MSG_DATA:
                 # Read the topic and timestamp from the header
                 header = _read_header(f)
-                
+
                 topic = _read_str_field(header, 'topic')
-                secs  = _read_uint32_field(header, 'sec')
+                secs = _read_uint32_field(header, 'sec')
                 nsecs = _read_uint32_field(header, 'nsec')
                 t = genpy.Time(secs, nsecs)
 
@@ -2304,13 +2444,13 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
         try:
             # Read the file header
             self.read_file_header_record()
-            
+
             total_bytes = self.bag.size
-    
+
             # Check if the index position has been written, i.e. the bag was closed successfully
             if self.bag._index_data_pos == 0:
                 raise ROSBagUnindexedException()
-    
+
             # Seek to the beginning of the topic index records
             self.bag._file.seek(self.bag._index_data_pos)
 
@@ -2328,13 +2468,13 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
             # Read the message definition records (one for each topic)
             for topic, index in topic_indexes.items():
                 self.bag._file.seek(index[0].offset)
-    
+
                 connection_info = self.read_message_definition_record()
-    
+
                 if connection_info.topic not in self.bag._topic_connections:
                     self.bag._topic_connections[connection_info.topic] = connection_info.id
                 self.bag._connections[connection_info.id] = connection_info
-    
+
                 self.bag._connection_indexes[connection_info.id] = index
 
             self.bag._connection_indexes_read = True
@@ -2357,22 +2497,22 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
         header = _read_header(f, _OP_INDEX_DATA)
 
         index_version = _read_uint32_field(header, 'ver')
-        topic         = _read_str_field   (header, 'topic')
-        count         = _read_uint32_field(header, 'count')
-        
+        topic = _read_str_field(header, 'topic')
+        count = _read_uint32_field(header, 'count')
+
         if index_version != 0:
             raise ROSBagFormatException('expecting index version 0, got %d' % index_version)
-    
-        _read_uint32(f) # skip the record data size
+
+        _read_uint32(f)  # skip the record data size
 
         topic_index = []
-                
+
         for i in range(count):
-            time   = _read_time  (f)
+            time = _read_time(f)
             offset = _read_uint64(f)
-            
+
             topic_index.append(_IndexEntry102(time, offset))
-            
+
         return (topic, topic_index)
 
     def seek_and_read_message_data_record(self, position, raw, return_connection_header=False):
@@ -2392,7 +2532,7 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
         # Check that we have a MSG_DATA record
         if op != _OP_MSG_DATA:
             raise ROSBagFormatException('Expecting OP_MSG_DATA, got %d' % op)
-        
+
         topic = _read_str_field(header, 'topic')
 
         connection_id = self.bag._topic_connections[topic]
@@ -2402,38 +2542,41 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
         try:
             msg_type = _get_message_type(info)
         except KeyError:
-            raise ROSBagException('Cannot deserialize messages of type [%s].  Message was not preceeded in bagfile by definition' % info.datatype)
+            raise ROSBagException(
+                'Cannot deserialize messages of type [%s].  Message was not preceeded in bagfile by definition' % info.datatype)
 
         # Get the timestamp
-        secs  = _read_uint32_field(header, 'sec')
+        secs = _read_uint32_field(header, 'sec')
         nsecs = _read_uint32_field(header, 'nsec')
         t = genpy.Time(secs, nsecs)
 
         # Read the message content
         data = _read_record_data(f)
-        
+
         if raw:
             msg = info.datatype, data, info.md5sum, position, msg_type
         else:
             # Deserialize the message
             msg = msg_type()
             msg.deserialize(data)
-        
+
         if return_connection_header:
             return BagMessageWithConnectionHeader(topic, msg, t, header)
         else:
             return BagMessage(topic, msg, t)
 
+
 class _BagReader200(_BagReader):
     """
     Support class for reading v2.0 bag files.
     """
+
     def __init__(self, bag):
         _BagReader.__init__(self, bag)
-        
+
         self.decompressed_chunk_pos = None
-        self.decompressed_chunk     = None
-        self.decompressed_chunk_io  = None
+        self.decompressed_chunk = None
+        self.decompressed_chunk_io = None
 
     def reindex(self):
         """
@@ -2466,7 +2609,7 @@ class _BagReader200(_BagReader):
                 self._reindex_read_chunk(f, chunk_pos, total_bytes)
             except Exception as ex:
                 break
-            
+
             trunc_pos = f.tell()
 
         if trunc_pos and trunc_pos < total_bytes:
@@ -2534,7 +2677,7 @@ class _BagReader200(_BagReader):
                 header = _read_header(chunk_file)
 
                 connection_id = _read_uint32_field(header, 'conn')
-                t             = _read_time_field  (header, 'time')
+                t = _read_time_field(header, 'time')
 
                 # Update the chunk info with this timestamp
                 if not self.bag._curr_chunk_info:
@@ -2554,8 +2697,10 @@ class _BagReader200(_BagReader):
 
                 # Insert the message entry (in order) into the connection index
                 if connection_id not in self.bag._connection_indexes:
-                    raise ROSBagException('connection id (id=%d) in chunk at position %d not preceded by connection record' % (connection_id, chunk_pos))
-                bisect.insort_right(self.bag._connection_indexes[connection_id], _IndexEntry200(t, chunk_pos, offset)) 
+                    raise ROSBagException(
+                        'connection id (id=%d) in chunk at position %d not preceded by connection record' % (
+                        connection_id, chunk_pos))
+                bisect.insort_right(self.bag._connection_indexes[connection_id], _IndexEntry200(t, chunk_pos, offset))
 
                 expected_index_length += 1
 
@@ -2567,9 +2712,9 @@ class _BagReader200(_BagReader):
 
         # Skip over index records, connection records and chunk info records
         next_op = _peek_next_header_op(f)
-        
+
         total_index_length = 0
-        
+
         while next_op != _OP_CHUNK:
             if next_op == _OP_INDEX_DATA:
                 # Bug workaround: C Turtle bags (pre-1.1.15) were written with an incorrect data length
@@ -2580,7 +2725,8 @@ class _BagReader200(_BagReader):
 
             if f.tell() >= total_bytes:
                 if total_index_length != expected_index_length:
-                    raise ROSBagException('index shorter than expected (%d vs %d)' % (total_index_length, expected_index_length))
+                    raise ROSBagException(
+                        'index shorter than expected (%d vs %d)' % (total_index_length, expected_index_length))
                 break
 
             next_op = _peek_next_header_op(f)
@@ -2638,11 +2784,11 @@ class _BagReader200(_BagReader):
         try:
             # Read the file header
             self.read_file_header_record()
-    
+
             # Check if the index position has been written, i.e. the bag was closed successfully
             if self.bag._index_data_pos == 0:
                 raise ROSBagUnindexedException()
-    
+
             # Seek to the end of the chunks
             self.bag._file.seek(self.bag._index_data_pos)
 
@@ -2656,7 +2802,7 @@ class _BagReader200(_BagReader):
 
             # Read the chunk info records
             self.bag._chunks = [self.read_chunk_info_record() for i in range(self.bag._chunk_count)]
-    
+
             # Read the chunk headers
             self.bag._chunk_headers = {}
             for chunk_info in self.bag._chunks:
@@ -2705,8 +2851,8 @@ class _BagReader200(_BagReader):
 
         header = _read_header(self.bag._file, _OP_FILE_HEADER)
 
-        self.bag._index_data_pos   = _read_uint64_field(header, 'index_pos')
-        self.bag._chunk_count      = _read_uint32_field(header, 'chunk_count')
+        self.bag._index_data_pos = _read_uint64_field(header, 'index_pos')
+        self.bag._chunk_count = _read_uint32_field(header, 'chunk_count')
         self.bag._connection_count = _read_uint32_field(header, 'conn_count')
         try:
             encryptor = _read_str_field(header, 'encryptor')
@@ -2725,7 +2871,7 @@ class _BagReader200(_BagReader):
             header = _read_header(f, _OP_CONNECTION)
 
         conn_id = _read_uint32_field(header, 'conn')
-        topic   = _read_str_field   (header, 'topic')
+        topic = _read_str_field(header, 'topic')
 
         if encrypt:
             connection_header = self.bag._encryptor.read_encrypted_header(_read_header, f)
@@ -2736,27 +2882,27 @@ class _BagReader200(_BagReader):
 
     def read_chunk_info_record(self):
         f = self.bag._file
-        
+
         header = _read_header(f, _OP_CHUNK_INFO)
 
         chunk_info_version = _read_uint32_field(header, 'ver')
-        
+
         if chunk_info_version == 1:
-            chunk_pos        = _read_uint64_field(header, 'chunk_pos')
-            start_time       = _read_time_field  (header, 'start_time')
-            end_time         = _read_time_field  (header, 'end_time')
-            connection_count = _read_uint32_field(header, 'count') 
+            chunk_pos = _read_uint64_field(header, 'chunk_pos')
+            start_time = _read_time_field(header, 'start_time')
+            end_time = _read_time_field(header, 'end_time')
+            connection_count = _read_uint32_field(header, 'count')
 
             chunk_info = _ChunkInfo(chunk_pos, start_time, end_time)
 
-            _read_uint32(f)   # skip the record data size
+            _read_uint32(f)  # skip the record data size
 
             for i in range(connection_count):
                 connection_id = _read_uint32(f)
-                count         = _read_uint32(f)
-    
+                count = _read_uint32(f)
+
                 chunk_info.connection_counts[connection_id] = count
-                
+
             return chunk_info
         else:
             raise ROSBagFormatException('Unknown chunk info record version: %d' % chunk_info_version)
@@ -2764,11 +2910,11 @@ class _BagReader200(_BagReader):
     def read_chunk_header(self):
         header = _read_header(self.bag._file, _OP_CHUNK)
 
-        compression       = _read_str_field   (header, 'compression')
+        compression = _read_str_field(header, 'compression')
         uncompressed_size = _read_uint32_field(header, 'size')
 
         compressed_size = _read_uint32(self.bag._file)  # read the record data size
-        
+
         data_pos = self.bag._file.tell()
 
         return _ChunkHeader(compression, compressed_size, uncompressed_size, data_pos)
@@ -2777,22 +2923,22 @@ class _BagReader200(_BagReader):
         f = self.bag._file
 
         header = _read_header(f, _OP_INDEX_DATA)
-        
+
         index_version = _read_uint32_field(header, 'ver')
         connection_id = _read_uint32_field(header, 'conn')
-        count         = _read_uint32_field(header, 'count')
-        
+        count = _read_uint32_field(header, 'count')
+
         if index_version != 1:
             raise ROSBagFormatException('expecting index version 1, got %d' % index_version)
-    
-        record_size = _read_uint32(f) # skip the record data size
+
+        record_size = _read_uint32(f)  # skip the record data size
 
         index = []
-                
+
         for i in range(count):
-            time   = _read_time  (f)
+            time = _read_time(f)
             offset = _read_uint32(f)
-            
+
             index.append(_IndexEntry200(time, self.bag._curr_chunk_info.pos, offset))
 
         return (connection_id, index)
@@ -2831,7 +2977,7 @@ class _BagReader200(_BagReader):
                     self.decompressed_chunk = roslz4.decompress(compressed_chunk)
                 else:
                     raise ROSBagException('unsupported compression type: %s' % chunk_header.compression)
-                
+
                 self.decompressed_chunk_pos = chunk_pos
 
                 if self.decompressed_chunk_io:
@@ -2854,18 +3000,19 @@ class _BagReader200(_BagReader):
             raise ROSBagFormatException('Expecting OP_MSG_DATA, got %d' % op)
 
         connection_id = _read_uint32_field(header, 'conn')
-        t             = _read_time_field  (header, 'time')
+        t = _read_time_field(header, 'time')
 
         # Get the message type
         connection_info = self.bag._connections[connection_id]
         try:
             msg_type = _get_message_type(connection_info)
         except KeyError:
-            raise ROSBagException('Cannot deserialize messages of type [%s].  Message was not preceded in bag by definition' % connection_info.datatype)
+            raise ROSBagException(
+                'Cannot deserialize messages of type [%s].  Message was not preceded in bag by definition' % connection_info.datatype)
 
         # Read the message content
         data = _read_record_data(f)
-        
+
         # Deserialize the message
         if raw:
             msg = connection_info.datatype, data, connection_info.md5sum, (chunk_pos, offset), msg_type
@@ -2878,11 +3025,13 @@ class _BagReader200(_BagReader):
         else:
             return BagMessage(connection_info.topic, msg, t)
 
+
 def _time_to_str(secs):
-    secs_frac = secs - int(secs) 
+    secs_frac = secs - int(secs)
     secs_frac_str = ('%.2f' % secs_frac)[1:]
 
     return time.strftime('%b %d %Y %H:%M:%S', time.localtime(secs)) + secs_frac_str
+
 
 def _human_readable_size(size):
     multiple = 1024.0
@@ -2893,6 +3042,7 @@ def _human_readable_size(size):
 
     return '-'
 
+
 def _human_readable_frequency(freq):
     multiple = 1000.0
     for suffix in ['Hz', 'kHz', 'MHz', 'GHz', 'THz', 'PHz', 'EHz', 'ZHz', 'YHz']:
@@ -2901,6 +3051,7 @@ def _human_readable_frequency(freq):
         freq /= multiple
 
     return '-'
+
 
 ## See http://code.activestate.com/recipes/511509
 def _mergesort(list_of_lists, key=None):
@@ -2954,7 +3105,7 @@ def _mergesort(list_of_lists, key=None):
             yield item, itr
             try:
                 item = next(itr)
-                heapq.heapreplace(heap, (key(item), idx, item, itr) )
+                heapq.heapreplace(heap, (key(item), idx, item, itr))
             except StopIteration:
                 heapq.heappop(heap)
 
@@ -2967,25 +3118,28 @@ def _mergesort(list_of_lists, key=None):
             except StopIteration:
                 heapq.heappop(heap)
 
+
 class _CompressorFileFacade(object):
     """
     A file facade for sequential compressors (e.g., bz2.BZ2Compressor).
     """
+
     def __init__(self, file, compressor):
-        self.file                = file
-        self.compressor          = compressor
+        self.file = file
+        self.compressor = compressor
         self.compressed_bytes_in = 0
-    
+
     def write(self, data):
         compressed = self.compressor.compress(data)
         if len(compressed) > 0:
             self.file.write(compressed)
         self.compressed_bytes_in += len(data)
-    
+
     def flush(self):
         compressed = self.compressor.flush()
         if len(compressed) > 0:
             self.file.write(compressed)
+
 
 def _median(values):
     values_len = len(values)


### PR DESCRIPTION
When writing a lot of messages sequentially in a bag, there are a lot of seemingly unnecessary seeks.
By creating a member state last_action with a corresponding enum, writing messages sequentially get a performance boost up to 80%.

Also ran a linter which explains all the whitespace changes. 