### PR TITLE
changes between 1.15.8 (Noetic) and 1.14.6 for backporting into Melodic 

### DIFF
--- a/clients/rospy/src/rospy/__init__.py
+++ b/clients/rospy/src/rospy/__init__.py
@@ -113,7 +113,6 @@ __all__ = [
     'logerr_once', 'logfatal_once',
     'parse_rosrpc_uri',
     'MasterProxy',
-    'NodeProxy',    
     'ROSException',
     'ROSSerializationException',
     'ROSInitException',

--- a/tools/rosmaster/src/rosmaster/registrations.py
+++ b/tools/rosmaster/src/rosmaster/registrations.py
@@ -125,7 +125,7 @@ def shutdown_node_task(api, caller_id, reason):
     @type  reason: str
     """
     try:
-        xmlrpcapi(api).shutdown('/master', reason)
+        xmlrpcapi(api).shutdown('/master', "[{}] Reason: {}".format(caller_id, reason))
     except:
         pass #expected in many common cases
     remove_server_proxy(api)

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
@@ -95,6 +95,13 @@ namespace XmlRpc {
     operator BinaryData&()    { assertTypeOrInvalid(TypeBase64); return *_value.asBinary; }
     operator struct tm&()     { assertTypeOrInvalid(TypeDateTime); return *_value.asTime; }
 
+    operator const bool&() const          { assertTypeOrInvalid(TypeBoolean); return _value.asBool; }
+    operator const int&() const           { assertTypeOrInvalid(TypeInt); return _value.asInt; }
+    operator const double&() const        { assertTypeOrInvalid(TypeDouble); return _value.asDouble; }
+    operator const std::string&() const   { assertTypeOrInvalid(TypeString); return *_value.asString; }
+    operator const BinaryData&() const    { assertTypeOrInvalid(TypeBase64); return *_value.asBinary; }
+    operator const struct tm&() const     { assertTypeOrInvalid(TypeDateTime); return *_value.asTime; }
+
     XmlRpcValue const& operator[](int i) const { assertArray(i+1); return _value.asArray->at(i); }
     XmlRpcValue& operator[](int i)             { assertArray(i+1); return _value.asArray->at(i); }
 
@@ -147,6 +154,7 @@ namespace XmlRpc {
     void invalidate();
 
     // Type checking
+    void assertTypeOrInvalid(Type t) const;
     void assertTypeOrInvalid(Type t);
     void assertArray(int size) const;
     void assertArray(int size);

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -70,6 +70,12 @@ namespace XmlRpc {
 
   
   // Type checking
+  void XmlRpcValue::assertTypeOrInvalid(Type t) const
+  {
+    if (_type != t)
+      throw XmlRpcException("type error");
+  }
+
   void XmlRpcValue::assertTypeOrInvalid(Type t)
   {
     if (_type == TypeInvalid)

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -49,7 +49,7 @@ TEST(XmlRpc, Bool) {
 }
 
 TEST(XmlRpc, testBoolean) {
-  XmlRpcValue booleanFalse(false);
+  const XmlRpcValue booleanFalse(false);
   XmlRpcValue booleanTrue(true);
   int offset = 0;
   XmlRpcValue booleanFalseXml("<value><boolean>0</boolean></value>", &offset);
@@ -75,7 +75,7 @@ TEST(XmlRpc, testBoolean) {
 
 // Int
 TEST(XmlRpc, testInt) {
-  XmlRpcValue int0(0);
+  const XmlRpcValue int0(0);
   ASSERT_EQ(XmlRpcValue::TypeInt, int0.getType());
 
   XmlRpcValue int1(1);
@@ -110,7 +110,7 @@ TEST(XmlRpc, testInt) {
 
 TEST(XmlRpc, testDouble) {
   // Double
-  XmlRpcValue d(43.7);
+  const XmlRpcValue d(43.7);
   ASSERT_EQ(XmlRpcValue::TypeDouble, d.getType());
   EXPECT_EQ("<value><double>43.700000000000003</double></value>", d.toXml());
   EXPECT_DOUBLE_EQ(43.7, double(d));
@@ -130,7 +130,7 @@ TEST(XmlRpc, testDouble) {
 
 TEST(XmlRpc, testString) {
   // String
-  XmlRpcValue s("Now is the time <&");
+  const XmlRpcValue s("Now is the time <&");
   ASSERT_EQ(XmlRpcValue::TypeString, s.getType());
   EXPECT_EQ(18, s.size());
   EXPECT_EQ("<value>Now is the time &lt;&amp;</value>", s.toXml());
@@ -178,7 +178,7 @@ TEST(XmlRpc, testDateTime) {
   // DateTime
   int offset = 0;
   // Construct from XML
-  XmlRpcValue dateTime(
+  const XmlRpcValue dateTime(
       "<value><dateTime.iso8601>19040503T03:12:35</dateTime.iso8601></value>",
       &offset);
   ASSERT_EQ(XmlRpcValue::TypeDateTime, dateTime.getType());
@@ -286,7 +286,7 @@ TEST(XmlRpc, testArray) {
   EXPECT_EQ(a, aXml);
 
   // Array copy works
-  XmlRpcValue copy(a);
+  const XmlRpcValue copy(a);
   ASSERT_EQ(a.getType(), copy.getType());
   ASSERT_EQ(a.size(), copy.size());
   for (int i = 0; i < 3; i++) {
@@ -345,7 +345,7 @@ TEST(XmlRpc, testStruct) {
                        "</struct></value>";
 
   int offset = 0;
-  XmlRpcValue structXml(csStructXml, &offset);
+  const XmlRpcValue structXml(csStructXml, &offset);
   EXPECT_EQ(struct1, structXml);
 
   for (XmlRpcValue::iterator itr = struct1.begin(); itr != struct1.end();
@@ -399,7 +399,7 @@ TEST(XmlRpc, testStruct) {
 
 TEST(XmlRpc, base64) {
   char data[] = {1, 2};
-  XmlRpcValue bin(data, 2);
+  const XmlRpcValue bin(data, 2);
 
   EXPECT_EQ(XmlRpcValue::TypeBase64, bin.getType());
   EXPECT_EQ(2, bin.size());


### PR DESCRIPTION
The following list of changes has been integrated into ros_comm 1.15.8 (Noetic) since the last Melodic release (1.14.6).


**Backported:** (these changes are part of this PR)

* Added const versions of XmlRpcValue converting operators (#1978)

  * Useful improvement

* Add latch param to throttle (#1944)

  * New parameter / feature

* Add which node has been registered with the same name (#1992)

  * Improved error message

* remove not existing NodeProxy from rospy __all_\_ (#2007)

  * Bug fix


**Not backported:**

* rostest: fixed missing reload() function in python 3 (#1968)

  * Not necessary, Python 3 only

* fix relative import with Python 3 (#1973)

  * Not necessary, Python 3 only

* Fix typo in topics.py (#1977)

  * Not necessary, comment only

* Remove dependency on rostopic from rostest package (#2002)

  * Not necessary

* Allow mixing latched and unlatched publishers (#1991)

  * Not applicable, only relevant for Noetic

* Changed is_async_connected to use epoll when available (#1983)

  * Significant change with regression potential