### PR TITLE
[rospy] fix param cache when node is subscribing and setting a parameter

### DIFF
--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -131,7 +131,13 @@ class MasterProxy(object):
         @param val: parameter value
         @type val: XMLRPC legal value
         """
-        self.target.setParam(rospy.names.get_caller_id(), rospy.names.resolve_name(key), val)
+        resolved_key = rospy.names.resolve_name(key)
+
+        self.target.setParam(rospy.names.get_caller_id(), resolved_key, val)
+        try:
+            rospy.impl.paramserver.get_param_server_cache().update(resolved_key, val)
+        except KeyError:
+            pass
         
     def search_param(self, key):
         """


### PR DESCRIPTION
If one ROS node is setting and at the same time subscribing to the same parameter the ROS master does not notify about a parameter change. This change makes sure that the cache is updated after a set_param call.

## Before
```
In [1]: import rospy
In [2]: rospy.init_node('asdf', log_level=rospy.DEBUG)
In [3]: rospy.set_param('a', 5)
In [4]: rospy.get_param('a')
Out[4]: 5
In [5]: rospy.get_param_cached('a')
Out[5]: 5
In [6]: rospy.set_param('a', 10)
In [7]: rospy.get_param_cached('a')
Out[7]: 5
In [8]: rospy.get_param('a')
Out[8]: 5
```


## After
```
In [1]: import rospy
In [2]: rospy.init_node('asdf', log_level=rospy.DEBUG)
In [3]: rospy.set_param("a", 5)
In [4]: rospy.get_param("a")
Out[4]: 5
In [5]: rospy.get_param_cached("a")
Out[5]: 5
In [6]: rospy.set_param("a", 10)
In [7]: rospy.get_param("a")
Out[7]: 10
In [8]: rospy.get_param_cached("a")
Out[8]: 10
```