### PR TITLE
use fully qualified ceil() in condition_variable.h

### DIFF
--- a/clients/roscpp/include/ros/internal/condition_variable.h
+++ b/clients/roscpp/include/ros/internal/condition_variable.h
@@ -34,7 +34,6 @@
 #ifndef ROSCPP_INTERNAL_CONDITION_VARIABLE_H
 #define ROSCPP_INTERNAL_CONDITION_VARIABLE_H
 
-#include <cmath>
 #include <boost/thread/condition_variable.hpp>
 
 namespace ros {
@@ -107,7 +106,7 @@ public:
     typedef boost::chrono::time_point<boost::chrono::steady_clock, boost::chrono::nanoseconds>
       nano_sys_tmpt;
     wait_until(lock,
-               nano_sys_tmpt(std::ceil<boost::chrono::nanoseconds>(t.time_since_epoch())));
+               nano_sys_tmpt(boost::chrono::ceil<boost::chrono::nanoseconds>(t.time_since_epoch())));
     return boost::chrono::steady_clock::now() < t ?
       boost::cv_status::no_timeout :
       boost::cv_status::timeout;
@@ -120,7 +119,7 @@ public:
   {
     boost::chrono::steady_clock::time_point s_now = boost::chrono::steady_clock::now();
     typename Clock::time_point c_now = Clock::now();
-    wait_until(lock, s_now + std::ceil<boost::chrono::nanoseconds>(t - c_now));
+    wait_until(lock, s_now + boost::chrono::ceil<boost::chrono::nanoseconds>(t - c_now));
     return Clock::now() < t ? boost::cv_status::no_timeout : boost::cv_status::timeout;
   }
 
@@ -130,7 +129,7 @@ public:
       const boost::chrono::duration<Rep, Period> &d)
   {
     boost::chrono::steady_clock::time_point c_now = boost::chrono::steady_clock::now();
-    wait_until(lock, c_now + std::ceil<boost::chrono::nanoseconds>(d));
+    wait_until(lock, c_now + boost::chrono::ceil<boost::chrono::nanoseconds>(d));
     return boost::chrono::steady_clock::now() - c_now < d ?
       boost::cv_status::no_timeout :
       boost::cv_status::timeout;

--- a/clients/roscpp/include/ros/internal/condition_variable.h
+++ b/clients/roscpp/include/ros/internal/condition_variable.h
@@ -34,6 +34,7 @@
 #ifndef ROSCPP_INTERNAL_CONDITION_VARIABLE_H
 #define ROSCPP_INTERNAL_CONDITION_VARIABLE_H
 
+#include <cmath>
 #include <boost/thread/condition_variable.hpp>
 
 namespace ros {
@@ -106,7 +107,7 @@ public:
     typedef boost::chrono::time_point<boost::chrono::steady_clock, boost::chrono::nanoseconds>
       nano_sys_tmpt;
     wait_until(lock,
-               nano_sys_tmpt(ceil<boost::chrono::nanoseconds>(t.time_since_epoch())));
+               nano_sys_tmpt(std::ceil<boost::chrono::nanoseconds>(t.time_since_epoch())));
     return boost::chrono::steady_clock::now() < t ?
       boost::cv_status::no_timeout :
       boost::cv_status::timeout;
@@ -119,7 +120,7 @@ public:
   {
     boost::chrono::steady_clock::time_point s_now = boost::chrono::steady_clock::now();
     typename Clock::time_point c_now = Clock::now();
-    wait_until(lock, s_now + ceil<boost::chrono::nanoseconds>(t - c_now));
+    wait_until(lock, s_now + std::ceil<boost::chrono::nanoseconds>(t - c_now));
     return Clock::now() < t ? boost::cv_status::no_timeout : boost::cv_status::timeout;
   }
 
@@ -129,7 +130,7 @@ public:
       const boost::chrono::duration<Rep, Period> &d)
   {
     boost::chrono::steady_clock::time_point c_now = boost::chrono::steady_clock::now();
-    wait_until(lock, c_now + ceil<boost::chrono::nanoseconds>(d));
+    wait_until(lock, c_now + std::ceil<boost::chrono::nanoseconds>(d));
     return boost::chrono::steady_clock::now() - c_now < d ?
       boost::cv_status::no_timeout :
       boost::cv_status::timeout;


### PR DESCRIPTION
That way downstream consumers can successfully use the
`wait_until` family of methods.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

There are some builds failing because of this: http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__grid_map_rviz_plugin__ubuntu_bionic_amd64__binary/37/console

Fixes a regression introduced by #2020 