### PR TITLE
changes between 1.12.15 and 1.14.9 for backporting

### DIFF
--- a/clients/roscpp/include/ros/internal/condition_variable.h
+++ b/clients/roscpp/include/ros/internal/condition_variable.h
@@ -103,11 +103,13 @@ public:
       boost::unique_lock<boost::mutex> &lock,
       const boost::chrono::time_point<boost::chrono::steady_clock, Duration> &t)
   {
-    using namespace boost::chrono;
-    typedef time_point<steady_clock, nanoseconds> nano_sys_tmpt;
+    typedef boost::chrono::time_point<boost::chrono::steady_clock, boost::chrono::nanoseconds>
+      nano_sys_tmpt;
     wait_until(lock,
-               nano_sys_tmpt(ceil<nanoseconds>(t.time_since_epoch())));
-    return steady_clock::now() < t ? boost::cv_status::no_timeout : boost::cv_status::timeout;
+               nano_sys_tmpt(ceil<boost::chrono::nanoseconds>(t.time_since_epoch())));
+    return boost::chrono::steady_clock::now() < t ?
+      boost::cv_status::no_timeout :
+      boost::cv_status::timeout;
   }
 
   template <class Clock, class Duration>
@@ -115,10 +117,9 @@ public:
       boost::unique_lock<boost::mutex> &lock,
       const boost::chrono::time_point<Clock, Duration> &t)
   {
-    using namespace boost::chrono;
-    steady_clock::time_point s_now = steady_clock::now();
+    boost::chrono::steady_clock::time_point s_now = boost::chrono::steady_clock::now();
     typename Clock::time_point c_now = Clock::now();
-    wait_until(lock, s_now + ceil<nanoseconds>(t - c_now));
+    wait_until(lock, s_now + ceil<boost::chrono::nanoseconds>(t - c_now));
     return Clock::now() < t ? boost::cv_status::no_timeout : boost::cv_status::timeout;
   }
 
@@ -127,18 +128,18 @@ public:
       boost::unique_lock<boost::mutex> &lock,
       const boost::chrono::duration<Rep, Period> &d)
   {
-    using namespace boost::chrono;
-    steady_clock::time_point c_now = steady_clock::now();
-    wait_until(lock, c_now + ceil<nanoseconds>(d));
-    return steady_clock::now() - c_now < d ? boost::cv_status::no_timeout : boost::cv_status::timeout;
+    boost::chrono::steady_clock::time_point c_now = boost::chrono::steady_clock::now();
+    wait_until(lock, c_now + ceil<boost::chrono::nanoseconds>(d));
+    return boost::chrono::steady_clock::now() - c_now < d ?
+      boost::cv_status::no_timeout :
+      boost::cv_status::timeout;
   }
 
   boost::cv_status wait_until(
       boost::unique_lock<boost::mutex> &lk,
       boost::chrono::time_point<boost::chrono::steady_clock, boost::chrono::nanoseconds> tp)
   {
-    using namespace boost::chrono;
-    nanoseconds d = tp.time_since_epoch();
+    boost::chrono::nanoseconds d = tp.time_since_epoch();
     timespec ts = boost::detail::to_timespec(d);
     if (do_wait_until(lk, ts))
       return boost::cv_status::no_timeout;

--- a/clients/roscpp/include/ros/internal/condition_variable.h
+++ b/clients/roscpp/include/ros/internal/condition_variable.h
@@ -106,7 +106,7 @@ public:
     typedef boost::chrono::time_point<boost::chrono::steady_clock, boost::chrono::nanoseconds>
       nano_sys_tmpt;
     wait_until(lock,
-               nano_sys_tmpt(ceil<boost::chrono::nanoseconds>(t.time_since_epoch())));
+               nano_sys_tmpt(boost::chrono::ceil<boost::chrono::nanoseconds>(t.time_since_epoch())));
     return boost::chrono::steady_clock::now() < t ?
       boost::cv_status::no_timeout :
       boost::cv_status::timeout;
@@ -119,7 +119,7 @@ public:
   {
     boost::chrono::steady_clock::time_point s_now = boost::chrono::steady_clock::now();
     typename Clock::time_point c_now = Clock::now();
-    wait_until(lock, s_now + ceil<boost::chrono::nanoseconds>(t - c_now));
+    wait_until(lock, s_now + boost::chrono::ceil<boost::chrono::nanoseconds>(t - c_now));
     return Clock::now() < t ? boost::cv_status::no_timeout : boost::cv_status::timeout;
   }
 
@@ -129,7 +129,7 @@ public:
       const boost::chrono::duration<Rep, Period> &d)
   {
     boost::chrono::steady_clock::time_point c_now = boost::chrono::steady_clock::now();
-    wait_until(lock, c_now + ceil<boost::chrono::nanoseconds>(d));
+    wait_until(lock, c_now + boost::chrono::ceil<boost::chrono::nanoseconds>(d));
     return boost::chrono::steady_clock::now() - c_now < d ?
       boost::cv_status::no_timeout :
       boost::cv_status::timeout;

--- a/test/test_rospy/test/unit/test_genmsg_py.py
+++ b/test/test_rospy/test/unit/test_genmsg_py.py
@@ -264,7 +264,7 @@ class TestGenmsgPy(unittest.TestCase):
         widths = [(8, Int8), (16, Int16), (32, Int32), (64, Int64)]
         for w, cls in widths:
             maxp = long(math.pow(2, w-1)) - 1
-            maxn = -long(math.pow(2, w-1)) + 1
+            maxn = -long(math.pow(2, w-1))
             self._test_ser_deser(cls(maxp), cls())
             self._test_ser_deser(cls(maxn), cls())
             try:


### PR DESCRIPTION
The following list of changes has been integrated into `ros_comm` between 1.14.7 and 1.14.9 (Melodic) since the last Kinetic release (1.12.15).


**Backported in this PR:**

* Remove 'using namespace' from condition_variable.h (#2020)
  * Bug fix
* use fully qualified ceil() in condition_variable.h (#2025)
  * Bug fix
* fix lower bound of signed int (#1781)
  * Needed to pass CI since ros/genpy#102 has been released into Kinetic

**Not backported:**
* support Boost 1.66 (#2016)
  * Not necessary