### PR TITLE
Remove dependency on rostopic from rostest package

### DIFF
--- a/tools/rostest/nodes/publishtest
+++ b/tools/rostest/nodes/publishtest
@@ -58,7 +58,6 @@ import time
 import unittest
 
 import rospy
-import rostopic
 
 
 PKG = 'rostest'

--- a/tools/rostest/test/advertisetest.test
+++ b/tools/rostest/test/advertisetest.test
@@ -1,12 +1,12 @@
 <launch>
-  <node pkg="rostopic" type="rostopic" name="freq_topic_pub" args="pub /frequent_topic std_msgs/Bool 'data: false' -r 10" />
-  <node pkg="rostopic" type="rostopic" name="once_topic_pub" args="pub /once_topic std_msgs/Bool 'data: false' -1l" />
+  <node pkg="rostest" type="talker.py" name="freq_topic_pub"/>
+  <node pkg="rostest" type="publish_once.py" name="once_topic_pub"/>
   <node pkg="rostest" type="service_server.py" name="service_server"/>
 
   <test test-name="advertisetest_test" pkg="rostest" type="advertisetest" time-limit="7.0" retry="3">
     <rosparam>
       topics:
-      - name: /frequent_topic
+      - name: /chatter
         timeout: 2.
       - name: /once_topic
         type: std_msgs/Bool

--- a/tools/rostest/test_nodes/publish_once.py
+++ b/tools/rostest/test_nodes/publish_once.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2008, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+## Simple auxiliary node that publishes a std_msgs/Bool message once
+
+import rospy
+from std_msgs.msg import Bool
+
+rospy.init_node('publish_once', anonymous=True)
+pub = rospy.Publisher('once_topic', Bool, queue_size=1, latch=True)
+pub.publish(Bool(data=False))
+rospy.sleep(rospy.Duration(3))


### PR DESCRIPTION
The advertisetest node test is depending rostopic package, which already depends on rostest (cyclic dependency detected in #1981). This PR substitutes rostopic tool by a simple helper node. Additionally, it removes a misplaced rostopic import in publishtest node.

Close #1981