### PR TITLE
Remove unavailable nodes from local node cache _caller_apis

### DIFF
--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -429,7 +429,7 @@ def cleanup_master_blacklist(master, blacklist):
                 service_api = master.lookupService(s)
                 master_n = rosgraph.Master(n)
                 master_n.unregisterService(s, service_api)
-		_caller_apis.pop(n, None)
+        _caller_apis.pop(n, None)
 
 def cleanup_master_whitelist(master, whitelist):
     """

--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -406,7 +406,7 @@ def rosnode_ping_all(verbose=False):
     
 def cleanup_master_blacklist(master, blacklist):
     """
-    Remove registrations from ROS Master that match blacklist.    
+    Remove registrations from ROS Master and node cache (_caller_apis) that match blacklist.    
     @param master: rosgraph Master instance
     @type  master: rosgraph.Master
     @param blacklist: list of nodes to scrub
@@ -429,6 +429,7 @@ def cleanup_master_blacklist(master, blacklist):
                 service_api = master.lookupService(s)
                 master_n = rosgraph.Master(n)
                 master_n.unregisterService(s, service_api)
+		_caller_apis.pop(n, None)
 
 def cleanup_master_whitelist(master, whitelist):
     """


### PR DESCRIPTION
Fixes #1967
Unavailable nodes that are still registered at master but are actually offline due to battery or network connection issues have to be removed from local cache _caller_apis. This avoids buggy behaviour explained in #1967.

How to reproduce
Two nodes will be needed.
- The first node continuously pings all registered nodes to see if any have died. If a node has died but is still registered, this node unregisters them from master. 
This is necessary because nodes running on a battery powered or mobile device do not have the chance to unregister themselves when their device runs out of battery or exits the wifi network due to too great distance to the router. 
- The second one can be any kind of node (service server/client or publisher/subscriber).

The bug that occurs is explained detailedly in the above mentioned bug.
After the second node has exit and rejoined the ros network, the pinging node will notice that the second node has come online again. But, it will look into its cache and try to ping the old URI of the second node which will yield a node is offline result. In order to avoid this, the cache also needs to be updated once a node is unregistered from master.
Since unregistering nodes eventually results in a call of `cleanup_master_blacklist`, this behaviour was implemented there.