### PR TITLE
[melodic] support Boost 1.66

### DIFF
--- a/clients/roscpp/include/ros/internal/condition_variable.h
+++ b/clients/roscpp/include/ros/internal/condition_variable.h
@@ -156,7 +156,10 @@ public:
       pthread_mutex_t *the_mutex = &internal_mutex;
       guard.activate(m);
       res = pthread_cond_wait(&cond, the_mutex);
-#if BOOST_VERSION >= 106500
+#if BOOST_VERSION >= 106600
+      check_for_interruption.unlock_if_locked();
+      guard.deactivate();
+#elif BOOST_VERSION >= 106500
       check_for_interruption.check();
       guard.deactivate();
 #endif
@@ -186,7 +189,10 @@ public:
       pthread_mutex_t *the_mutex = &internal_mutex;
       guard.activate(m);
       cond_res = pthread_cond_timedwait(&cond, the_mutex, &timeout);
-#if BOOST_VERSION >= 106500
+#if BOOST_VERSION >= 106600
+      check_for_interruption.unlock_if_locked();
+      guard.deactivate();
+#elif BOOST_VERSION >= 106500
       check_for_interruption.check();
       guard.deactivate();
 #endif


### PR DESCRIPTION
interruption_checker::check() had been available only between Boost 1.65.0 and 1.65.1.
It has been renamed to unlock_if_locked() since 1.66.0.

ref: https://github.com/seqsense/aports-ros-experimental/pull/281 (build for Alpine Linux failed)