### PR TITLE
Use heapq.merge instead of custom merge sort code

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -1333,7 +1333,7 @@ class Bag(object):
         """
         Yield index entries on the given connections in the given time range.
         """
-        for entry, _ in _mergesort(self._get_indexes(connections), key=lambda entry: entry.time):
+        for entry in heapq.merge(*self._get_indexes(connections), key=lambda x: x.time.to_nsec()):
             if start_time and entry.time < start_time:
                 continue
             if end_time and entry.time > end_time:
@@ -1344,7 +1344,8 @@ class Bag(object):
         """
         Yield index entries on the given connections in the given time range in reverse order.
         """
-        for entry, _ in _mergesort((reversed(index) for index in self._get_indexes(connections)), key=lambda entry: -entry.time.to_sec()):
+        for entry in heapq.merge(*(reversed(index) for index in self._get_indexes(connections)),
+                                 key=lambda x: x.time.to_nsec(), reverse=True):
             if end_time and entry.time > end_time:
                 continue
             if start_time and entry.time < start_time:
@@ -2901,71 +2902,6 @@ def _human_readable_frequency(freq):
         freq /= multiple
 
     return '-'
-
-## See http://code.activestate.com/recipes/511509
-def _mergesort(list_of_lists, key=None):
-    """
-    Perform an N-way merge operation on sorted lists.
-
-    @param list_of_lists: (really iterable of iterable) of sorted elements
-    (either by naturally or by C{key})
-    @param key: specify sort key function (like C{sort()}, C{sorted()})
-    @param iterfun: function that returns an iterator.
-
-    Yields tuples of the form C{(item, iterator)}, where the iterator is the
-    built-in list iterator or something you pass in, if you pre-generate the
-    iterators.
-
-    This is a stable merge; complexity O(N lg N)
-
-    Examples::
-
-    print list(x[0] for x in mergesort([[1,2,3,4],
-                                        [2,3.5,3.7,4.5,6,7],
-                                        [2.6,3.6,6.6,9]]))
-    [1, 2, 2, 2.6, 3, 3.5, 3.6, 3.7, 4, 4.5, 6, 6.6, 7, 9]
-
-    # note stability
-    print list(x[0] for x in mergesort([[1,2,3,4],
-                                        [2,3.5,3.7,4.5,6,7],
-                                        [2.6,3.6,6.6,9]], key=int))
-    [1, 2, 2, 2.6, 3, 3.5, 3.6, 3.7, 4, 4.5, 6, 6.6, 7, 9]
-
-    print list(x[0] for x in mergesort([[4,3,2,1],
-                                        [7,6.5,4,3.7,3.3,1.9],
-                                        [9,8.6,7.6,6.6,5.5,4.4,3.3]],
-                                        key=lambda x: -x))
-    [9, 8.6, 7.6, 7, 6.6, 6.5, 5.5, 4.4, 4, 4, 3.7, 3.3, 3.3, 3, 2, 1.9, 1]
-    """
-
-    heap = []
-    for i, itr in enumerate(iter(pl) for pl in list_of_lists):
-        try:
-            item = next(itr)
-            toadd = (key(item), i, item, itr) if key else (item, i, itr)
-            heap.append(toadd)
-        except StopIteration:
-            pass
-    heapq.heapify(heap)
-
-    if key:
-        while heap:
-            _, idx, item, itr = heap[0]
-            yield item, itr
-            try:
-                item = next(itr)
-                heapq.heapreplace(heap, (key(item), idx, item, itr) )
-            except StopIteration:
-                heapq.heappop(heap)
-
-    else:
-        while heap:
-            item, idx, itr = heap[0]
-            yield item, itr
-            try:
-                heapq.heapreplace(heap, (next(itr), idx, itr))
-            except StopIteration:
-                heapq.heappop(heap)
 
 class _CompressorFileFacade(object):
     """


### PR DESCRIPTION
Since Python 3.5 a library function exists that does what we need. I'm therefore proposing to replace custom merge sort code with calls to heapq.merge.