### PR TITLE
Allow mixing latched and unlatched publishers.

### DIFF
--- a/clients/roscpp/include/ros/publication.h
+++ b/clients/roscpp/include/ros/publication.h
@@ -58,7 +58,7 @@ public:
             const std::string& _md5sum,
             const std::string& message_definition,
             size_t max_queue,
-            bool latch,
+            bool /* unused */,
             bool has_header);
 
   ~Publication();

--- a/clients/roscpp/include/ros/publication.h
+++ b/clients/roscpp/include/ros/publication.h
@@ -115,7 +115,7 @@ public:
    */
   uint32_t getSequence() { return seq_; }
 
-  bool isLatched() { return latch_; }
+  bool isLatched();
 
   /**
    * \brief Adds a publisher to our list
@@ -139,7 +139,7 @@ public:
 
   size_t getNumCallbacks();
 
-  bool isLatching() { return latch_; }
+  bool isLatching() { return isLatched(); }
 
   void publish(SerializedMessage& m);
   void processPublishQueue();

--- a/clients/roscpp/src/libros/publication.cpp
+++ b/clients/roscpp/src/libros/publication.cpp
@@ -393,6 +393,12 @@ uint32_t Publication::getNumSubscribers()
   return (uint32_t)subscriber_links_.size();
 }
 
+bool Publication::isLatched()
+{
+  boost::mutex::scoped_lock lock(callbacks_mutex_);
+  return latch_;
+}
+
 void Publication::getPublishTypes(bool& serialize, bool& nocopy, const std::type_info& ti)
 {
   boost::mutex::scoped_lock lock(subscriber_links_mutex_);

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -346,13 +346,6 @@ bool TopicManager::advertise(const AdvertiseOptions& ops, const SubscriberCallba
         return false;
       }
 
-      if (pub->isLatched() != ops.latch)
-      {
-        ROS_ERROR("Tried to advertise on topic [%s] with latch=%d but the topic is already advertised with latch=%d",
-                  ops.topic.c_str(), ops.latch, pub->isLatched());
-        return false;
-      }
-
       pub->addCallbacks(callbacks);
 
       return true;

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -351,7 +351,7 @@ bool TopicManager::advertise(const AdvertiseOptions& ops, const SubscriberCallba
       return true;
     }
 
-    pub = PublicationPtr(boost::make_shared<Publication>(ops.topic, ops.datatype, ops.md5sum, ops.message_definition, ops.queue_size, ops.latch, ops.has_header));
+    pub = PublicationPtr(boost::make_shared<Publication>(ops.topic, ops.datatype, ops.md5sum, ops.message_definition, ops.queue_size, false, ops.has_header));
     pub->addCallbacks(callbacks);
     advertised_topics_.push_back(pub);
   }

--- a/test/test_roscpp/test/src/multiple_latched_publishers.cpp
+++ b/test/test_roscpp/test/src/multiple_latched_publishers.cpp
@@ -43,38 +43,6 @@
 #include <std_msgs/builtin_bool.h>
 
 
-TEST(MultipleLatchedPublishers, PublisherIncompatibleAdvertise)
-{
-  {
-    ros::NodeHandle nh;
-    auto pub1 = nh.advertise<bool>("foo", 10, true);
-    auto pub2 = nh.advertise<bool>("foo", 10, false);
-    EXPECT_TRUE(pub1);
-    EXPECT_FALSE(pub2);
-  }
-  {
-    ros::NodeHandle nh;
-    auto pub1 = nh.advertise<bool>("foo", 10, false);
-    auto pub2 = nh.advertise<bool>("foo", 10, true);
-    EXPECT_TRUE(pub1);
-    EXPECT_FALSE(pub2);
-  }
-  {
-    ros::NodeHandle nh;
-    auto pub1 = nh.advertise<bool>("foo", 10, true);
-    auto pub2 = nh.advertise<bool>("foo", 10, true);
-    EXPECT_TRUE(pub1);
-    EXPECT_TRUE(pub2);
-  }
-  {
-    ros::NodeHandle nh;
-    auto pub1 = nh.advertise<bool>("foo", 10, false);
-    auto pub2 = nh.advertise<bool>("foo", 10, false);
-    EXPECT_TRUE(pub1);
-    EXPECT_TRUE(pub2);
-  }
-}
-
 TEST(MultipleLatchedPublishers, LatchedPublisherReceiveMultiple)
 {
   ros::NodeHandle nh;
@@ -83,8 +51,15 @@ TEST(MultipleLatchedPublishers, LatchedPublisherReceiveMultiple)
     nh.advertise<bool>("foo", 10, true),
     nh.advertise<bool>("foo", 10, true),
   };
+  std::vector<ros::Publisher> unlatched_publishers = {
+    nh.advertise<bool>("foo", 10, false),
+    nh.advertise<bool>("foo", 10, false),
+  };
 
   for (auto& pub : latched_publishers) {
+    pub.publish(true);
+  }
+  for (auto& pub : unlatched_publishers) {
     pub.publish(true);
   }
 

--- a/test/test_roscpp/test/src/multiple_latched_publishers.cpp
+++ b/test/test_roscpp/test/src/multiple_latched_publishers.cpp
@@ -40,6 +40,7 @@
 
 #include <gtest/gtest.h>
 #include "ros/ros.h"
+#include "ros/topic_manager.h"
 #include <std_msgs/builtin_bool.h>
 
 
@@ -77,6 +78,34 @@ TEST(MultipleLatchedPublishers, LatchedPublisherReceiveMultiple)
   const auto received = received_future.get();
   EXPECT_TRUE(received);
   EXPECT_EQ(latched_publishers.size(), msg_count);
+}
+
+TEST(MultipleLatchedPublishers, TopicManagerIsLatched)
+{
+  ros::NodeHandle nh;
+  std::vector<ros::Publisher> publishers_bar = {
+    nh.advertise<bool>("bar", 10, false),
+    nh.advertise<bool>("bar", 10, true),
+    nh.advertise<bool>("bar", 10, false),
+  };
+  EXPECT_TRUE(ros::TopicManager::instance()->isLatched("/bar"));
+
+  std::vector<ros::Publisher> publishers_baz = {
+    nh.advertise<bool>("baz", 10, false),
+    nh.advertise<bool>("baz", 10, false),
+  };
+  EXPECT_FALSE(ros::TopicManager::instance()->isLatched("/baz"));
+}
+
+TEST(MultipleLatchedPublishers, TopicManagerLatchShutdown)
+{
+  ros::NodeHandle nh;
+  ros::Publisher qux_latched = nh.advertise<bool>("qux", 10, true);
+  ros::Publisher qux_unlatched = nh.advertise<bool>("qux", 10, false);
+  EXPECT_TRUE(ros::TopicManager::instance()->isLatched("/qux"));
+
+  qux_latched.shutdown();
+  EXPECT_FALSE(ros::TopicManager::instance()->isLatched("/qux"));
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This is a naive change (so far) that just removes the check against mixing latched and unlatched publishers and updates the test added in #1544 so that it covers this scenario (it still passes). As far as I can tell, this should be totally safe and in line with the design intent of the original change:

1. Each Publisher instance now stores its own latched/unlatched status, and its own `last_message_` pointer, rather than this being at the TopicManager/singleton level.
2. When a new subscriber connects, the `Publication::peerConnect` method iterates its list of callbacks, which will call the `push_latched_message_` std::function for any that have it defined.

Would love to hear from @meyerj if there's something lurking here that I've missed.

Fixes #1966.