### PR TITLE
changes between 1.12.14 and 1.14.7 for backporting

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -2150,7 +2150,7 @@ if (service)  // Enter if advertised service is valid
    * or is an otherwise invalid graph resource name.
    */
   template<typename T>
-  T param(const std::string& param_name, const T& default_val)
+  T param(const std::string& param_name, const T& default_val) const
   {
       T param_val;
       param(param_name, param_val, default_val);

--- a/clients/roscpp/include/ros/timer.h
+++ b/clients/roscpp/include/ros/timer.h
@@ -73,6 +73,7 @@ public:
 
   bool hasStarted() const { return impl_ && impl_->hasStarted(); }
   bool isValid() { return impl_ && impl_->isValid(); }
+  bool isValid() const { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void*)1 : (void*)0; }
 
   bool operator<(const Timer& rhs)
@@ -101,6 +102,7 @@ private:
 
     bool hasStarted() const;
     bool isValid();
+    bool isValid() const;
     bool hasPending();
     void setPeriod(const Duration& period, bool reset=true);
 

--- a/clients/roscpp/include/ros/timer.h
+++ b/clients/roscpp/include/ros/timer.h
@@ -71,7 +71,7 @@ public:
    */
   void setPeriod(const Duration& period, bool reset=true);
 
-  bool hasStarted() const { return impl_->hasStarted(); }
+  bool hasStarted() const { return impl_ && impl_->hasStarted(); }
   bool isValid() { return impl_ && impl_->isValid(); }
   operator void*() { return isValid() ? (void*)1 : (void*)0; }
 

--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -337,8 +337,8 @@ void Connection::drop(DropReason reason)
 
   if (did_drop)
   {
-    drop_signal_(shared_from_this(), reason);
     transport_->close();
+    drop_signal_(shared_from_this(), reason);
   }
 }
 

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -592,7 +592,8 @@ void shutdown()
   {
     g_internal_queue_thread.join();
   }
-
+  //ros::console::deregister_appender(g_rosout_appender);
+  delete g_rosout_appender;
   g_rosout_appender = 0;
 
   if (g_started)

--- a/clients/roscpp/src/libros/node_handle.cpp
+++ b/clients/roscpp/src/libros/node_handle.cpp
@@ -68,6 +68,10 @@ public:
   V_SrvCImpl srv_cs_;
 
   boost::mutex mutex_;
+
+  // keep shared_ptrs to these managers to avoid assertions. Fixes #838
+  TopicManagerPtr keep_alive_topic_manager = TopicManager::instance();
+  ServiceManagerPtr keep_alive_service_manager = ServiceManager::instance();
 };
 
 NodeHandle::NodeHandle(const std::string& ns, const M_string& remappings)

--- a/clients/roscpp/src/libros/poll_set.cpp
+++ b/clients/roscpp/src/libros/poll_set.cpp
@@ -191,7 +191,10 @@ void PollSet::update(int poll_timeout)
   boost::shared_ptr<std::vector<socket_pollfd> > ofds = poll_sockets(epfd_, &ufds_.front(), ufds_.size(), poll_timeout);
   if (!ofds)
   {
-    ROS_ERROR_STREAM("poll failed with error " << last_socket_error_string());
+    if (last_socket_error() != EINTR)
+    {
+      ROS_ERROR_STREAM("poll failed with error " << last_socket_error_string());
+    }
   }
   else
   {

--- a/clients/roscpp/src/libros/publication.cpp
+++ b/clients/roscpp/src/libros/publication.cpp
@@ -324,6 +324,8 @@ void Publication::dropAllConnections()
 
 void Publication::peerConnect(const SubscriberLinkPtr& sub_link)
 {
+  boost::mutex::scoped_lock lock(callbacks_mutex_);
+
   V_Callback::iterator it = callbacks_.begin();
   V_Callback::iterator end = callbacks_.end();
   for (; it != end; ++it)
@@ -339,6 +341,8 @@ void Publication::peerConnect(const SubscriberLinkPtr& sub_link)
 
 void Publication::peerDisconnect(const SubscriberLinkPtr& sub_link)
 {
+  boost::mutex::scoped_lock lock(callbacks_mutex_);
+
   V_Callback::iterator it = callbacks_.begin();
   V_Callback::iterator end = callbacks_.end();
   for (; it != end; ++it)

--- a/clients/roscpp/src/libros/service.cpp
+++ b/clients/roscpp/src/libros/service.cpp
@@ -88,7 +88,8 @@ bool service::waitForService(const std::string& service_name, ros::Duration time
 {
   std::string mapped_name = names::resolve(service_name);
 
-  Time start_time = Time::now();
+  const WallTime start_time = WallTime::now();
+  const WallDuration wall_timeout{timeout.toSec()};
 
   bool printed = false;
   bool result = false;
@@ -103,17 +104,17 @@ bool service::waitForService(const std::string& service_name, ros::Duration time
     {
       printed = true;
 
-      if (timeout >= Duration(0))
+      if (wall_timeout >= WallDuration(0))
       {
-        Time current_time = Time::now();
+        const WallTime current_time = WallTime::now();
 
-        if ((current_time - start_time) >= timeout)
+        if ((current_time - start_time) >= wall_timeout)
         {
           return false;
         }
       }
 
-      Duration(0.02).sleep();
+      WallDuration(0.02).sleep();
     }
   }
 

--- a/clients/roscpp/src/libros/service_manager.cpp
+++ b/clients/roscpp/src/libros/service_manager.cpp
@@ -200,9 +200,7 @@ bool ServiceManager::unregisterService(const std::string& service)
            network::getHost().c_str(), connection_manager_->getTCPPort());
   args[2] = string(uri_buf);
 
-  master::execute("unregisterService", args, result, payload, false);
-
-  return true;
+  return master::execute("unregisterService", args, result, payload, false);
 }
 
 bool ServiceManager::isServiceAdvertised(const string& serv_name)

--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -132,13 +132,13 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
     // not all message types have this
     if (stats.age_list.size() > 0)
     {
-      msg.stamp_age_mean = ros::Duration(0);
+      double stamp_age_sum = 0.0;
       msg.stamp_age_max = ros::Duration(0);
 
       for(std::list<ros::Duration>::iterator it = stats.age_list.begin(); it != stats.age_list.end(); it++)
       {
         ros::Duration age = *it;
-        msg.stamp_age_mean += age;
+        stamp_age_sum += age.toSec();
 
         if (age > msg.stamp_age_max)
         {
@@ -146,7 +146,7 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
         }
       }
 
-      msg.stamp_age_mean *= 1.0 / stats.age_list.size();
+      msg.stamp_age_mean = ros::Duration(stamp_age_sum / stats.age_list.size());
 
       double stamp_age_variance = 0.0;
       for(std::list<ros::Duration>::iterator it = stats.age_list.begin(); it != stats.age_list.end(); it++)

--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -113,7 +113,7 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
   }
 
   // should publish new statistics?
-  if (stats.last_publish + ros::Duration(pub_frequency_) < received_time)
+  if (stats.last_publish + ros::Duration(1 / pub_frequency_) < received_time)
   {
     ros::Time window_start = stats.last_publish;
     stats.last_publish = received_time;

--- a/clients/roscpp/src/libros/timer.cpp
+++ b/clients/roscpp/src/libros/timer.cpp
@@ -52,6 +52,11 @@ bool Timer::Impl::isValid()
   return !period_.isZero();
 }
 
+bool Timer::Impl::isValid() const
+{
+  return !period_.isZero();
+}
+
 void Timer::Impl::start()
 {
   if (!started_)

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -97,9 +97,10 @@ void TopicManager::shutdown()
   }
 
   {
-    boost::recursive_mutex::scoped_lock lock1(advertised_topics_mutex_);
-    boost::mutex::scoped_lock lock2(subs_mutex_);
+    boost::lock(subs_mutex_, advertised_topics_mutex_);
     shutting_down_ = true;
+    subs_mutex_.unlock();
+    advertised_topics_mutex_.unlock();
   }
 
   // actually one should call poll_manager_->removePollThreadListener(), but the connection is not stored above

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -270,7 +270,7 @@ bool TransportTCP::connect(const std::string& host, int port)
 
     bool found = false;
     struct addrinfo* it = addr;
-    char namebuf[128];
+    char namebuf[128] = {};
     for (; it; it = it->ai_next)
     {
       if (!s_use_ipv6_ && it->ai_family == AF_INET)
@@ -282,7 +282,7 @@ bool TransportTCP::connect(const std::string& host, int port)
         address->sin_family = it->ai_family;
         address->sin_port = htons(port);
 	
-        strcpy(namebuf, inet_ntoa(address->sin_addr));
+        strncpy(namebuf, inet_ntoa(address->sin_addr), sizeof(namebuf)-1);
         found = true;
         break;
       }
@@ -728,14 +728,14 @@ std::string TransportTCP::getClientURI()
   sockaddr_in *sin = (sockaddr_in *)&sas;
   sockaddr_in6 *sin6 = (sockaddr_in6 *)&sas;
 
-  char namebuf[128];
+  char namebuf[128] = {};
   int port;
 
   switch (sas.ss_family)
   {
     case AF_INET:
       port = ntohs(sin->sin_port);
-      strcpy(namebuf, inet_ntoa(sin->sin_addr));
+      strncpy(namebuf, inet_ntoa(sin->sin_addr), sizeof(namebuf)-1);
       break;
     case AF_INET6:
       port = ntohs(sin6->sin6_port);

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -138,6 +138,10 @@ bool TransportTCP::initializeSocket()
   {
     ROS_DEBUG("Adding tcp socket [%d] to pollset", sock_);
     poll_set_->addSocket(sock_, boost::bind(&TransportTCP::socketUpdate, this, _1), shared_from_this());
+#if defined(POLLRDHUP) // POLLRDHUP is not part of POSIX!
+    // This is needed to detect dead connections. #1704
+    poll_set_->addEvents(sock_, POLLRDHUP);
+#endif
   }
 
   if (!(flags_ & SYNCHRONOUS))
@@ -690,6 +694,9 @@ void TransportTCP::socketUpdate(int events)
 
   if((events & POLLERR) ||
      (events & POLLHUP) ||
+#if defined(POLLRDHUP) // POLLRDHUP is not part of POSIX!
+     (events & POLLRDHUP) ||
+#endif
      (events & POLLNVAL))
   {
     uint32_t error = -1;

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -387,7 +387,7 @@ bool TransportTCP::listen(int port, int backlog, const AcceptCallback& accept_cb
     sa_len_ = sizeof(sockaddr_in);
   }
 
-  if (sock_ <= 0)
+  if (sock_ == ROS_INVALID_SOCKET)
   {
     ROS_ERROR("socket() failed with error [%s]", last_socket_error_string());
     return false;

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -240,7 +240,7 @@ bool TransportUDP::createIncoming(int port, bool is_server)
 
   sock_ = socket(AF_INET, SOCK_DGRAM, 0);
 
-  if (sock_ <= 0)
+  if (sock_ == ROS_INVALID_SOCKET)
   {
     ROS_ERROR("socket() failed with error [%s]", last_socket_error_string());
     return false;

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -710,9 +710,9 @@ std::string TransportUDP::getClientURI()
 
   sockaddr_in *sin = (sockaddr_in *)&sas;
 
-  char namebuf[128];
+  char namebuf[128] = {};
   int port = ntohs(sin->sin_port);
-  strcpy(namebuf, inet_ntoa(sin->sin_addr));
+  strncpy(namebuf, inet_ntoa(sin->sin_addr), sizeof(namebuf)-1);
 
   std::string ip = namebuf;
   std::stringstream uri;

--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -198,7 +198,7 @@ void TransportSubscriberLink::enqueueMessage(const SerializedMessage& m, bool se
       if (!queue_full_)
       {
         ROS_DEBUG("Outgoing queue full for topic [%s].  "
-               "Discarding oldest message\n",
+               "Discarding oldest message",
                topic_.c_str());
       }
 

--- a/clients/rospy/src/rospy/__init__.py
+++ b/clients/rospy/src/rospy/__init__.py
@@ -94,7 +94,7 @@ __all__ = [
     'INFO',
     'WARN',
     'ERROR',
-    'FATAL'
+    'FATAL',
     'is_shutdown',
     'signal_shutdown',
     'get_node_uri',

--- a/clients/rospy/src/rospy/__init__.py
+++ b/clients/rospy/src/rospy/__init__.py
@@ -107,7 +107,6 @@ __all__ = [
     'logerr_throttle', 'logfatal_throttle',
     'parse_rosrpc_uri',
     'MasterProxy',
-    'NodeProxy',    
     'ROSException',
     'ROSSerializationException',
     'ROSInitException',

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -157,7 +157,8 @@ class TCPServer(object):
                 (errno, msg) = e.args
                 if errno == 4: #interrupted system call
                     continue
-                raise
+                if not self.is_shutdown:
+                    raise
             if self.is_shutdown:
                 break
             try:

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -1264,7 +1264,7 @@ class _TopicManager(object):
             rmap = self.subs
             impl_class = _SubscriberImpl
         else:
-            raise TypeError("invalid reg_type: %s"%s)
+            raise TypeError("invalid reg_type: %s"%reg_type)
         with self.lock:
             impl = rmap.get(resolved_name, None)            
             if not impl:

--- a/clients/rospy/src/rospy/topics.py
+++ b/clients/rospy/src/rospy/topics.py
@@ -1173,7 +1173,7 @@ class _TopicManager(object):
         Check all registered publication and subscriptions.
         """
         with self.lock:
-            for t in chain(iter(self.pubs.values()), iter(self.subs.values())):
+            for t in chain(list(self.pubs.values()), list(self.subs.values())):
                 t.check()
         
     def _add(self, ps, rmap, reg_type):

--- a/test/test_roscpp/test/src/params.cpp
+++ b/test/test_roscpp/test/src/params.cpp
@@ -566,12 +566,23 @@ TEST(Params, getParamNames) {
   EXPECT_LT(10, test_params.size());
 }
 
+TEST(Params, getParamCachedSetParamLoop) {
+  NodeHandle nh;
+  const std::string name = "changeable_int";
+  for (int i = 0; i < 100; i++) {
+    nh.setParam(name, i);
+    int v = 0;
+    ASSERT_TRUE(nh.getParamCached(name, v));
+    ASSERT_EQ(i, v);
+  }
+}
+
 int
 main(int argc, char** argv)
 {
   testing::InitGoogleTest(&argc, argv);
-  ros::init( argc, argv, "params" );
-//  ros::NodeHandle nh;
+  ros::init(argc, argv, "params");
+  ros::NodeHandle nh;
 
   return RUN_ALL_TESTS();
 }

--- a/test/test_rospy/test/rostest/sub_to_multiple_pubs.test
+++ b/test/test_rospy/test/rostest/sub_to_multiple_pubs.test
@@ -1,4 +1,5 @@
 <launch>
+  <node name="listener" pkg="test_rospy" type="listener.py" />
   <node name="talker1" pkg="test_rospy" type="talker.py" />
   <node name="talker2" pkg="test_rospy" type="talker.py" />
   <node name="talker3" pkg="test_rospy" type="talker.py" />
@@ -98,6 +99,5 @@
   <node name="talker97" pkg="test_rospy" type="talker.py" />
   <node name="talker98" pkg="test_rospy" type="talker.py" />
   <node name="talker99" pkg="test_rospy" type="talker.py" />
-  <node name="listener" pkg="test_rospy" type="listener.py" />
   <test test-name="sub_to_multiple_pubs" pkg="test_rospy" type="test_sub_to_multiple_pubs.py" />
 </launch>

--- a/tools/rosbag/scripts/fix_msg_defs.py
+++ b/tools/rosbag/scripts/fix_msg_defs.py
@@ -35,6 +35,7 @@ from __future__ import print_function
 
 import sys
 import rosbag.migration
+import roslib.message
 
 if __name__ == '__main__':
     if len(sys.argv) != 3:

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -405,7 +405,7 @@ void Player::waitForSubscribers() const
         foreach(const PublisherMap::value_type& pub, publishers_) {
             all_topics_subscribed &= pub.second.getNumSubscribers() > 0;
         }
-        ros::Duration(0.1).sleep();
+        ros::WallDuration(0.1).sleep();
     }
     std::cout << "Finished waiting for subscribers." << std::endl;
 }

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -123,7 +123,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
         ROS_WARN("Use of \"--split <MAX_SIZE>\" has been deprecated.  Please use --split --size <MAX_SIZE> or --split --duration <MAX_DURATION>");
         if (S < 0)
           throw ros::Exception("Split size must be 0 or positive");
-        opts.max_size = 1048576 * S;
+        opts.max_size = 1048576 * static_cast<uint64_t>(S);
       }
     }
     if(vm.count("max-splits"))

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -733,8 +733,11 @@ class Bag(object):
 
                     msg_count = 0
                     for connection in connections:
-                        for chunk in self._chunks:
-                            msg_count += chunk.connection_counts.get(connection.id, 0)
+                        if self._chunks:
+                            for chunk in self._chunks:
+                                msg_count += chunk.connection_counts.get(connection.id, 0)
+                        else:
+                            msg_count += len(self._connection_indexes.get(connection.id, []))
                     topic_msg_counts[topic] = msg_count
 
                     if self._connection_indexes_read:

--- a/tools/rosbag/src/rosbag/migration.py
+++ b/tools/rosbag/src/rosbag/migration.py
@@ -43,6 +43,7 @@ import itertools
 import os
 import string
 import sys
+import traceback
 
 import genmsg.msgs
 import genpy
@@ -257,6 +258,9 @@ class MessageUpdateRule(object):
 
     valid = False
 
+    class EmptyType(Exception):
+        pass
+
     ## Initialize class
     def __init__(self, migrator, location):
         # Every rule needs to hang onto the migrator so we can potentially use it
@@ -271,23 +275,26 @@ class MessageUpdateRule(object):
         # Instantiate types dynamically based on definition
         try:
             if self.old_type == "":
-                raise Exception
+                raise self.EmptyType
             self.old_types = genpy.dynamic.generate_dynamic(self.old_type, self.old_full_text)
             self.old_class = self.old_types[self.old_type]
             self.old_md5sum = self.old_class._md5sum
-        except:
-            self.old_types = []
+        except Exception as e:
+            if not isinstance(e, self.EmptyType):
+                traceback.print_exc(file=sys.stderr)
+            self.old_types = {}
             self.old_class = None
             self.old_md5sum = ""
-
         try:
             if self.new_type == "":
-                raise Exception
+                raise self.EmptyType
             self.new_types = genpy.dynamic.generate_dynamic(self.new_type, self.new_full_text)
             self.new_class = self.new_types[self.new_type]
             self.new_md5sum = self.new_class._md5sum
-        except:
-            self.new_types = []
+        except Exception as e:
+            if not isinstance(e, self.EmptyType):
+                traceback.print_exc(file=sys.stderr)
+            self.new_types = {}
             self.new_class = None
             self.new_md5sum = ""
 

--- a/tools/rosbag/src/rosbag/migration.py
+++ b/tools/rosbag/src/rosbag/migration.py
@@ -837,7 +837,7 @@ class MessageMigrator(object):
                 if (tmp_sn != first_sn):
                     sn_range.append(tmp_sn)
                 if (tmp_sn.new_class._type == new_type):
-                    found_new_type == True
+                    found_new_type = True
                 if (found_new_type and tmp_sn.new_class._type != new_type):
                     break
 

--- a/tools/rosbag_storage/include/rosbag/structures.h
+++ b/tools/rosbag_storage/include/rosbag/structures.h
@@ -59,25 +59,25 @@ struct ROSBAG_DECL ConnectionInfo
 
 struct ChunkInfo
 {
-    ros::Time   start_time;    //! earliest timestamp of a message in the chunk
-    ros::Time   end_time;      //! latest timestamp of a message in the chunk
-    uint64_t    pos;           //! absolute byte offset of chunk record in bag file
+    ros::Time   start_time;    //!< earliest timestamp of a message in the chunk
+    ros::Time   end_time;      //!< latest timestamp of a message in the chunk
+    uint64_t    pos;           //!< absolute byte offset of chunk record in bag file
 
-    std::map<uint32_t, uint32_t> connection_counts;   //! number of messages in each connection stored in the chunk
+    std::map<uint32_t, uint32_t> connection_counts;   //!< number of messages in each connection stored in the chunk
 };
 
 struct ROSBAG_DECL ChunkHeader
 {
-    std::string compression;          //! chunk compression type, e.g. "none" or "bz2" (see constants.h)
-    uint32_t    compressed_size;      //! compressed size of the chunk in bytes
-    uint32_t    uncompressed_size;    //! uncompressed size of the chunk in bytes
+    std::string compression;          //!< chunk compression type, e.g. "none" or "bz2" (see constants.h)
+    uint32_t    compressed_size;      //!< compressed size of the chunk in bytes
+    uint32_t    uncompressed_size;    //!< uncompressed size of the chunk in bytes
 };
 
 struct ROSBAG_DECL IndexEntry
 {
-    ros::Time time;            //! timestamp of the message
-    uint64_t  chunk_pos;       //! absolute byte offset of the chunk record containing the message
-    uint32_t  offset;          //! relative byte offset of the message record (either definition or data) in the chunk
+    ros::Time time;            //!< timestamp of the message
+    uint64_t  chunk_pos;       //!< absolute byte offset of the chunk record containing the message
+    uint32_t  offset;          //!< relative byte offset of the message record (either definition or data) in the chunk
 
     bool operator<(IndexEntry const& b) const { return time < b.time; }
 };

--- a/tools/rosbag_storage/src/buffer.cpp
+++ b/tools/rosbag_storage/src/buffer.cpp
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <utility>
+#include <limits>
 
 #include "rosbag/buffer.h"
 
@@ -65,7 +66,12 @@ void Buffer::ensureCapacity(uint32_t capacity) {
         capacity_ = capacity;
     else {
         while (capacity_ < capacity)
+        {
+          if (static_cast<uint64_t>(capacity) * 2 > std::numeric_limits<uint32_t>::max())
+            capacity_ = std::numeric_limits<uint32_t>::max();
+          else
             capacity_ *= 2;
+        }
     }
 
     buffer_ = (uint8_t*) realloc(buffer_, capacity_);

--- a/tools/rosbag_storage/src/chunked_file.cpp
+++ b/tools/rosbag_storage/src/chunked_file.cpp
@@ -100,7 +100,9 @@ void ChunkedFile::open(string const& filename, string const& mode) {
                 file_ = fopen(filename.c_str(), "w+b");
             #endif
         else {
-            fclose(file_);
+            if (fclose(file_) != 0)
+              throw BagIOException((format("Error closing file: %1%") % filename.c_str()).str());
+
             // open existing file for update
             #if defined(_MSC_VER) && (_MSC_VER >= 1400 )
                 fopen_s( &file_, filename.c_str(), "r+b" );

--- a/tools/roslaunch/resources/example.launch
+++ b/tools/roslaunch/resources/example.launch
@@ -70,4 +70,10 @@
     <include file="does/not/exist.launch" />
     <node pkg="doesnt_exist" type="nope" name="nope" />
   </group>
+
+  <!-- Pass over argument from commandline. Set to false should fail -->
+  <arg name="commandline_true_arg" default="true" />
+  <group unless="$(arg commandline_true_arg)">
+    <node pkg="doesnt_exist" type="nope" name="nope" />
+  </group>
 </launch>

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -205,8 +205,10 @@ def _validate_args(parser, options, args):
 
     elif len(args) == 0:
         parser.error("you must specify at least one input file")
-    elif [f for f in args if not (f == '-' or os.path.exists(f))]:
-        parser.error("The following input files do not exist: %s"%f)
+    else:
+        missing_files = [f for f in args if not (f == '-' or os.path.exists(f))]
+        if missing_files:
+            parser.error("The following input files do not exist: %s"%', '.join(missing_files))
 
     if args.count('-') > 1:
         parser.error("Only a single instance of the dash ('-') may be specified.")

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -208,9 +208,9 @@ def setup_env(node, machine, master_uri, env=None):
         if ns[-1] == '/':
             ns = ns[:-1]
         if ns:
-            d[rosgraph.ROS_NAMESPACE] = ns 
+            d[rosgraph.ROS_NAMESPACE] = str(ns)
         for name, value in node.env_args:
-            d[name] = value
+            d[str(name)] = str(value)
 
     return d
 

--- a/tools/roslaunch/src/roslaunch/core.py
+++ b/tools/roslaunch/src/roslaunch/core.py
@@ -346,7 +346,7 @@ class Machine(object):
         self.name = name
         self.env_loader = env_loader
         self.user = user or None
-        self.password = password or None
+        self.password = password
         self.address = address
         self.ssh_port = ssh_port
         self.assignable = assignable

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -118,6 +118,7 @@ def _parse_subcontext(tags, context):
     return subcontext
 
 def _parse_launch(tags, launch_file, file_deps, verbose, context):
+    context['filename'] = os.path.abspath(launch_file)
     dir_path = os.path.dirname(os.path.abspath(launch_file))
     launch_file_pkg = rospkg.get_package_name(dir_path)
             

--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -45,7 +45,7 @@ from xml.dom import Node as DomNode
 
 import rospkg
 
-from .loader import convert_value
+from .loader import convert_value, load_mappings
 from .substitution_args import resolve_args
 
 NAME="roslaunch-deps"
@@ -205,7 +205,7 @@ def parse_launch(launch_file, file_deps, verbose):
 
     file_deps[launch_file] = RoslaunchDeps()
     launch_tag = dom[0]
-    context = { 'arg': {}}
+    context = { 'arg': load_mappings(sys.argv) }
     _parse_launch(launch_tag.childNodes, launch_file, file_deps, verbose, context)
 
 def rl_file_deps(file_deps, launch_file, verbose=False):

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -586,7 +586,9 @@ class ProcessMonitor(Thread):
                     break #stop polling
             for d in dead:
                 try:
-                    if d.should_respawn():
+                    # when should_respawn() returns 0.0, bool(0.0) evaluates to False
+                    # work around this by checking if the return value is False
+                    if d.should_respawn() is not False:
                         respawn.append(d)
                     else:
                         self.unregister(d)

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -186,7 +186,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
         if not err_msg:
             username_str = '%s@'%username if username else ''
             try:
-                if not password: #use SSH agent
+                if password is None: #use SSH agent
                     ssh.connect(address, port, username, timeout=TIMEOUT_SSH_CONNECT, key_filename=identity_file)
                 else: #use SSH with login/pass
                     ssh.connect(address, port, username, password, timeout=TIMEOUT_SSH_CONNECT)

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -714,7 +714,7 @@ class XmlLoader(loader.Loader):
             argv = sys.argv
 
         self._launch_tag(launch, ros_config, filename)
-        self.root_context = loader.LoaderContext(get_ros_namespace(), filename)
+        self.root_context = loader.LoaderContext(get_ros_namespace(argv=argv), filename)
         loader.load_sysargs_into_context(self.root_context, argv)
 
         if len(launch.getElementsByTagName('master')) > 0:

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -626,8 +626,9 @@ class XmlLoader(loader.Loader):
                 self._recurse_load(ros_config, launch.childNodes, child_ns, \
                                        default_machine, is_core, verbose)
 
-            # check for unused args
-            loader.post_process_include_args(child_ns)
+            if not pass_all_args:
+                # check for unused args
+                loader.post_process_include_args(child_ns)
 
         except ArgException as e:
             raise XmlParseException("included file [%s] requires the '%s' arg to be set"%(inc_filename, str(e)))

--- a/tools/roslaunch/test/xml/test-arg-valid-include.xml
+++ b/tools/roslaunch/test/xml/test-arg-valid-include.xml
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="another_parameter_not_used" value="dummy"/>
   <arg name="grounded" value="not_set"/>
   <include file="$(find roslaunch)/test/xml/test-arg-invalid-included.xml" pass_all_args="true"/>
 </launch>

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -623,7 +623,7 @@ class ROSMasterHandler(object):
             self.ps_lock.release()
         return 1, "Registered [%s] as provider of [%s]"%(caller_id, service), 1
 
-    @apivalidate(0, (is_service('service'),))
+    @apivalidate('', (is_service('service'),))
     def lookupService(self, caller_id, service):
         """
         Lookup all provider of a particular service.
@@ -672,7 +672,7 @@ class ROSMasterHandler(object):
     ##################################################################################
     # PUBLISH/SUBSCRIBE
 
-    @apivalidate(0, ( is_topic('topic'), valid_type_name('topic_type'), is_api('caller_api')))
+    @apivalidate([], ( is_topic('topic'), valid_type_name('topic_type'), is_api('caller_api')))
     def registerSubscriber(self, caller_id, topic, topic_type, caller_api):
         """
         Subscribe the caller to the specified topic. In addition to receiving
@@ -729,7 +729,7 @@ class ROSMasterHandler(object):
         finally:
             self.ps_lock.release()
 
-    @apivalidate(0, ( is_topic('topic'), valid_type_name('topic_type'), is_api('caller_api')))
+    @apivalidate([], ( is_topic('topic'), valid_type_name('topic_type'), is_api('caller_api')))
     def registerPublisher(self, caller_id, topic, topic_type, caller_api):
         """
         Register the caller as a publisher the topic.

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -375,7 +375,7 @@ class ROSMasterHandler(object):
         @rtype: [int, str, int]
         """
         key = resolve_name(key, caller_id)
-        self.param_server.set_param(key, value, self._notify_param_subscribers)
+        self.param_server.set_param(key, value, self._notify_param_subscribers, caller_id)
         mloginfo("+PARAM [%s] by %s",key, caller_id)
         return 1, "parameter %s set"%key, 0
 

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -708,7 +708,7 @@ class ROSMasterHandler(object):
     @apivalidate(0, (is_topic('topic'), is_api('caller_api')))
     def unregisterSubscriber(self, caller_id, topic, caller_api):
         """
-        Unregister the caller as a publisher of the topic.
+        Unregister the caller as a subscriber of the topic.
         @param caller_id: ROS caller id
         @type  caller_id: str
         @param topic: Fully-qualified name of topic to unregister.

--- a/tools/rosmaster/src/rosmaster/util.py
+++ b/tools/rosmaster/src/rosmaster/util.py
@@ -51,8 +51,9 @@ del monkey_patch
 
 import errno
 import socket
+import threading
 
-_proxies = {} #cache ServerProxys
+_proxies = threading.local() #cache ServerProxys
 def xmlrpcapi(uri):
     """
     @return: instance for calling remote server or None if not a valid URI
@@ -63,16 +64,16 @@ def xmlrpcapi(uri):
     uriValidate = urlparse(uri)
     if not uriValidate[0] or not uriValidate[1]:
         return None
-    if not uri in _proxies:
-        _proxies[uri] = ServerProxy(uri)
+    if not uri in _proxies.__dict__:
+        _proxies.__dict__[uri] = ServerProxy(uri)
     close_half_closed_sockets()
-    return _proxies[uri]
+    return _proxies.__dict__[uri]
 
 
 def close_half_closed_sockets():
     if not hasattr(socket, 'TCP_INFO'):
         return
-    for proxy in _proxies.values():
+    for proxy in _proxies.__dict__.values():
         transport = proxy("transport")
         if transport._connection and transport._connection[1] is not None and transport._connection[1].sock is not None:
             try:
@@ -86,5 +87,5 @@ def close_half_closed_sockets():
 
 
 def remove_server_proxy(uri):
-    if uri in _proxies:
-        del _proxies[uri]
+    if uri in _proxies.__dict__:
+        del _proxies.__dict__[uri]

--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -333,6 +333,9 @@ def rosnode_ping(node_name, max_count=None, verbose=False):
                 if verbose:
                     print("xmlrpc reply from %s\ttime=%fms"%(node_api, dur))
                 # 1s between pings
+            except socket.timeout:
+                print("connection to [%s] timed out"%node_name, file=sys.stderr)
+                return False
             except socket.error as e:
                 # 3786: catch ValueError on unpack as socket.error is not always a tuple
                 try:
@@ -355,7 +358,7 @@ def rosnode_ping(node_name, max_count=None, verbose=False):
                             continue
                         print("ERROR: connection refused to [%s]"%(node_api), file=sys.stderr)
                     else:
-                        print("connection to [%s] timed out"%node_name, file=sys.stderr)
+                        print("connection to [%s] failed"%node_name, file=sys.stderr)
                     return False
                 except ValueError:
                     print("unknown network error contacting node: %s"%(str(e)))

--- a/tools/rosout/rosout.cpp
+++ b/tools/rosout/rosout.cpp
@@ -171,7 +171,7 @@ public:
       current_file_size_ += written;
       if (fflush(handle_))
       {
-        std::cerr << "Error flushing rosout log file '" << log_file_name_.c_str() << "': " << strerror(ferror(handle_));
+        std::cerr << "Error flushing rosout log file '" << log_file_name_.c_str() << "': " << strerror(errno);
       }
 
       // check for rolling
@@ -179,7 +179,7 @@ public:
       {
         if (fclose(handle_))
         {
-          std::cerr << "Error closing rosout log file '" << log_file_name_.c_str() << "': " << strerror(ferror(handle_)) << std::endl;
+          std::cerr << "Error closing rosout log file '" << log_file_name_.c_str() << "': " << strerror(errno) << std::endl;
         }
         current_backup_index_++;
         if (current_backup_index_ <= max_backup_index_)

--- a/tools/rosservice/src/rosservice/__init__.py
+++ b/tools/rosservice/src/rosservice/__init__.py
@@ -322,7 +322,10 @@ def rosservice_find(service_type):
     try:
         _, _, services = master.getSystemState()
         for s, l in services:
-            t = get_service_type(s)
+            try:
+                t = get_service_type(s)
+            except ROSServiceIOException:
+                continue
             if t == service_type:
                 matches.append(s)
     except socket.error:

--- a/tools/rostopic/src/rostopic/__init__.py
+++ b/tools/rostopic/src/rostopic/__init__.py
@@ -1172,11 +1172,11 @@ def _rostopic_list_group_by_host(master, pubs, subs):
                 if not puri.hostname in tmap:
                     tmap[puri.hostname] = []
                 # recreate the system state data structure, but for a single host
-                matches = [l for x, l in tmap[puri.hostname] if x == topic]
+                matches = [l for x, _, l in tmap[puri.hostname] if x == topic]
                 if matches:
                     matches[0].append(p)
                 else:
-                    tmap[puri.hostname].append((topic, [p]))
+                    tmap[puri.hostname].append((topic, ttype, [p]))
         return tmap
         
     uricache = {}

--- a/tools/topic_tools/env-hooks/20.transform.bash
+++ b/tools/topic_tools/env-hooks/20.transform.bash
@@ -20,7 +20,7 @@ function _roscomplete_node_transform
     fi
 }
 
-_sav_transform_roscomplete_rosrun=$(complete | grep -w rosrun | awk '{print $3}')
+_sav_transform_roscomplete_rosrun=$(complete | { grep -w rosrun || test $? = 1; } | awk '{print $3}')
 
 function is_transform_node
 {

--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -83,8 +83,8 @@ class TopicOp:
 
         self.output_class = roslib.message.get_message_class(args.output_type)
 
-        self.sub = rospy.Subscriber(input_topic, input_class, self.callback)
         self.pub = rospy.Publisher(args.output_topic, self.output_class, queue_size=1)
+        self.sub = rospy.Subscriber(input_topic, input_class, self.callback)
 
     def callback(self, m):
         if self.input_fn is not None:

--- a/tools/topic_tools/src/mux.cpp
+++ b/tools/topic_tools/src/mux.cpp
@@ -167,7 +167,7 @@ void in_cb(const boost::shared_ptr<ShapeShifter const>& msg,
     }
   }
   
-  if (s != g_selected->msg)
+  if (g_selected == g_subs.end() || s != g_selected->msg)
     return;
   
   // If we're in lazy subscribe mode, and nobody's listening, then unsubscribe

--- a/utilities/roslz4/src/lz4s.c
+++ b/utilities/roslz4/src/lz4s.c
@@ -247,6 +247,14 @@ int streamStateAlloc(roslz4_stream *str) {
   state->finished = 0;
 
   state->xxh32_state = XXH32_init(0);
+  if (state->xxh32_state == NULL) {
+    if (state->buffer != NULL) {
+      free(state->buffer);
+    }
+    free(state);
+    str->state = NULL;
+    return ROSLZ4_MEMORY_ERROR; // Allocation failed
+  }
   state->stream_checksum = 0;
   state->stream_checksum_read = 0;
 

--- a/utilities/roslz4/src/xxhash.c
+++ b/utilities/roslz4/src/xxhash.c
@@ -331,7 +331,10 @@ XXH_errorcode XXH32_resetState(void* state_in, U32 seed)
 void* XXH32_init (U32 seed)
 {
     void* state = XXH_malloc (sizeof(struct XXH_state32_t));
-    XXH32_resetState(state, seed);
+    if (state != NULL)
+    {
+      XXH32_resetState(state, seed);
+    }
     return state;
 }
 

--- a/utilities/roswtf/src/roswtf/plugins.py
+++ b/utilities/roswtf/src/roswtf/plugins.py
@@ -89,7 +89,7 @@ def load_plugins():
             else:
                 print("Loaded plugin", p_module)
 
-        except Exception:
-            print("Unable to load plugin [%s] from package [%s]"%(p_module, pkg), file=sys.stderr)
+        except Exception as e:
+            print("Unable to load plugin [%s] from package [%s]. Exception thrown: [%s]"%(p_module, pkg, str(e)), file=sys.stderr)
     return static_plugins, online_plugins
 

--- a/utilities/roswtf/src/roswtf/roslaunchwtf.py
+++ b/utilities/roswtf/src/roswtf/roslaunchwtf.py
@@ -293,6 +293,8 @@ def _load_online_ctx(ctx):
     
 def wtf_check_online(ctx):
     _load_online_ctx(ctx)
+    if not ctx.roslaunch_uris:
+        return
     for r in online_roslaunch_warnings:
         warning_rule(r, r[0](ctx), ctx)
     for r in online_roslaunch_errors:

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
@@ -42,7 +42,7 @@ namespace XmlRpc {
     typedef std::vector<XmlRpcValue> ValueArray;
     typedef std::map<std::string, XmlRpcValue> ValueStruct;
     typedef ValueStruct::iterator iterator;
-
+    typedef ValueStruct::const_iterator const_iterator;
 
     //! Constructors
     XmlRpcValue() : _type(TypeInvalid) { _value.asBinary = 0; }
@@ -97,11 +97,16 @@ namespace XmlRpc {
     XmlRpcValue const& operator[](int i) const { assertArray(i+1); return _value.asArray->at(i); }
     XmlRpcValue& operator[](int i)             { assertArray(i+1); return _value.asArray->at(i); }
 
+    XmlRpcValue& operator[](std::string const& k) const { assertStruct(); return (*_value.asStruct)[k]; }
     XmlRpcValue& operator[](std::string const& k) { assertStruct(); return (*_value.asStruct)[k]; }
+    XmlRpcValue& operator[](const char* k) const { assertStruct(); std::string s(k); return (*_value.asStruct)[s]; }
     XmlRpcValue& operator[](const char* k) { assertStruct(); std::string s(k); return (*_value.asStruct)[s]; }
 
     iterator begin() {assertStruct(); return (*_value.asStruct).begin(); }
     iterator end() {assertStruct(); return (*_value.asStruct).end(); }
+
+    const_iterator begin() const {assertStruct(); return (*_value.asStruct).begin(); }
+    const_iterator end() const {assertStruct(); return (*_value.asStruct).end(); }
 
     // Accessors
     //! Return true if the value has been set to something.
@@ -144,6 +149,7 @@ namespace XmlRpc {
     void assertTypeOrInvalid(Type t);
     void assertArray(int size) const;
     void assertArray(int size);
+    void assertStruct() const;
     void assertStruct();
 
     // XML decoding

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
@@ -80,6 +80,7 @@ namespace XmlRpc {
 
     // Operators
     XmlRpcValue& operator=(XmlRpcValue const& rhs);
+    XmlRpcValue& operator=(bool const& rhs) { return operator=(XmlRpcValue(rhs)); }
     XmlRpcValue& operator=(int const& rhs) { return operator=(XmlRpcValue(rhs)); }
     XmlRpcValue& operator=(double const& rhs) { return operator=(XmlRpcValue(rhs)); }
     XmlRpcValue& operator=(const char* rhs) { return operator=(XmlRpcValue(std::string(rhs))); }

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -107,6 +107,12 @@ namespace XmlRpc {
       throw XmlRpcException("type error: expected an array");
   }
 
+  void XmlRpcValue::assertStruct() const
+  {
+    if (_type != TypeStruct)
+      throw XmlRpcException("type error: expected a struct");
+  }
+
   void XmlRpcValue::assertStruct()
   {
     if (_type == TypeInvalid) {


### PR DESCRIPTION
The following list of changes has been integrated into `ros_comm` between 1.14.3 and 1.14.7 (Melodic) since the last Kinetic release (1.12.14).

**Already merged before this PR:**
* Improves lunar-devel jenkins test stability (#1578)
* fix compiler warnings about unused variables (#1576)
* rosconsole: don't use 0 as null pointer in macros (#1730)
* Added rosbag::Bag::isOpen (#1789)
* Adding template (#1685)
* Use an internal implementation of boost::condition_variable with monotonic clock (#2011)

**Backported in this PR:**
* fix topic_tools environment hook (#1486)
  * Bug fix
* rosnode: Explicitly handle socket.timeout in rosnode ping (#1517)
  * Bug fix
* Fix stamp_age_mean overflow when stamp age very big (#1526)
  * Bug fix
* Exclude unused args check if pass_all_args is set (#1520)
  * Bug fix
* Setting correctly typed @apivalidate default return values (#1472)
  * Bug fix
* roscpp: Add const specifier to `NodeHandle::param(param_name, default_val)` (#1539)
  * Useful API improvement
* Fixed docstring in unregisterSubscriber (#1553)
  * Bug fix
* Removed nullptr access from Timer().hasStarted() (#1541)
  * Bug fix
* Fix race due unprotected access to callbacks_ in roscpp client (#1595)
  * Bug fix
* normalize strings to utf-8 before setting as environment variable (#1593
  * Bug fix
* /topic_tools/mux: do not dereference the end-iterator (#1579)
  * Bug fix
* Catch exeption when searching for services and a single service fails (#1519)
  * Bug fix
* respawn if process died while checking should_respawn() (#1590)
  * Bug fix
* [rosbag] Fix waitForSubscribers hanging with simtime (#1543)
  * Bug fix
* fix infinite loop in rosbag buffer resize (#1623)
  * Bug fix
* fixed bug in statistics decision making if one should publish (#1625)
  * Bug fix
* roscpp/service: use WallTime/WallDuration for waiting (#1638)
  * Bug fix
* roscpp/TopicManager: avoid deadlock (#1645)
  * Bug fix
* make roslaunch-check respect arg remappings with command line argument (#1653)
  * Bug fix
* Fix wrong error handling in migration (#1639)
  * Bug fix
* topic_tools/transfom: create publisher before subscriber, because callback may use the publisher (#1669)
  * Bug fix
* Fix $(dirname) for roslaunch-check (#1624)
  * Bug fix
* fix topic message count for rosbag indexed v1.2 (#1648)
  * Bug fix
* /libros/node_handle: alternative way to fix #838 (#1656)
  * Bug fix
* Fixed issue occuring during alternating calls of getParamCached and setParam (#1439)
  * Bug fix
* Resolve memory leak (#1503)
  * Bug fix
* Fix error handling for Topic constructor (#1701)
  * Bug fix
* Add missing comma in the list of strings (#1760)
  * Bug fix
* Added const indexer for xmlrpc (#1759)
  * Useful API improvement
* rosbag/record: fix signed int overflow (#1741)
  * Bug fix
* fixing string check (#1771)
  * Bug fix
* Fix use-after-free issue in rosout (#1764)
  * Bug fix
* Check for fclose returning 0 in rosbag_storage (#1750)
  * Bug fix
* rostopic: _rostopic_list_group_by_host: publisher/subscriber lists have correct type now (#1780)
  * Bug fix
* check for XXH_malloc NULL return (#1778)
  * Bug fix
* unregisterService returns result of execute("unregisterService") (#1751)
  * Bug fix
* roscpp/transport_tcp: enable poll event POLLRDHUP to detect dead (#1704)
  * Bug fix
* Fix segfault in TransportPublisherLink (#1714)
  * Bug fix
* add Timer::isValid() const (#1779)
  * Useful API improvement
* XmlRpcValue added bool assignment operator (#1709)
  * Bug fix
* fixed #1776 deadcode (#1786)
  * Bug fix
* Missing args (#1733)
  * Bug fix
* [roswtf] Print exception content to show better idea why loading plugin failed (#1721)
  * Helpful improvement
* Do not raise socket exception during shutdown (#1720)
  * Bug fix
* Use thread local storage for caching instances of ServerProxy (#1732)
  * Bug fix
* roscpp: TransportTCP: Allow socket() to return 0 (#1707)
  * Bug fix
* Bug: roslib not being imported (#1818)
  * Bug fix
* do not try to run online checks if there are no roslaunch uris (#1848)
  * Bug fix
* Allowed empty ssh password for remote launching (#1826)
  * Bug fix
* Do not display error message if poll yields EINTR (#1868)
  * Bug fix
* fix dictionary changed size during iteration (#1894)
  * Bug fix
* Fix brief description comments after members (#1920)
  * Bug fix
* Remove extra \n in ROS_DEBUG (#1925)
  * Bug fix
* Fix a bug that using a destroyed connection object (#1950)
  * Bug fix
* fix NameError in launch error handling (#1965)
  * Bug fix
* remove not existing NodeProxy from rospy __all__ (#2007)
  * Bug fix

**Not backported:**
* fix compiler warnings about unused variables (#1610)
  * Not necessary
* Disable rosout.log by using environment variable (#1425)
  * New feature
* Fix issues when built or run on Windows (#1466)
  * Windows specific
* reduce test threshold to avoid flakiness (#1485)
  * Not necessary
* topic_tools/mux: add ~latch option (#1489)
  * New feature
* import socket, threading in udpros.py (#1494)
  * Not necessary
* Fix test code build issues on Windows (#1479)
  * Windows specific
* Fix message_filters build issue on the template syntax (#1483)
  * Windows specific
* [roslaunch] Better exception handling when resource is not found (#1476)
  * Not necessary
* show connection info on rosnode info (#1497)
  * New feature
* [roswtf] Better msg replacement for 'No package or stack in context' (#1505)
  * Not necessary
* Fix memory error due to missing rosout_disable_topics_generation parameter (#1507)
  * Not applicable
* [C++14] remove explicit -std=c++11, default to 14 (#1525)
  * Not necessary
* Add a new option to publish when a bag write begin (#1527)
  * New feature
* Update wiki.ros.org URLs (#1536)
  * Not necessary
* roslaunch: add an option in XmlLoader to only load arg tags (#1521)
  * New feature
* Fix test_roscpp build issues on Windows (#1482)
  * Windows specific
* Added more useful helper text here to indicate that this might be a permission error (#1568)
  * Not necessary
* Fixed typos: awhile -> a while (#1534)
  * Not necessary
* query ipv6 only if specified (#1596)
  * Not necessary
* visibility macros update (#1591)
  * Windows specific
* Revert "Revert "move the winsock2.h into cpp."" (#1588)
  * Windows specific
* include cctype for std::tolower (#1587)
  * Windows specific
* Directly run python script if run test through cmake (#24) (#1583)
  * Windows specific
* Fix string error on windows (#1582)
  * Windows specific
* Remove signals from find_package(Boost COMPONENTS ...) (#1580)
  * Not necessary
* Added a check for missing dependencies and Docker container (#1573)
  * Not necessary
* fix various test problems (#1601)
  * Not necessary
* Add hasStarted() const to WallTimer and SteadyTimer API (#1565)
  * New feature
* remove messages that are newer than the newly added message (#1438)
  * New feature
* roslaunch/xmlloader: use continue instead of pass for args_only (#1540)
  * Not necessary
* Avoid calling memcpy on NULL pointer with size 0 (#1546)
  * Not applicable
* Publish last message from latch topics when start time > 0 (#1537)
  * New feature
* duplicate test nodes which aren't available to other packages, add missing dependencies (#1611)
  * Not necessary
* fix paths (and regex for paths) comparison issues (#1592)
  * Windows specific
* normalize paths before comparison in rosmsg (#1586)
  * Windows specific
* add python prefix for python scripts when there is no .py extension (#1589)
  * Windows specific
* test_rospy: added queue_size arguments to Publishers to avoid warnings (#1615)
  * Not necessary
* Make sigterm handling python3 compatible. (#1559)
  * Not necessary
* add Windows.h usage explicitly (#1616)
  * Windows specific
* fix IOError during Python file operation (#1617)
  * Windows specific
* update CMakeLists.txt in rosbag_storage (#1618)
  * Windows specific
* add POSIX flag for shlex.split() (#1619)
  * Windows specific
* update install destination for roslz4 (#1620)
  * Windows specific
* xmlrpcpp: fixed invalid zero index as suggested in #1547 (#1631)
  * Not necessary
* roscpp: added missin include path (for bazel workspaces) (#1636)
  * Not necessary
* rosbag_storage: fixed dangeling if-else (#1637)
  * Not necessary
* rosbag_storage modernization: replaced BOOST_FOREACH with range-based for loops, used algorithm, where appropriated (#1640)
  * Not necessary
* test_rospy: added queue_size arguments to Publishers to avoid warning (#1643)
  * Not necessary
* test_rosbag modernization: replaced BOOST_FOREACH with range-based for-loops (#1642)
  * Not necessary
* rostopic: repeatedly republish message from file (#1635)
  * New feature
* rosbag modernization: replaced BOOST_FOREACH with range-based for-loops (#1641)
  * Not necessary
* message_filters/__init_\_.py - Added reduce import for python3 compatability (#1633)
  * Not necessary
* add option to hide summary from roslaunch output (#1655)
  * New feature
* update approximate time filter to work with python2 and python3 (#1660)
  * Not necessary
* change how commands are executed (#1628)
  * Windows specific
* rosservice: use myargv() (#1667) 
  * Not necessary
* rostest: use AnyMsg in publishtest (#1659)
  * New feature
* rostest: fix flaky hztests (#1661)
  * Not necessary
* move bag encryption plugins into separate library (#1499)
  * Not necessary
* Pickleable rosbag exceptions (#1652)
  * Not applicable
* fix windows build for rosbag_storage (#1687)
  * Windows specific
* fix(tools/rostopic): fix typo, confict -> conflict (#1690)
  * Not necessary
* rosgraph/network: use urlparse for parsing the port, whick makes ipv6 possible (#1698)
  * New feature
* Switch to yaml.safe_load(_all) to prevent YAMLLoadWarning (#1688)
  * Not necessary
* more Python 3 compatibility (#1782)
  * Not necessary
* more Python 3 compatibility (#1783)
  * Not necessary
* roscpp/transport_udp: zero-initialize sockaddr_in object (#1740)
  * Not necessary
* Wrap the rosbag filter eval in a lambda (#1712)
  * Not necessary
* /topic_tools/relay_field: added --tcpnodely (#1682)
  * New feature
* roslaunch added --required option (#1681)
  * New feature
* rosbag fix: keep latched topics latched (#1708)
  * New feature
* added is_legal_remap() to rosgraph to make remap-detection more precise (#1683)
  * New feature
* Added possibility to pass rospy.Duration as timeout to wait_for_service and wait_for_message. (#1703)
  * New feature
* fix base64 encode error (#1769)
  * Not applicable
* more Python 3 compatibility (#1784)
  * Not necessary
* more Python 3 compatibility (#1785)
  * Not necessary
* Encrypted rosbag fixes for Python 3 (#1777)
  * Not necessary
* Small fixes for roslaunch-check on Python 3 (#1770)
  * Not necessary
* rostest: add advertisetest (#1761)
  * New feature
* Taskkill process tree (#1725)
  * Windows specific
* Fixed test build errors (#1723)
  * Windows specific
* rostopic: added --use-rostime for pub (#1717)
  * New feature
* roscpp/service_publication: removed int-bool-comparison (#1710)
  * Not necessary
* topic_tools/relay: fixed boost::lock exception (#1696)
  * Not applicable
* Fix dynamic windowing for Topic Statistics (#1695)
  * Not applicable
* [Windows][melodic-devel] Skip `cat` related test cases on Windows build (#1724)
  * Windows specific
* Add pycryptodome as default on melodic (#1609)
  * Not applicable
* use condition attributes to specify Python 2 and 3 dependencies (#1792)
  * Not necessary
* fix line endings to be LF (#1794)
  * Not necessary
* more Python 3 compatibility (#1795)
  * Not necessary
* more Python 3 compatibility (#1796)
  * Not necessary
* Make log config from rosgraph optional (#1797)
  * New feature
* Make log config from rosgraph optional (#1797)
  * Not applicable
* fix Coverity forward null (#1787)
  * Not necessary
* rosbag_storage: Fixed unnecessary writing to map in write only mode (#1798)
  * Not applicable
* Correct an issue from pycrypodome switchover (#1814)
  * Not applicable
* Make test code to be more portable (#1726)
  * Windows specific
* Add more Windows test code fixes (#1727)
  * Windows specific
* fix lower bound of signed int (#1781)
  * Not applicable without corresponding genpy change
* compatibility: RospyLogger findCaller arguments (#1838)
  * Not necessary
* fix escape sequences in regular expressions (#1837)
  * Not necessary
* change unsafe yaml.load to yaml.safe_load (#1835)
  * Not necessary
* Escape drive as well as path separator (#1815)
  * Windows specific
* Add alternative lz4 name for Windows (#1821)
  * Windows specific
* Python 3 compatibility. (#1819)
  * Windows specific
* use c++11 std::snprintf (#1820)
  * Windows specific
* Remove DEBUG statements from getImpl (#1823)
  * Not applicable
* Fix base64 decode error on ARM platforms (#1853)
  * Not applicable
* Read GPG passphrase from an environment variable (#1856)
  * New feature
* prevent indefinitely trapping in unknown error state (#1854)
  * Not applicable
* workaround WSAPoll doesn't report failed connections (#1816)
  * Windows specific
* explicit include of socket.h to support FreeBSD (#1864)
  * Not necessary
* rosbag_storage: use find_library for abs path of crypto and gpgme libraries (#1867)
  * Not necessary
* [rosbag] Catch exceptions by const ref. (#1874)
  * Not necessary
* conditionally gaurd sys/socket.h for Windows (#1876)
  * Windows specific
* Add quotes around file name so they can be click selected in terminal (#1813)
  * Not necessary
* test_rosbag: add target dependency to fix unit test failures in parallel builds (#1877)
  * Not necessary
* Workaround for Python 2 xmlrpc performance issues (#1872)
  * Windows specific
* Add overload of ApproximateTime::setInterMessageLowerBound() to set all topics to the same value (#1860)
  * New feature
* roscpp: disable rosout via ROSCPP_NO_ROSOUT env var (#1858)
  * New feature
* add platform check for --args code path (#1809)
  * Windows specific
* Drop custom implementation of boost::condition_variable to fix busy-wait spinning (#1878)
  * Not applicable
* rospy: added get_param_cached (#1515)
  * New feature
* [roslaunch] Add ignore default args option to roslaunch-check (#1788)
  * New feature
* Use node namespace when looking up topic (#1663)
  * Not applicable
* Added kwargs to internal logging functions (#1290)
  * New feature
* Added args and kwargs to rospy.log* (#1289)
  * New feature
* wrap env prefix with double quotes (#1810)
  * New feature
* portable duration cast (#1882)
  * Windows specific
* Use cached parameter for rosout_disable_topics_generation (#1881)
  * New feature
* Reuse xmlrpc connections everywhere (#1471)
  * Not necessary
* Bump CMake version to avoid CMP0048 warning (#1869)
  * Not necessary
* catch polymorphic exceptions by reference (#1887)
  * Not necessary
* add default assignment operator for various classes (#1888)
  * Not necessary
* Use double quotes for portable roslaunch-check command (#1883)
  * Windows specific
* Allow empty machine arg in node tag (#1885)
  * New feature
* fix test which fails on Noetic (#1891)
  * Not necessary
* Add default ROS_MASTER_URI (#1666)
  * Not necessary
* update test to pass with old and new yaml (#1893)
  * Not necessary
* fix flakyness of transform test (#1890)
  * Not necessary
* fix flakyness of test_topic_statistics (#1896)
  * Not necessary
* increase time limit of advertisetest/publishtest.test to reduce flakyness (#1897)
  * Not necessary
* make statistics.test less flaky (#1899)
  * Not necessary
* make statistics.test less flaky (#1899)
  * Not applicable
* fix mac trying to use epoll instead of kqueue (#1907)
  * Not necessary
* add exception for ConnectionAbortedError (#1908)
  * Not necessary
* Check if enough FDs are free, instead counting the total free FDs. (#1929)
  * Not necessary
* Fix use undefined dynamic_lookup on OSX (#1923)
  * Not necessary
* [roslaunch] remove pycrypto import (not used) (#1922)
  * Not necessary
* Sort printed nodes by namespace alphabetically (#1934)
  * New feature
* Avoid infinite recursion in rosrun tab completion when rosbash is not installed (#1948)
  * Not necessary
* Fix bag migration failures caused by typo in connection_header assignment (#1952)
  * Not applicable
* Added const versions of XmlRpcValue converting operators (#1978)
  * Not applicable
* Add latch param to throttle (#1944)
  * New feature
* Add which node has been registered with the same name (#1992)
  * New feature
* Use an internal implementation of boost::condition_variable with monotonic clock (#1932)
  * Not applicable
* Fix subscription busy wait melodic (#1684)
  * Not applicable
* Fix subscription busy wait melodic (#2014)
  * Not applicable