### PR TITLE
Add which node has been registered with the same name

### DIFF
--- a/tools/rosmaster/src/rosmaster/registrations.py
+++ b/tools/rosmaster/src/rosmaster/registrations.py
@@ -464,7 +464,7 @@ class RegistrationManager(object):
             else:
                 bumped_api = node_ref.api
                 self.thread_pool.queue_task(bumped_api, shutdown_node_task,
-                                            (bumped_api, caller_id, "new node registered with same name"))
+                                            (bumped_api, caller_id, "new node registered with same name {}".format(node_ref.id)))
 
         node_ref = NodeRef(caller_id, caller_api)
         self.nodes[caller_id] = node_ref

--- a/tools/rosmaster/src/rosmaster/registrations.py
+++ b/tools/rosmaster/src/rosmaster/registrations.py
@@ -125,7 +125,7 @@ def shutdown_node_task(api, caller_id, reason):
     @type  reason: str
     """
     try:
-        xmlrpcapi(api).shutdown('/master', reason)
+        xmlrpcapi(api).shutdown('/master', "[{}] Reason: {}".format(caller_id, reason))
     except:
         pass #expected in many common cases
     remove_server_proxy(api)
@@ -464,7 +464,7 @@ class RegistrationManager(object):
             else:
                 bumped_api = node_ref.api
                 self.thread_pool.queue_task(bumped_api, shutdown_node_task,
-                                            (bumped_api, caller_id, "new node registered with same name {}".format(node_ref.id)))
+                                            (bumped_api, caller_id, "new node registered with same name"))
 
         node_ref = NodeRef(caller_id, caller_api)
         self.nodes[caller_id] = node_ref


### PR DESCRIPTION
Was looking through logs of several nodes that had been launched at the same time and it was getting hard to tell which node was being duplicated. This would allow you do to see the name of the node that caused the issue

