### PR TITLE
XmlRpcValue::_doubleFormat should be used during write.

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -615,16 +615,19 @@ namespace XmlRpc {
           int required_size;
           char buf[128]; // Should be long enough
           required_size = std::snprintf(buf, sizeof(buf)-1,
-                                        getDoubleFormat().c_str(), _value.asDouble);
-          if (required_size < (int) sizeof(buf)) {
+                            getDoubleFormat().c_str(), _value.asDouble);
+          if (required_size >= 0 && required_size < (int) sizeof(buf)) {
             buf[sizeof(buf)-1] = 0;
             os << buf;
-          } else {
+          } else if (required_size >= (int) sizeof(buf)) {
+            int ret;
             char required_buf[required_size+1];
-            std::snprintf(required_buf, required_size,
-                          getDoubleFormat().c_str(), _value.asDouble);
-            required_buf[required_size] = 0;
-            os << required_buf;
+            ret = std::snprintf(required_buf, required_size,
+                    getDoubleFormat().c_str(), _value.asDouble);
+            if (ret == required_size) {
+              required_buf[required_size] = 0;
+              os << required_buf;
+            }
           }
           break;
         }
@@ -632,11 +635,14 @@ namespace XmlRpc {
       case TypeDateTime:
         {
           struct tm* t = _value.asTime;
+          int ret;
           char buf[20];
-          std::snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d", 
-            t->tm_year,t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
-          buf[sizeof(buf)-1] = 0;
-          os << buf;
+          ret = std::snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d",
+                  t->tm_year,t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
+          if (ret > 0) {
+            buf[sizeof(buf)-1] = 0;
+            os << buf;
+          }
           break;
         }
       case TypeBase64:

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -612,10 +612,20 @@ namespace XmlRpc {
       case TypeInt:      os << _value.asInt; break;
       case TypeDouble:
         {
-          char buf[100]; // Should be long enough
-          std::snprintf(buf, sizeof(buf)-1, getDoubleFormat().c_str(), _value.asDouble);
-          buf[sizeof(buf)-1] = 0;
-          os << buf;
+          int required_size;
+          char buf[128]; // Should be long enough
+          required_size = std::snprintf(buf, sizeof(buf)-1,
+                                        getDoubleFormat().c_str(), _value.asDouble);
+          if (required_size < (int) sizeof(buf)) {
+            buf[sizeof(buf)-1] = 0;
+            os << buf;
+          } else {
+            char required_buf[required_size+1];
+            std::snprintf(required_buf, required_size,
+                          getDoubleFormat().c_str(), _value.asDouble);
+            required_buf[required_size] = 0;
+            os << required_buf;
+          }
           break;
         }
       case TypeString:   os << *_value.asString; break;

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -610,7 +610,14 @@ namespace XmlRpc {
       default:           break;
       case TypeBoolean:  os << _value.asBool; break;
       case TypeInt:      os << _value.asInt; break;
-      case TypeDouble:   os << _value.asDouble; break;
+      case TypeDouble:
+        {
+          char buf[100]; // Should be long enough
+          std::snprintf(buf, sizeof(buf)-1, getDoubleFormat().c_str(), _value.asDouble);
+          buf[sizeof(buf)-1] = 0;
+          os << buf;
+          break;
+        }
       case TypeString:   os << *_value.asString; break;
       case TypeDateTime:
         {

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -1,5 +1,4 @@
 
-#include "ros/ros.h"
 #include "xmlrpcpp/XmlRpcValue.h"
 #include "xmlrpcpp/XmlRpcException.h"
 #include "xmlrpcpp/XmlRpcUtil.h"
@@ -621,7 +620,7 @@ namespace XmlRpc {
                   getDoubleFormat().c_str(), _value.asDouble);
           if (ret < 0) {
             std::call_once(once,
-              [](){ROS_WARN("Failed to format with %s, using default %%.16g format",
+              [](){XmlRpcUtil::error("Failed to format with %s, using default %%.16g format",
                 getDoubleFormat().c_str());});
             required_size = std::snprintf(buf, sizeof(buf)-1, "%.16g", _value.asDouble);
           } else {
@@ -640,7 +639,7 @@ namespace XmlRpc {
               os << required_buf;
             }
           } else {
-            ROS_ERROR("Unexpected error to format %s", getDoubleFormat().c_str());
+            XmlRpcUtil::error("Unexpected error to format %s", getDoubleFormat().c_str());
           }
           break;
         }
@@ -656,7 +655,7 @@ namespace XmlRpc {
             buf[sizeof(buf)-1] = 0;
             os << buf;
           } else {
-            ROS_ERROR("Unexpected error to format TypeDateTime");
+            XmlRpcUtil::error("Unexpected error to format TypeDateTime");
           }
           break;
         }

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -621,7 +621,7 @@ namespace XmlRpc {
             std::call_once(once,
               [](){XmlRpcUtil::error("Failed to format with %s", getDoubleFormat().c_str());});
             os << _value.asDouble;
-          } else if (required_size >= 0 && required_size < static_cast<int>(sizeof(buf))) {
+          } else if (required_size < static_cast<int>(sizeof(buf))) {
             buf[sizeof(buf)-1] = 0;
             os << buf;
           } else { // required_size >= static_cast<int>(sizeof(buf)

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -614,33 +614,22 @@ namespace XmlRpc {
       case TypeDouble:
         {
           static std::once_flag once;
-          bool use_default = false;
           char buf[128]; // Should be long enough
           int required_size = std::snprintf(buf, sizeof(buf)-1,
                                 getDoubleFormat().c_str(), _value.asDouble);
           if (required_size < 0) {
-            use_default = true;
             std::call_once(once,
-              [](){XmlRpcUtil::error("Failed to format with %s, using default %%.16g format",
-                getDoubleFormat().c_str());});
-            required_size = std::snprintf(buf, sizeof(buf)-1, "%.16g", _value.asDouble);
-          }
-          if (required_size >= 0 && required_size < static_cast<int>(sizeof(buf))) {
+              [](){XmlRpcUtil::error("Failed to format with %s", getDoubleFormat().c_str());});
+            os << _value.asDouble;
+          } else if (required_size >= 0 && required_size < static_cast<int>(sizeof(buf))) {
             buf[sizeof(buf)-1] = 0;
             os << buf;
-          } else if (required_size >= static_cast<int>(sizeof(buf))) {
+          } else { // required_size >= static_cast<int>(sizeof(buf)
             char required_buf[required_size+1];
-            if (use_default) {
-              std::snprintf(required_buf, required_size,
-                "%.16g", _value.asDouble);
-            } else {
-              std::snprintf(required_buf, required_size,
-                getDoubleFormat().c_str(), _value.asDouble);
-            }
+            std::snprintf(required_buf, required_size,
+              getDoubleFormat().c_str(), _value.asDouble);
             required_buf[required_size] = 0;
             os << required_buf;
-          } else {
-            XmlRpcUtil::error("Unexpected error to format %%.16g");
           }
           break;
         }
@@ -649,7 +638,7 @@ namespace XmlRpc {
         {
           struct tm* t = _value.asTime;
           char buf[20];
-          std::snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d",
+          std::snprintf(buf, sizeof(buf)-1, "%4d%02d%02dT%02d:%02d:%02d", 
             t->tm_year,t->tm_mon,t->tm_mday,t->tm_hour,t->tm_min,t->tm_sec);
           buf[sizeof(buf)-1] = 0;
           os << buf;

--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 
 catkin_add_gtest(TestValues TestValues.cpp)
 if(TARGET TestValues)
-  target_link_libraries(TestValues xmlrpcpp roscpp)
+  target_link_libraries(TestValues xmlrpcpp)
 endif()
 
 catkin_add_gtest(test_util test_util.cpp)

--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -119,7 +119,7 @@ endif()
 
 catkin_add_gtest(TestValues TestValues.cpp)
 if(TARGET TestValues)
-  target_link_libraries(TestValues xmlrpcpp)
+  target_link_libraries(TestValues xmlrpcpp roscpp)
 endif()
 
 catkin_add_gtest(test_util test_util.cpp)

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -131,6 +131,7 @@ TEST(XmlRpc, testDouble) {
   // Test format
   const XmlRpc::XmlRpcValue a(2.0);
   ASSERT_EQ(XmlRpcValue::TypeDouble, d.getType());
+  const std::string save_format = XmlRpc::XmlRpcValue::getDoubleFormat();
 
   XmlRpc::XmlRpcValue::setDoubleFormat("%32.10f");
   ss << a;
@@ -141,6 +142,24 @@ TEST(XmlRpc, testDouble) {
   ss << a;
   EXPECT_EQ("2.00000000000000000000000000000000", ss.str());
   ss.str("");
+
+  XmlRpc::XmlRpcValue::setDoubleFormat("%128.10f");
+  ss << a;
+  EXPECT_EQ("                                "
+            "                                "
+            "                                "
+            "                    2.000000000", ss.str());
+  ss.str("");
+
+  XmlRpc::XmlRpcValue::setDoubleFormat("%10.128f");
+  ss << a;
+  EXPECT_EQ("2.000000000000000000000000000000"
+            "00000000000000000000000000000000"
+            "00000000000000000000000000000000"
+            "000000000000000000000000000000000", ss.str());
+  ss.str("");
+
+  XmlRpc::XmlRpcValue::setDoubleFormat(save_format.c_str());
 }
 
 TEST(XmlRpc, testString) {

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -126,6 +126,21 @@ TEST(XmlRpc, testDouble) {
   std::stringstream ss;
   ss << d;
   EXPECT_EQ("43.7", ss.str());
+  ss.str("");
+
+  // Test format
+  const XmlRpc::XmlRpcValue a(2.0);
+  ASSERT_EQ(XmlRpcValue::TypeDouble, d.getType());
+
+  XmlRpc::XmlRpcValue::setDoubleFormat("%32.10f");
+  ss << a;
+  EXPECT_EQ("                    2.0000000000", ss.str());
+  ss.str("");
+
+  XmlRpc::XmlRpcValue::setDoubleFormat("%10.32f");
+  ss << a;
+  EXPECT_EQ("2.00000000000000000000000000000000", ss.str());
+  ss.str("");
 }
 
 TEST(XmlRpc, testString) {


### PR DESCRIPTION
fix https://github.com/ros/ros_comm/issues/1958

Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>