### PR TITLE
Fix issue with rospy.set_param('')

### DIFF
--- a/clients/rospy/src/rospy/impl/paramserver.py
+++ b/clients/rospy/src/rospy/impl/paramserver.py
@@ -96,11 +96,11 @@ class ParamServerCache(object):
             # partially borrowed from rosmaster/paramserver.py
             namespaces = [x for x in key.split(SEP) if x]
             # - last namespace is the actual key we're storing in
-            value_key = namespaces[-1]
-            namespaces = namespaces[:-1]
             d = self.d
             if d is None:
                 raise KeyError(key)
+            value_key = namespaces[-1]
+            namespaces = namespaces[:-1]
             # - descend tree to the node we're setting
             for ns in namespaces:
                 if ns not in d:


### PR DESCRIPTION
ParamServerCache was making problems when setting a param on '/' or on the namespace of the node ('').

Before the change, the `paramserver.py` was raising an IndexError:

```python
2020-08-17 07:24:18 (UTC)
IN [1]: rospy.set_param('', {'a': 1})
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-1-4cd7519fe9aa> in <module>()
----> 1 rospy.set_param('', {'a': 1})

/home/luetjens/catkin_ws/src/ros_comm/clients/rospy/src/rospy/client.py in set_param(param_name, param_value)
    537
    538     _init_param_server()
--> 539     _param_server[param_name] = param_value #MasterProxy does all the magic for us
    540
    541 def search_param(param_name):

/home/luetjens/catkin_ws/src/ros_comm/clients/rospy/src/rospy/msproxy.py in __setitem__(self, key, val)
    136         self.target.setParam(rospy.names.get_caller_id(), resolved_key, val)
    137         try:
--> 138             rospy.impl.paramserver.get_param_server_cache().update(resolved_key, val)
    139         except KeyError:
    140             pass

/home/luetjens/catkin_ws/src/ros_comm/clients/rospy/src/rospy/impl/paramserver.py in update(self, key, value)
     97             namespaces = [x for x in key.split(SEP) if x]
     98             # - last namespace is the actual key we're storing in
---> 99             value_key = namespaces[-1]
    100             namespaces = namespaces[:-1]
    101             d = self.d

IndexError: list index out of range
```

After the change, setting params works as expected. Setting on root:

```python
2020-08-17 07:35:22 (UTC)
IN [1]: rospy.set_param('/', {'a': 4})

2020-08-17 07:35:27 (UTC)
IN [2]: rospy.get_param('/')
OUT [2]: {'a': 4}

2020-08-17 07:35:35 (UTC)
IN [3]: rospy.set_param('/', {'a': 5})

2020-08-17 07:35:36 (UTC)
IN [4]: rospy.get_param('/')
OUT [4]: {'a': 5}
```

Setting on the namespace of the node:

```python
2020-08-17 08:12:10 (UTC)
IN [1]: rospy.set_param('', {'a': 5})

2020-08-17 08:12:12 (UTC)
IN [2]: rospy.get_param('')
OUT [2]: {'a': 5}
```