### PR TITLE
Fix Lost Wake Bug in ROSOutAppender

### DIFF
--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -137,7 +137,10 @@ void ROSOutAppender::logThread()
         return;
       }
 
-      queue_condition_.wait(lock);
+      if (log_queue_.empty())
+      {
+        queue_condition_.wait(lock);
+      }
 
       if (shutting_down_)
       {


### PR DESCRIPTION
### Description

This fixes a bug in ROSOutAppender that consists of waiting on the condition variable `queue_condition_` without checking if the `log_queue_` is empty.

In this situation if the `log_queue_` had some messages that were inserted while `ROSOutAppender::logThread` was publishing other messages, the new messages in the queue won't be published until another message eventually is added.

Note that the `notify_all` sent in the destructor would not cause the unpublished messages to get published upon node termination.  This is because when the `queue_condition_`  is awaken by this notification, `shutting_down_` would be true and would cause `ROSOutAppender::logThread`  to return immediately.

### How to Reproduce

One way to reproduce is illustrated in the snippet below. Send a bunch a bunch of log messages right after each other. Running multiple times, in many instances the last few messages won't be received on rosout. With the fix, all the messages are received everytime. 

``` 
#include<ros/ros.h> 
#include <ros/topic_manager.h> 
#include <ros/publication.h> 
#include<chrono> 
#include<thread> 

int main(int argc, char** argv)  
{ 
  ros::init(argc, argv, "test"); 
  
  ros::NodeHandle n; 

  // Wait for rosout to subscribe 
  auto pub_ptr = ros::TopicManager::instance()->lookupPublication("/rosout"); 
  while (!pub_ptr->getNumSubscribers ()) 
  { 
    std::this_thread::yield(); 
  } 

  // Send a bunch of messages right after each other 
  const auto num_msgs = 10; 
  for (auto i = 0; i < num_msgs;)  
  { 
    ROS_INFO_STREAM("Message " << ++i << " of " << num_msgs); 
  } 

  // If another message is sent after a while, the missing messages will show up 
  /*using namespace std::chrono_literals; 
  std::this_thread::sleep_for(30s); 
  //Send another message to wake up the condition 
  ROS_INFO("Message after wait");*/ 

  ros::spin(); 
} 
```