### PR TITLE
Ignore underscores when parsing literal numeric values

### DIFF
--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -74,6 +74,8 @@ def convert_value(value, type_):
         try:
             if '.' in value:
                 return float(value)
+            # Python 3 ignores/drops underscores in number literals (due to PEP515).
+            # Here, we want to handle literals with underscores as plain strings.
             if '_' not in value:
                 return int(value)
         except ValueError as e:

--- a/tools/roslaunch/src/roslaunch/loader.py
+++ b/tools/roslaunch/src/roslaunch/loader.py
@@ -74,7 +74,7 @@ def convert_value(value, type_):
         try:
             if '.' in value:
                 return float(value)
-            else:
+            if '_' not in value:
                 return int(value)
         except ValueError as e:
             pass


### PR DESCRIPTION
Python 3, due to PEP515, allows numerical values to be (visually)
grouped via underscores. However, here, we want to consider literals
containing an underscore as a string.