### PR TITLE
[roscpp] Update boost::placeholders usage for boost 1.73 (and later)

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -281,7 +281,7 @@ namespace ros
 
      MyClass my_class;
      ros::Publisher pub = handle.advertise<std_msgs::Empty>("my_topic", 1, 
-                                                            boost::bind(&MyClass::connectCallback, my_class, _1));
+                                                            boost::bind(&MyClass::connectCallback, my_class, boost::placeholders::_1));
      \endverbatim
      *
    *
@@ -403,7 +403,7 @@ if (sub)  // Enter if subscriber is valid
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj, boost::placeholders::_1));
     ops.transport_hints = transport_hints;
     return subscribe(ops);
   }
@@ -414,7 +414,7 @@ if (sub)  // Enter if subscriber is valid
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj, boost::placeholders::_1));
     ops.transport_hints = transport_hints;
     return subscribe(ops);
   }
@@ -467,7 +467,7 @@ if (sub)  // Enter if subscriber is valid
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    ops.template init<M>(topic, queue_size, boost::bind(fp, obj, boost::placeholders::_1));
     ops.transport_hints = transport_hints;
     return subscribe(ops);
   }
@@ -477,7 +477,7 @@ if (sub)  // Enter if subscriber is valid
                        const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, boost::bind(fp, obj, _1));
+    ops.template init<M>(topic, queue_size, boost::bind(fp, obj, boost::placeholders::_1));
     ops.transport_hints = transport_hints;
     return subscribe(ops);
   }
@@ -530,7 +530,7 @@ if (sub)  // Enter if subscriber is valid
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
+    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj.get(), boost::placeholders::_1));
     ops.tracked_object = obj;
     ops.transport_hints = transport_hints;
     return subscribe(ops);
@@ -541,7 +541,7 @@ if (sub)  // Enter if subscriber is valid
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
-    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
+    ops.template initByFullCallbackType<M>(topic, queue_size, boost::bind(fp, obj.get(), boost::placeholders::_1));
     ops.tracked_object = obj;
     ops.transport_hints = transport_hints;
     return subscribe(ops);
@@ -596,7 +596,7 @@ if (sub)  // Enter if subscriber is valid
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
+    ops.template init<M>(topic, queue_size, boost::bind(fp, obj.get(), boost::placeholders::_1));
     ops.tracked_object = obj;
     ops.transport_hints = transport_hints;
     return subscribe(ops);
@@ -607,7 +607,7 @@ if (sub)  // Enter if subscriber is valid
                        const boost::shared_ptr<T>& obj, const TransportHints& transport_hints = TransportHints())
   {
     SubscribeOptions ops;
-    ops.template init<M>(topic, queue_size, boost::bind(fp, obj.get(), _1));
+    ops.template init<M>(topic, queue_size, boost::bind(fp, obj.get(), boost::placeholders::_1));
     ops.tracked_object = obj;
     ops.transport_hints = transport_hints;
     return subscribe(ops);
@@ -879,7 +879,7 @@ if (service)  // Enter if advertised service is valid
   ServiceServer advertiseService(const std::string& service, bool(T::*srv_func)(MReq &, MRes &), T *obj)
   {
     AdvertiseServiceOptions ops;
-    ops.template init<MReq, MRes>(service, boost::bind(srv_func, obj, _1, _2));
+    ops.template init<MReq, MRes>(service, boost::bind(srv_func, obj, boost::placeholders::_1, boost::placeholders::_2));
     return advertiseService(ops);
   }
 
@@ -924,7 +924,7 @@ if (service)  // Enter if advertised service is valid
   ServiceServer advertiseService(const std::string& service, bool(T::*srv_func)(ServiceEvent<MReq, MRes>&), T *obj)
   {
     AdvertiseServiceOptions ops;
-    ops.template initBySpecType<ServiceEvent<MReq, MRes> >(service, boost::bind(srv_func, obj, _1));
+    ops.template initBySpecType<ServiceEvent<MReq, MRes> >(service, boost::bind(srv_func, obj, boost::placeholders::_1));
     return advertiseService(ops);
   }
 
@@ -970,7 +970,7 @@ if (service)  // Enter if advertised service is valid
   ServiceServer advertiseService(const std::string& service, bool(T::*srv_func)(MReq &, MRes &), const boost::shared_ptr<T>& obj)
   {
     AdvertiseServiceOptions ops;
-    ops.template init<MReq, MRes>(service, boost::bind(srv_func, obj.get(), _1, _2));
+    ops.template init<MReq, MRes>(service, boost::bind(srv_func, obj.get(), boost::placeholders::_1, boost::placeholders::_2));
     ops.tracked_object = obj;
     return advertiseService(ops);
   }
@@ -1017,7 +1017,7 @@ if (service)  // Enter if advertised service is valid
   ServiceServer advertiseService(const std::string& service, bool(T::*srv_func)(ServiceEvent<MReq, MRes>&), const boost::shared_ptr<T>& obj)
   {
     AdvertiseServiceOptions ops;
-    ops.template initBySpecType<ServiceEvent<MReq, MRes> >(service, boost::bind(srv_func, obj.get(), _1));
+    ops.template initBySpecType<ServiceEvent<MReq, MRes> >(service, boost::bind(srv_func, obj.get(), boost::placeholders::_1));
     ops.tracked_object = obj;
     return advertiseService(ops);
   }
@@ -1313,7 +1313,7 @@ if (service)  // Enter if advertised service is valid
   Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&) const, T* obj, 
                     bool oneshot = false, bool autostart = true) const
   {
-    return createTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
+    return createTimer(period, boost::bind(callback, obj, boost::placeholders::_1), oneshot, autostart);
   }
 
   /**
@@ -1333,7 +1333,7 @@ if (service)  // Enter if advertised service is valid
   Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), T* obj, 
                     bool oneshot = false, bool autostart = true) const
   {
-    return createTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
+    return createTimer(period, boost::bind(callback, obj, boost::placeholders::_1), oneshot, autostart);
   }
 
   /**
@@ -1355,7 +1355,7 @@ if (service)  // Enter if advertised service is valid
   Timer createTimer(Duration period, void(T::*callback)(const TimerEvent&), const boost::shared_ptr<T>& obj, 
                     bool oneshot = false, bool autostart = true) const
   {
-    TimerOptions ops(period, boost::bind(callback, obj.get(), _1), 0);
+    TimerOptions ops(period, boost::bind(callback, obj.get(), boost::placeholders::_1), 0);
     ops.tracked_object = obj;
     ops.oneshot = oneshot;
     ops.autostart = autostart;
@@ -1410,7 +1410,7 @@ if (service)  // Enter if advertised service is valid
   WallTimer createWallTimer(WallDuration period, void(T::*callback)(const WallTimerEvent&), T* obj, 
                             bool oneshot = false, bool autostart = true) const
   {
-    return createWallTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
+    return createWallTimer(period, boost::bind(callback, obj, boost::placeholders::_1), oneshot, autostart);
   }
 
   /**
@@ -1433,7 +1433,7 @@ if (service)  // Enter if advertised service is valid
                             const boost::shared_ptr<T>& obj, 
                             bool oneshot = false, bool autostart = true) const
   {
-    WallTimerOptions ops(period, boost::bind(callback, obj.get(), _1), 0);
+    WallTimerOptions ops(period, boost::bind(callback, obj.get(), boost::placeholders::_1), 0);
     ops.tracked_object = obj;
     ops.oneshot = oneshot;
     ops.autostart = autostart;
@@ -1489,7 +1489,7 @@ if (service)  // Enter if advertised service is valid
   SteadyTimer createSteadyTimer(WallDuration period, void(T::*callback)(const SteadyTimerEvent&), T* obj,
                                 bool oneshot = false, bool autostart = true) const
   {
-    return createSteadyTimer(period, boost::bind(callback, obj, _1), oneshot, autostart);
+    return createSteadyTimer(period, boost::bind(callback, obj, boost::placeholders::_1), oneshot, autostart);
   }
 
   /**
@@ -1512,7 +1512,7 @@ if (service)  // Enter if advertised service is valid
                                 const boost::shared_ptr<T>& obj,
                                 bool oneshot = false, bool autostart = true) const
   {
-    SteadyTimerOptions ops(period, boost::bind(callback, obj.get(), _1), 0);
+    SteadyTimerOptions ops(period, boost::bind(callback, obj.get(), boost::placeholders::_1), 0);
     ops.tracked_object = obj;
     ops.oneshot = oneshot;
     ops.autostart = autostart;

--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -341,7 +341,7 @@ int32_t TimerManager<T, D, E>::add(const D& period, const boost::function<void(c
     {
       boost::mutex::scoped_lock lock(waiting_mutex_);
       waiting_.push_back(info->handle);
-      waiting_.sort(boost::bind(&TimerManager::waitingCompare, this, _1, _2));
+      waiting_.sort(boost::bind(&TimerManager::waitingCompare, this, boost::placeholders::_1, boost::placeholders::_2));
     }
 
     new_timer_ = true;
@@ -408,7 +408,7 @@ void TimerManager<T, D, E>::schedule(const TimerInfoPtr& info)
 
     waiting_.push_back(info->handle);
     // waitingCompare requires a lock on the timers_mutex_
-    waiting_.sort(boost::bind(&TimerManager::waitingCompare, this, _1, _2));
+    waiting_.sort(boost::bind(&TimerManager::waitingCompare, this, boost::placeholders::_1, boost::placeholders::_2));
   }
 
   new_timer_ = true;
@@ -482,7 +482,7 @@ void TimerManager<T, D, E>::setPeriod(int32_t handle, const D& period, bool rese
     // In this case, let next_expected be updated only in updateNext
     
     info->period = period;
-    waiting_.sort(boost::bind(&TimerManager::waitingCompare, this, _1, _2));
+    waiting_.sort(boost::bind(&TimerManager::waitingCompare, this, boost::placeholders::_1, boost::placeholders::_2));
   }
 
   new_timer_ = true;

--- a/clients/roscpp/include/ros/topic.h
+++ b/clients/roscpp/include/ros/topic.h
@@ -87,7 +87,7 @@ boost::shared_ptr<M const> waitForMessage(const std::string& topic, NodeHandle& 
 {
   SubscribeHelper<M> helper;
   SubscribeOptions ops;
-  ops.template init<M>(topic, 1, boost::bind(&SubscribeHelper<M>::callback, &helper, _1));
+  ops.template init<M>(topic, 1, boost::bind(&SubscribeHelper<M>::callback, &helper, boost::placeholders::_1));
 
   waitForMessageImpl(ops, boost::bind(&SubscribeHelper<M>::hasMessage, &helper), nh, timeout);
 

--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -74,13 +74,13 @@ void Connection::initialize(const TransportPtr& transport, bool is_server, const
   header_func_ = header_func;
   is_server_ = is_server;
 
-  transport_->setReadCallback(boost::bind(&Connection::onReadable, this, _1));
-  transport_->setWriteCallback(boost::bind(&Connection::onWriteable, this, _1));
-  transport_->setDisconnectCallback(boost::bind(&Connection::onDisconnect, this, _1));
+  transport_->setReadCallback(boost::bind(&Connection::onReadable, this, boost::placeholders::_1));
+  transport_->setWriteCallback(boost::bind(&Connection::onWriteable, this, boost::placeholders::_1));
+  transport_->setDisconnectCallback(boost::bind(&Connection::onDisconnect, this, boost::placeholders::_1));
 
   if (header_func)
   {
-    read(4, boost::bind(&Connection::onHeaderLengthRead, this, _1, _2, _3, _4));
+    read(4, boost::bind(&Connection::onHeaderLengthRead, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
   }
 }
 
@@ -368,7 +368,7 @@ void Connection::writeHeader(const M_string& key_vals, const WriteFinishedFunc& 
   memcpy(full_msg.get() + 4, buffer.get(), len);
   *((uint32_t*)full_msg.get()) = len;
 
-  write(full_msg, msg_len, boost::bind(&Connection::onHeaderWritten, this, _1), false);
+  write(full_msg, msg_len, boost::bind(&Connection::onHeaderWritten, this, boost::placeholders::_1), false);
 }
 
 void Connection::sendHeaderError(const std::string& error_msg)
@@ -376,7 +376,7 @@ void Connection::sendHeaderError(const std::string& error_msg)
   M_string m;
   m["error"] = error_msg;
 
-  writeHeader(m, boost::bind(&Connection::onErrorHeaderWritten, this, _1));
+  writeHeader(m, boost::bind(&Connection::onErrorHeaderWritten, this, boost::placeholders::_1));
   sending_header_error_ = true;
 }
 
@@ -400,7 +400,7 @@ void Connection::onHeaderLengthRead(const ConnectionPtr& conn, const boost::shar
     conn->drop(HeaderError);
   }
 
-  read(len, boost::bind(&Connection::onHeaderRead, this, _1, _2, _3, _4));
+  read(len, boost::bind(&Connection::onHeaderRead, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
 }
 
 void Connection::onHeaderRead(const ConnectionPtr& conn, const boost::shared_array<uint8_t>& buffer, uint32_t size, bool success)
@@ -455,7 +455,7 @@ void Connection::setHeaderReceivedCallback(const HeaderReceivedFunc& func)
   header_func_ = func;
 
   if (transport_->requiresHeader())
-    read(4, boost::bind(&Connection::onHeaderLengthRead, this, _1, _2, _3, _4));
+    read(4, boost::bind(&Connection::onHeaderLengthRead, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
 }
 
 std::string Connection::getCallerId()

--- a/clients/roscpp/src/libros/connection_manager.cpp
+++ b/clients/roscpp/src/libros/connection_manager.cpp
@@ -66,7 +66,7 @@ void ConnectionManager::start()
   tcpserver_transport_ = boost::make_shared<TransportTCP>(&poll_manager_->getPollSet());
   if (!tcpserver_transport_->listen(network::getTCPROSPort(), 
 				    MAX_TCPROS_CONN_QUEUE, 
-				    boost::bind(&ConnectionManager::tcprosAcceptConnection, this, _1)))
+				    boost::bind(&ConnectionManager::tcprosAcceptConnection, this, boost::placeholders::_1)))
   {
     ROS_FATAL("Listen on port [%d] failed", network::getTCPROSPort());
     ROS_BREAK();
@@ -142,7 +142,7 @@ void ConnectionManager::addConnection(const ConnectionPtr& conn)
   boost::mutex::scoped_lock lock(connections_mutex_);
 
   connections_.insert(conn);
-  conn->addDropListener(boost::bind(&ConnectionManager::onConnectionDropped, this, _1));
+  conn->addDropListener(boost::bind(&ConnectionManager::onConnectionDropped, this, boost::placeholders::_1));
 }
 
 void ConnectionManager::onConnectionDropped(const ConnectionPtr& conn)
@@ -190,7 +190,7 @@ void ConnectionManager::tcprosAcceptConnection(const TransportTCPPtr& transport)
   ConnectionPtr conn(boost::make_shared<Connection>());
   addConnection(conn);
 
-  conn->initialize(transport, true, boost::bind(&ConnectionManager::onConnectionHeaderReceived, this, _1, _2));
+  conn->initialize(transport, true, boost::bind(&ConnectionManager::onConnectionHeaderReceived, this, boost::placeholders::_1, boost::placeholders::_2));
 }
 
 bool ConnectionManager::onConnectionHeaderReceived(const ConnectionPtr& conn, const Header& header)

--- a/clients/roscpp/src/libros/poll_set.cpp
+++ b/clients/roscpp/src/libros/poll_set.cpp
@@ -53,7 +53,7 @@ PollSet::PollSet()
         ROS_FATAL("create_signal_pair() failed");
     ROS_BREAK();
   }
-  addSocket(signal_pipe_[0], boost::bind(&PollSet::onLocalPipeEvents, this, _1));
+  addSocket(signal_pipe_[0], boost::bind(&PollSet::onLocalPipeEvents, this, boost::placeholders::_1));
   addEvents(signal_pipe_[0], POLLIN);
 }
 

--- a/clients/roscpp/src/libros/service_client_link.cpp
+++ b/clients/roscpp/src/libros/service_client_link.cpp
@@ -69,7 +69,7 @@ ServiceClientLink::~ServiceClientLink()
 bool ServiceClientLink::initialize(const ConnectionPtr& connection)
 {
   connection_ = connection;
-  dropped_conn_ = connection_->addDropListener(boost::bind(&ServiceClientLink::onConnectionDropped, this, _1));
+  dropped_conn_ = connection_->addDropListener(boost::bind(&ServiceClientLink::onConnectionDropped, this, boost::placeholders::_1));
 
   return true;
 }
@@ -152,7 +152,7 @@ bool ServiceClientLink::handleHeader(const Header& header)
     m["type"] = ss->getDataType();
     m["md5sum"] = ss->getMD5Sum();
     m["callerid"] = this_node::getName();
-    connection_->writeHeader(m, boost::bind(&ServiceClientLink::onHeaderWritten, this, _1));
+    connection_->writeHeader(m, boost::bind(&ServiceClientLink::onHeaderWritten, this, boost::placeholders::_1));
 
     ss->addServiceClientLink(shared_from_this());
   }
@@ -174,7 +174,7 @@ void ServiceClientLink::onConnectionDropped(const ConnectionPtr& conn)
 void ServiceClientLink::onHeaderWritten(const ConnectionPtr& conn)
 {
   (void)conn;
-  connection_->read(4, boost::bind(&ServiceClientLink::onRequestLength, this, _1, _2, _3, _4));
+  connection_->read(4, boost::bind(&ServiceClientLink::onRequestLength, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
 }
 
 void ServiceClientLink::onRequestLength(const ConnectionPtr& conn, const boost::shared_array<uint8_t>& buffer, uint32_t size, bool success)
@@ -198,7 +198,7 @@ void ServiceClientLink::onRequestLength(const ConnectionPtr& conn, const boost::
     return;
   }
 
-  connection_->read(len, boost::bind(&ServiceClientLink::onRequest, this, _1, _2, _3, _4));
+  connection_->read(len, boost::bind(&ServiceClientLink::onRequest, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
 }
 
 void ServiceClientLink::onRequest(const ConnectionPtr& conn, const boost::shared_array<uint8_t>& buffer, uint32_t size, bool success)
@@ -226,7 +226,7 @@ void ServiceClientLink::onResponseWritten(const ConnectionPtr& conn)
 
   if (persistent_)
   {
-    connection_->read(4, boost::bind(&ServiceClientLink::onRequestLength, this, _1, _2, _3, _4));
+    connection_->read(4, boost::bind(&ServiceClientLink::onRequestLength, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
   }
   else
   {
@@ -237,7 +237,7 @@ void ServiceClientLink::onResponseWritten(const ConnectionPtr& conn)
 void ServiceClientLink::processResponse(bool ok, const SerializedMessage& res)
 {
   (void)ok;
-  connection_->write(res.buf, res.num_bytes, boost::bind(&ServiceClientLink::onResponseWritten, this, _1));
+  connection_->write(res.buf, res.num_bytes, boost::bind(&ServiceClientLink::onResponseWritten, this, boost::placeholders::_1));
 }
 
 

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -114,8 +114,8 @@ void ServiceServerLink::clearCalls()
 bool ServiceServerLink::initialize(const ConnectionPtr& connection)
 {
   connection_ = connection;
-  connection_->addDropListener(boost::bind(&ServiceServerLink::onConnectionDropped, this, _1));
-  connection_->setHeaderReceivedCallback(boost::bind(&ServiceServerLink::onHeaderReceived, this, _1, _2));
+  connection_->addDropListener(boost::bind(&ServiceServerLink::onConnectionDropped, this, boost::placeholders::_1));
+  connection_->setHeaderReceivedCallback(boost::bind(&ServiceServerLink::onHeaderReceived, this, boost::placeholders::_1, boost::placeholders::_2));
 
   M_string header;
   header["service"] = service_name_;
@@ -124,7 +124,7 @@ bool ServiceServerLink::initialize(const ConnectionPtr& connection)
   header["persistent"] = persistent_ ? "1" : "0";
   header.insert(extra_outgoing_header_values_.begin(), extra_outgoing_header_values_.end());
 
-  connection_->writeHeader(header, boost::bind(&ServiceServerLink::onHeaderWritten, this, _1));
+  connection_->writeHeader(header, boost::bind(&ServiceServerLink::onHeaderWritten, this, boost::placeholders::_1));
 
   return true;
 }
@@ -181,7 +181,7 @@ void ServiceServerLink::onRequestWritten(const ConnectionPtr& conn)
 {
   (void)conn;
   //ros::WallDuration(0.1).sleep();
-  connection_->read(5, boost::bind(&ServiceServerLink::onResponseOkAndLength, this, _1, _2, _3, _4));
+  connection_->read(5, boost::bind(&ServiceServerLink::onResponseOkAndLength, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
 }
 
 void ServiceServerLink::onResponseOkAndLength(const ConnectionPtr& conn, const boost::shared_array<uint8_t>& buffer, uint32_t size, bool success)
@@ -218,7 +218,7 @@ void ServiceServerLink::onResponseOkAndLength(const ConnectionPtr& conn, const b
 
   if (len > 0)
   {
-    connection_->read(len, boost::bind(&ServiceServerLink::onResponse, this, _1, _2, _3, _4));
+    connection_->read(len, boost::bind(&ServiceServerLink::onResponse, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
   }
   else
   {
@@ -322,7 +322,7 @@ void ServiceServerLink::processNextCall()
       request = current_call_->req_;
     }
 
-    connection_->write(request.buf, request.num_bytes, boost::bind(&ServiceServerLink::onRequestWritten, this, _1));
+    connection_->write(request.buf, request.num_bytes, boost::bind(&ServiceServerLink::onRequestWritten, this, boost::placeholders::_1));
   }
 }
 

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -78,12 +78,12 @@ void TopicManager::start()
   connection_manager_ = ConnectionManager::instance();
   xmlrpc_manager_ = XMLRPCManager::instance();
 
-  xmlrpc_manager_->bind("publisherUpdate", boost::bind(&TopicManager::pubUpdateCallback, this, _1, _2));
-  xmlrpc_manager_->bind("requestTopic", boost::bind(&TopicManager::requestTopicCallback, this, _1, _2));
-  xmlrpc_manager_->bind("getBusStats", boost::bind(&TopicManager::getBusStatsCallback, this, _1, _2));
-  xmlrpc_manager_->bind("getBusInfo", boost::bind(&TopicManager::getBusInfoCallback, this, _1, _2));
-  xmlrpc_manager_->bind("getSubscriptions", boost::bind(&TopicManager::getSubscriptionsCallback, this, _1, _2));
-  xmlrpc_manager_->bind("getPublications", boost::bind(&TopicManager::getPublicationsCallback, this, _1, _2));
+  xmlrpc_manager_->bind("publisherUpdate", boost::bind(&TopicManager::pubUpdateCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+  xmlrpc_manager_->bind("requestTopic", boost::bind(&TopicManager::requestTopicCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+  xmlrpc_manager_->bind("getBusStats", boost::bind(&TopicManager::getBusStatsCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+  xmlrpc_manager_->bind("getBusInfo", boost::bind(&TopicManager::getBusInfoCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+  xmlrpc_manager_->bind("getSubscriptions", boost::bind(&TopicManager::getSubscriptionsCallback, this, boost::placeholders::_1, boost::placeholders::_2));
+  xmlrpc_manager_->bind("getPublications", boost::bind(&TopicManager::getPublicationsCallback, this, boost::placeholders::_1, boost::placeholders::_2));
 
   poll_manager_->addPollThreadListener(boost::bind(&TopicManager::processPublishQueues, this));
 }

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -140,7 +140,7 @@ bool TransportTCP::initializeSocket()
   if (poll_set_)
   {
     ROS_DEBUG("Adding tcp socket [%d] to pollset", sock_);
-    poll_set_->addSocket(sock_, boost::bind(&TransportTCP::socketUpdate, this, _1), shared_from_this());
+    poll_set_->addSocket(sock_, boost::bind(&TransportTCP::socketUpdate, this, boost::placeholders::_1), shared_from_this());
 #if defined(POLLRDHUP) // POLLRDHUP is not part of POSIX!
     // This is needed to detect dead connections. #1704
     poll_set_->addEvents(sock_, POLLRDHUP);

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -298,7 +298,7 @@ bool TransportUDP::initializeSocket()
   ROS_ASSERT(poll_set_ || (flags_ & SYNCHRONOUS));
   if (poll_set_)
   {
-    poll_set_->addSocket(sock_, boost::bind(&TransportUDP::socketUpdate, this, _1), shared_from_this());
+    poll_set_->addSocket(sock_, boost::bind(&TransportUDP::socketUpdate, this, boost::placeholders::_1), shared_from_this());
   }
 
   return true;

--- a/clients/roscpp/src/libros/transport_publisher_link.cpp
+++ b/clients/roscpp/src/libros/transport_publisher_link.cpp
@@ -82,11 +82,11 @@ bool TransportPublisherLink::initialize(const ConnectionPtr& connection)
   // and disconnect when this class' reference count is decremented to 0. It increments
   // then decrements the shared_from_this reference count around calls to the
   // onConnectionDropped function, preventing a coredump in the middle of execution.
-  connection_->addDropListener(Connection::DropSignal::slot_type(&TransportPublisherLink::onConnectionDropped, this, _1, _2).track(shared_from_this()));
+  connection_->addDropListener(Connection::DropSignal::slot_type(&TransportPublisherLink::onConnectionDropped, this, boost::placeholders::_1, boost::placeholders::_2).track(shared_from_this()));
 
   if (connection_->getTransport()->requiresHeader())
   {
-    connection_->setHeaderReceivedCallback(boost::bind(&TransportPublisherLink::onHeaderReceived, this, _1, _2));
+    connection_->setHeaderReceivedCallback(boost::bind(&TransportPublisherLink::onHeaderReceived, this, boost::placeholders::_1, boost::placeholders::_2));
 
     SubscriptionPtr parent = parent_.lock();
     if (!parent)
@@ -100,11 +100,11 @@ bool TransportPublisherLink::initialize(const ConnectionPtr& connection)
     header["callerid"] = this_node::getName();
     header["type"] = parent->datatype();
     header["tcp_nodelay"] = transport_hints_.getTCPNoDelay() ? "1" : "0";
-    connection_->writeHeader(header, boost::bind(&TransportPublisherLink::onHeaderWritten, this, _1));
+    connection_->writeHeader(header, boost::bind(&TransportPublisherLink::onHeaderWritten, this, boost::placeholders::_1));
   }
   else
   {
-    connection_->read(4, boost::bind(&TransportPublisherLink::onMessageLength, this, _1, _2, _3, _4));
+    connection_->read(4, boost::bind(&TransportPublisherLink::onMessageLength, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
   }
 
   return true;
@@ -144,7 +144,7 @@ bool TransportPublisherLink::onHeaderReceived(const ConnectionPtr& conn, const H
     retry_timer_handle_ = -1;
   }
 
-  connection_->read(4, boost::bind(&TransportPublisherLink::onMessageLength, this, _1, _2, _3, _4));
+  connection_->read(4, boost::bind(&TransportPublisherLink::onMessageLength, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
 
   return true;
 }
@@ -162,7 +162,7 @@ void TransportPublisherLink::onMessageLength(const ConnectionPtr& conn, const bo
   if (!success)
   {
     if (connection_)
-      connection_->read(4, boost::bind(&TransportPublisherLink::onMessageLength, this, _1, _2, _3, _4));
+      connection_->read(4, boost::bind(&TransportPublisherLink::onMessageLength, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
     return;
   }
 
@@ -181,7 +181,7 @@ void TransportPublisherLink::onMessageLength(const ConnectionPtr& conn, const bo
     return;
   }
 
-  connection_->read(len, boost::bind(&TransportPublisherLink::onMessage, this, _1, _2, _3, _4));
+  connection_->read(len, boost::bind(&TransportPublisherLink::onMessage, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
 }
 
 void TransportPublisherLink::onMessage(const ConnectionPtr& conn, const boost::shared_array<uint8_t>& buffer, uint32_t size, bool success)
@@ -198,7 +198,7 @@ void TransportPublisherLink::onMessage(const ConnectionPtr& conn, const boost::s
 
   if (success || !connection_->getTransport()->requiresHeader())
   {
-    connection_->read(4, boost::bind(&TransportPublisherLink::onMessageLength, this, _1, _2, _3, _4));
+    connection_->read(4, boost::bind(&TransportPublisherLink::onMessageLength, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
   }
 }
 
@@ -282,7 +282,7 @@ void TransportPublisherLink::onConnectionDropped(const ConnectionPtr& conn, Conn
       // shared_from_this() shared_ptr is used to ensure TransportPublisherLink is not
       // destroyed in the middle of onRetryTimer execution
       retry_timer_handle_ = getInternalTimerManager()->add(WallDuration(retry_period_),
-          boost::bind(&TransportPublisherLink::onRetryTimer, this, _1), getInternalCallbackQueue().get(),
+          boost::bind(&TransportPublisherLink::onRetryTimer, this, boost::placeholders::_1), getInternalCallbackQueue().get(),
           shared_from_this(), false);
     }
     else

--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -57,7 +57,7 @@ TransportSubscriberLink::~TransportSubscriberLink()
 bool TransportSubscriberLink::initialize(const ConnectionPtr& connection)
 {
   connection_ = connection;
-  dropped_conn_ = connection_->addDropListener(boost::bind(&TransportSubscriberLink::onConnectionDropped, this, _1));
+  dropped_conn_ = connection_->addDropListener(boost::bind(&TransportSubscriberLink::onConnectionDropped, this, boost::placeholders::_1));
 
   return true;
 }
@@ -112,7 +112,7 @@ bool TransportSubscriberLink::handleHeader(const Header& header)
   m["callerid"] = this_node::getName();
   m["latching"] = pt->isLatching() ? "1" : "0";
   m["topic"] = topic_;
-  connection_->writeHeader(m, boost::bind(&TransportSubscriberLink::onHeaderWritten, this, _1));
+  connection_->writeHeader(m, boost::bind(&TransportSubscriberLink::onHeaderWritten, this, boost::placeholders::_1));
 
   pt->addSubscriberLink(shared_from_this());
 
@@ -170,7 +170,7 @@ void TransportSubscriberLink::startMessageWrite(bool immediate_write)
 
   if (m.num_bytes > 0)
   {
-    connection_->write(m.buf, m.num_bytes, boost::bind(&TransportSubscriberLink::onMessageWritten, this, _1), immediate_write);
+    connection_->write(m.buf, m.num_bytes, boost::bind(&TransportSubscriberLink::onMessageWritten, this, boost::placeholders::_1), immediate_write);
   }
 }
 

--- a/test/test_rosbag_storage/src/bag_player.cpp
+++ b/test/test_rosbag_storage/src/bag_player.cpp
@@ -147,7 +147,7 @@ TEST_F(BagPlayerTest, bag_player_message_instance)
 TEST_F(BagPlayerTest, bag_player_message_class)
 {
   rosbag::BagPlayer player(bag_filename);
-  player.register_callback<std_msgs::UInt64>(topic, boost::bind(&BagPlayerTest::callbackMessage, this, _1));
+  player.register_callback<std_msgs::UInt64>(topic, boost::bind(&BagPlayerTest::callbackMessage, this, boost::placeholders::_1));
   player.start_play();
 
   EXPECT_EQ(bag_messages, num_messages);
@@ -158,7 +158,7 @@ TEST_F(BagPlayerTest, bag_player_message_instance_class)
 {
   rosbag::BagPlayer player(bag_filename);
   player.register_callback<rosbag::MessageInstance>(topic,
-                                                    boost::bind(&BagPlayerTest::callbackMessageInstance, this, _1));
+                                                    boost::bind(&BagPlayerTest::callbackMessageInstance, this, boost::placeholders::_1));
   player.start_play();
 
   EXPECT_EQ(bag_messages, num_messages);

--- a/test/test_roscpp/perf/src/intra.cpp
+++ b/test/test_roscpp/perf/src/intra.cpp
@@ -424,7 +424,7 @@ void LatencyTest::sendThread(boost::barrier* all_connected, uint32_t thread_inde
     pubs.push_back(nh.advertise<test_roscpp::LatencyMessage>(ss.str(), 0));
 
     ss << "_return";
-    subs.push_back(nh.subscribe<test_roscpp::LatencyMessage>(ss.str(), 0, boost::bind(&LatencyTest::sendCallback, this, _1, boost::ref(pubs[i]), thread_index), ros::VoidConstPtr(), ros::TransportHints().tcpNoDelay()));
+    subs.push_back(nh.subscribe<test_roscpp::LatencyMessage>(ss.str(), 0, boost::bind(&LatencyTest::sendCallback, this, boost::placeholders::_1, boost::ref(pubs[i]), thread_index), ros::VoidConstPtr(), ros::TransportHints().tcpNoDelay()));
   }
 
   bool cont = true;
@@ -493,7 +493,7 @@ LatencyResult LatencyTest::run()
     ss << "_return";
     std::string pub_topic = ss.str();
     pubs.push_back(nh.advertise<test_roscpp::LatencyMessage>(pub_topic, 0));
-    subs.push_back(nh.subscribe<test_roscpp::LatencyMessage>(sub_topic, 0, boost::bind(&LatencyTest::receiveCallback, this, _1, boost::ref(pubs.back())), ros::VoidConstPtr(), ros::TransportHints().tcpNoDelay()));
+    subs.push_back(nh.subscribe<test_roscpp::LatencyMessage>(sub_topic, 0, boost::bind(&LatencyTest::receiveCallback, this, boost::placeholders::_1, boost::ref(pubs.back())), ros::VoidConstPtr(), ros::TransportHints().tcpNoDelay()));
   }
 
   boost::barrier all_connected(1 + sender_threads_);
@@ -655,9 +655,9 @@ STLatencyResult STLatencyTest::run()
   nh.setCallbackQueue(&receive_queue_);
 
   ros::Publisher recv_pub = nh.advertise<test_roscpp::LatencyMessage>("stlatency_perf_test_return", 0);
-  ros::Subscriber recv_sub = nh.subscribe<test_roscpp::LatencyMessage>("stlatency_perf_test", 0, boost::bind(&STLatencyTest::receiveCallback, this, _1, boost::ref(recv_pub)), ros::VoidConstPtr(), ros::TransportHints().tcpNoDelay());
+  ros::Subscriber recv_sub = nh.subscribe<test_roscpp::LatencyMessage>("stlatency_perf_test", 0, boost::bind(&STLatencyTest::receiveCallback, this, boost::placeholders::_1, boost::ref(recv_pub)), ros::VoidConstPtr(), ros::TransportHints().tcpNoDelay());
   ros::Publisher send_pub = nh.advertise<test_roscpp::LatencyMessage>("stlatency_perf_test", 0);
-  ros::Subscriber send_sub = nh.subscribe<test_roscpp::LatencyMessage>("stlatency_perf_test_return", 0, boost::bind(&STLatencyTest::sendCallback, this, _1, boost::ref(send_pub)), ros::VoidConstPtr(), ros::TransportHints().tcpNoDelay());
+  ros::Subscriber send_sub = nh.subscribe<test_roscpp::LatencyMessage>("stlatency_perf_test_return", 0, boost::bind(&STLatencyTest::sendCallback, this, boost::placeholders::_1, boost::ref(send_pub)), ros::VoidConstPtr(), ros::TransportHints().tcpNoDelay());
 
   ROS_INFO("Waiting for all connections to establish");
 

--- a/test/test_roscpp/test/src/multiple_subscriptions.cpp
+++ b/test/test_roscpp/test/src/multiple_subscriptions.cpp
@@ -80,10 +80,10 @@ class Subscriptions : public testing::Test
       ROS_INFO("Subscribing %d", cb_num);
       boost::function<void(const test_roscpp::TestArrayConstPtr&)> funcs[4] =
       {
-        boost::bind(&Subscriptions::cb0, this, _1),
-        boost::bind(&Subscriptions::cb1, this, _1),
-        boost::bind(&Subscriptions::cb2, this, _1),
-        boost::bind(&Subscriptions::cb3, this, _1),
+        boost::bind(&Subscriptions::cb0, this, boost::placeholders::_1),
+        boost::bind(&Subscriptions::cb1, this, boost::placeholders::_1),
+        boost::bind(&Subscriptions::cb2, this, boost::placeholders::_1),
+        boost::bind(&Subscriptions::cb3, this, boost::placeholders::_1),
       };
 
       subs_[cb_num] = nh_.subscribe("roscpp/pubsub_test", 10, funcs[cb_num]);

--- a/test/test_roscpp/test/src/pub_sub.cpp
+++ b/test/test_roscpp/test/src/pub_sub.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv)
   ros::NodeHandle nh;
 
   ros::Publisher pub = nh.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", 1);
-  ros::Subscriber sub = nh.subscribe<test_roscpp::TestArray>("roscpp/subpub_test", 1, boost::bind(messageCallback, _1, pub));
+  ros::Subscriber sub = nh.subscribe<test_roscpp::TestArray>("roscpp/subpub_test", 1, boost::bind(messageCallback, boost::placeholders::_1, pub));
 
   ros::spin();
 }

--- a/test/test_roscpp/test/src/publish_empty.cpp
+++ b/test/test_roscpp/test/src/publish_empty.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv)
 
   ros::NodeHandle nh;
   ros::Publisher pub;
-  pub = nh.advertise<test_roscpp::TestEmpty>("roscpp/pubsub_test", g_msg_count, boost::bind(subscriberCallback, _1, boost::ref(pub)));
+  pub = nh.advertise<test_roscpp::TestEmpty>("roscpp/pubsub_test", g_msg_count, boost::bind(subscriberCallback, boost::placeholders::_1, boost::ref(pub)));
 
   ros::spin();
 }

--- a/test/test_roscpp/test/src/publish_n_fast.cpp
+++ b/test/test_roscpp/test/src/publish_n_fast.cpp
@@ -73,7 +73,7 @@ main(int argc, char** argv)
   int min_size = atoi(argv[2]);
   int max_size = atoi(argv[3]);
 
-  ros::Publisher pub_ = n.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", msg_count, boost::bind(&connectCallback, _1, msg_count, min_size, max_size));
+  ros::Publisher pub_ = n.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", msg_count, boost::bind(&connectCallback, boost::placeholders::_1, msg_count, min_size, max_size));
   ros::spin();
 
   return 0;

--- a/test/test_roscpp/test/src/publish_onsub.cpp
+++ b/test/test_roscpp/test/src/publish_onsub.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv)
   g_msg_count = atoi(argv[1]);
 
   ros::NodeHandle nh;
-  ros::Publisher pub = nh.advertise<test_roscpp::TestEmpty>("roscpp/pubsub_test", g_msg_count, boost::bind(subscriberCallback, _1));
+  ros::Publisher pub = nh.advertise<test_roscpp::TestEmpty>("roscpp/pubsub_test", g_msg_count, boost::bind(subscriberCallback, boost::placeholders::_1));
 
   ros::spin();
 }

--- a/test/test_roscpp/test/src/publish_unadvertise.cpp
+++ b/test/test_roscpp/test/src/publish_unadvertise.cpp
@@ -63,7 +63,7 @@ public:
 
   bool adv()
   {
-    pub_ = nh_.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", 1, boost::bind(&Publications::subscriberCallback, this, _1));
+    pub_ = nh_.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", 1, boost::bind(&Publications::subscriberCallback, this, boost::placeholders::_1));
     return pub_;
   }
 

--- a/test/test_roscpp/test/src/service_adv.cpp
+++ b/test/test_roscpp/test/src/service_adv.cpp
@@ -83,7 +83,7 @@ main(int argc, char** argv)
   ros::ServiceServer srv1, srv2, srv3;
   srv1 = nh.advertiseService("service_adv", caseFlip);
   srv2 = nh.advertiseService("service_adv_long", caseFlipLongRunning);
-  srv3 = nh.advertiseService<test_roscpp::TestStringString::Request, test_roscpp::TestStringString::Response>("service_adv_unadv_in_callback", boost::bind(caseFlipUnadvertise, _1, _2, boost::ref(srv3)));
+  srv3 = nh.advertiseService<test_roscpp::TestStringString::Request, test_roscpp::TestStringString::Response>("service_adv_unadv_in_callback", boost::bind(caseFlipUnadvertise, boost::placeholders::_1, boost::placeholders::_2, boost::ref(srv3)));
   ros::spin();
 }
 

--- a/test/test_roscpp/test/src/service_callback_types.cpp
+++ b/test/test_roscpp/test/src/service_callback_types.cpp
@@ -82,12 +82,12 @@ TEST(ServiceCallbackTypes, compile)
   std::vector<ros::ServiceServer> srvs;
   srvs.push_back(n.advertiseService("add_two_ints", add));
   srvs.push_back(n.advertiseService("add_two_ints2", add2));
-  srvs.push_back(n.advertiseService<ros::ServiceEvent<test_roscpp::TestStringString::Request, test_roscpp::TestStringString::Response> >("add_two_ints3", boost::bind(add3, _1, std::string("blah"))));
+  srvs.push_back(n.advertiseService<ros::ServiceEvent<test_roscpp::TestStringString::Request, test_roscpp::TestStringString::Response> >("add_two_ints3", boost::bind(add3, boost::placeholders::_1, std::string("blah"))));
 
   A a;
   srvs.push_back(n.advertiseService("add_two_ints10", &A::add, &a));
   srvs.push_back(n.advertiseService("add_two_ints11", &A::add2, &a));
-  srvs.push_back(n.advertiseService<ros::ServiceEvent<test_roscpp::TestStringString::Request, test_roscpp::TestStringString::Response> >("add_two_ints12", boost::bind(&A::add3, &a, _1, std::string("blah"))));
+  srvs.push_back(n.advertiseService<ros::ServiceEvent<test_roscpp::TestStringString::Request, test_roscpp::TestStringString::Response> >("add_two_ints12", boost::bind(&A::add3, &a, boost::placeholders::_1, std::string("blah"))));
 }
 
 int main(int argc, char **argv)

--- a/test/test_roscpp/test/src/sub_pub.cpp
+++ b/test/test_roscpp/test/src/sub_pub.cpp
@@ -111,7 +111,7 @@ TEST_F(Subscriptions, subPub)
   ros::NodeHandle nh;
   ros::Subscriber sub = nh.subscribe("roscpp/pubsub_test", 0, &Subscriptions::messageCallback, (Subscriptions*)this);
   ASSERT_TRUE(sub);
-  pub_ = nh.advertise<test_roscpp::TestArray>("roscpp/subpub_test", 0, boost::bind(&Subscriptions::subscriberCallback, this, _1));
+  pub_ = nh.advertise<test_roscpp::TestArray>("roscpp/subpub_test", 0, boost::bind(&Subscriptions::subscriberCallback, this, boost::placeholders::_1));
   ASSERT_TRUE(pub_);
   ros::Time t1(ros::Time::now()+g_dt);
 

--- a/test/test_roscpp/test/src/subscribe_self.cpp
+++ b/test/test_roscpp/test/src/subscribe_self.cpp
@@ -91,7 +91,7 @@ TEST(SelfSubscribe, advSub)
 
   {
     ros::Publisher pub;
-    pub = nh.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", g_msg_count, boost::bind(subscriberCallback, _1, boost::ref(pub)));
+    pub = nh.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", g_msg_count, boost::bind(subscriberCallback, boost::placeholders::_1, boost::ref(pub)));
     ASSERT_TRUE(pub);
     ros::Subscriber sub = nh.subscribe("roscpp/pubsub_test", g_msg_count, messageCallback);
     ASSERT_TRUE(sub);
@@ -115,7 +115,7 @@ TEST(SelfSubscribe, advSub)
     ros::Subscriber sub = nh.subscribe("roscpp/pubsub_test", g_msg_count, messageCallback);
     ASSERT_TRUE(sub);
     ros::Publisher pub;
-    pub = nh.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", g_msg_count, boost::bind(subscriberCallback, _1, boost::ref(pub)));
+    pub = nh.advertise<test_roscpp::TestArray>("roscpp/pubsub_test", g_msg_count, boost::bind(subscriberCallback, boost::placeholders::_1, boost::ref(pub)));
     ASSERT_TRUE(pub);
 
     ros::Time t1(ros::Time::now()+g_dt);

--- a/test/test_roscpp/test/src/subscription_callback_types.cpp
+++ b/test/test_roscpp/test/src/subscription_callback_types.cpp
@@ -167,8 +167,8 @@ TEST(SubscriptionCallbackTypes, compile)
   subs.push_back(n.subscribe("chatter", 1000, &A::chatterCallback4, &a));
   subs.push_back(n.subscribe("chatter", 1000, &A::chatterCallback5, &a));
 
-  subs.push_back(n.subscribe<std_msgs::String>("chatter", 1000, boost::bind(&A::chatterCallback6, &a, _1, std::string("hello"))));
-  subs.push_back(n.subscribe<std_msgs::String, const std_msgs::String&>("chatter", 1000, boost::bind(&A::chatterCallback7, &a, _1, std::string("hello2"))));
+  subs.push_back(n.subscribe<std_msgs::String>("chatter", 1000, boost::bind(&A::chatterCallback6, &a, boost::placeholders::_1, std::string("hello"))));
+  subs.push_back(n.subscribe<std_msgs::String, const std_msgs::String&>("chatter", 1000, boost::bind(&A::chatterCallback7, &a, boost::placeholders::_1, std::string("hello2"))));
 
 
   subs.push_back(n.subscribe("chatter", 1000, &A::chatterCallback8, &a));

--- a/test/test_roscpp/test/test_poll_set.cpp
+++ b/test/test_roscpp/test/test_poll_set.cpp
@@ -261,7 +261,7 @@ public:
 TEST_F(Poller, read)
 {
   SocketHelper sh(sockets_[0]);
-  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, boost::bind(&SocketHelper::processEvents, &sh, _1)));
+  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, boost::bind(&SocketHelper::processEvents, &sh, boost::placeholders::_1)));
 
   char b = 0;
 
@@ -295,7 +295,7 @@ TEST_F(Poller, read)
 TEST_F(Poller, write)
 {
   SocketHelper sh(sockets_[0]);
-  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, boost::bind(&SocketHelper::processEvents, &sh, _1)));
+  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, boost::bind(&SocketHelper::processEvents, &sh, boost::placeholders::_1)));
   ASSERT_TRUE(poll_set_.addEvents(sh.socket_, POLLOUT));
 
   poll_set_.update(1);
@@ -313,8 +313,8 @@ TEST_F(Poller, readAndWrite)
 {
   SocketHelper sh1(sockets_[0]);
   SocketHelper sh2(sockets_[1]);
-  ASSERT_TRUE(poll_set_.addSocket(sh1.socket_, boost::bind(&SocketHelper::processEvents, &sh1, _1)));
-  ASSERT_TRUE(poll_set_.addSocket(sh2.socket_, boost::bind(&SocketHelper::processEvents, &sh2, _1)));
+  ASSERT_TRUE(poll_set_.addSocket(sh1.socket_, boost::bind(&SocketHelper::processEvents, &sh1, boost::placeholders::_1)));
+  ASSERT_TRUE(poll_set_.addSocket(sh2.socket_, boost::bind(&SocketHelper::processEvents, &sh2, boost::placeholders::_1)));
 
   ASSERT_TRUE(poll_set_.addEvents(sh1.socket_, POLLIN));
   ASSERT_TRUE(poll_set_.addEvents(sh2.socket_, POLLIN));
@@ -350,8 +350,8 @@ TEST_F(Poller, readAndWrite)
 TEST_F(Poller, multiAddDel)
 {
   SocketHelper sh(sockets_[0]);
-  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, boost::bind(&SocketHelper::processEvents, &sh, _1)));
-  ASSERT_FALSE(poll_set_.addSocket(sh.socket_, boost::bind(&SocketHelper::processEvents, &sh, _1)));
+  ASSERT_TRUE(poll_set_.addSocket(sh.socket_, boost::bind(&SocketHelper::processEvents, &sh, boost::placeholders::_1)));
+  ASSERT_FALSE(poll_set_.addSocket(sh.socket_, boost::bind(&SocketHelper::processEvents, &sh, boost::placeholders::_1)));
 
   ASSERT_TRUE(poll_set_.addEvents(sh.socket_, 0));
   ASSERT_FALSE(poll_set_.addEvents(sh.socket_ + 1, 0));
@@ -367,7 +367,7 @@ void addThread(PollSet* ps, SocketHelper* sh, boost::barrier* barrier)
 {
   barrier->wait();
 
-  ps->addSocket(sh->socket_, boost::bind(&SocketHelper::processEvents, sh, _1));
+  ps->addSocket(sh->socket_, boost::bind(&SocketHelper::processEvents, sh, boost::placeholders::_1));
   ps->addEvents(sh->socket_, POLLIN);
   ps->addEvents(sh->socket_, POLLOUT);
 }
@@ -460,11 +460,11 @@ void addDelManyTimesThread(PollSet* ps, SocketHelper* sh1, SocketHelper* sh2, bo
 
   for (int i = 0; i < count; ++i)
   {
-    ps->addSocket(sh1->socket_, boost::bind(&SocketHelper::processEvents, sh1, _1));
+    ps->addSocket(sh1->socket_, boost::bind(&SocketHelper::processEvents, sh1, boost::placeholders::_1));
     ps->addEvents(sh1->socket_, POLLIN);
     ps->addEvents(sh1->socket_, POLLOUT);
 
-    ps->addSocket(sh2->socket_, boost::bind(&SocketHelper::processEvents, sh2, _1));
+    ps->addSocket(sh2->socket_, boost::bind(&SocketHelper::processEvents, sh2, boost::placeholders::_1));
     ps->addEvents(sh2->socket_, POLLIN);
     ps->addEvents(sh2->socket_, POLLOUT);
 

--- a/test/test_roscpp/test/test_transport_tcp.cpp
+++ b/test/test_roscpp/test/test_transport_tcp.cpp
@@ -254,7 +254,7 @@ protected:
     transports_[0] = boost::make_shared<TransportTCP>(&poll_set_);
     transports_[1] = boost::make_shared<TransportTCP>(&poll_set_);
 
-    if (!transports_[0]->listen(0, 100, boost::bind(&Polled::connectionReceived, this, _1)))
+    if (!transports_[0]->listen(0, 100, boost::bind(&Polled::connectionReceived, this, boost::placeholders::_1)))
     {
       FAIL();
     }
@@ -278,12 +278,12 @@ protected:
       FAIL();
     }
 
-    transports_[1]->setReadCallback(boost::bind(&Polled::onReadable, this, _1, 1));
-    transports_[2]->setReadCallback(boost::bind(&Polled::onReadable, this, _1, 2));
-    transports_[1]->setWriteCallback(boost::bind(&Polled::onWriteable, this, _1, 1));
-    transports_[2]->setWriteCallback(boost::bind(&Polled::onWriteable, this, _1, 2));
-    transports_[1]->setDisconnectCallback(boost::bind(&Polled::onDisconnect, this, _1, 1));
-    transports_[2]->setDisconnectCallback(boost::bind(&Polled::onDisconnect, this, _1, 2));
+    transports_[1]->setReadCallback(boost::bind(&Polled::onReadable, this, boost::placeholders::_1, 1));
+    transports_[2]->setReadCallback(boost::bind(&Polled::onReadable, this, boost::placeholders::_1, 2));
+    transports_[1]->setWriteCallback(boost::bind(&Polled::onWriteable, this, boost::placeholders::_1, 1));
+    transports_[2]->setWriteCallback(boost::bind(&Polled::onWriteable, this, boost::placeholders::_1, 2));
+    transports_[1]->setDisconnectCallback(boost::bind(&Polled::onDisconnect, this, boost::placeholders::_1, 1));
+    transports_[2]->setDisconnectCallback(boost::bind(&Polled::onDisconnect, this, boost::placeholders::_1, 2));
 
     transports_[1]->enableRead();
     transports_[2]->enableRead();

--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -212,7 +212,7 @@ void Player::publish() {
         ops.datatype = ros::message_traits::datatype<topic_tools::ShapeShifter>();
         ops.helper = boost::make_shared<ros::SubscriptionCallbackHelperT<
             const ros::MessageEvent<topic_tools::ShapeShifter const> &> >(
-                boost::bind(&Player::updateRateTopicTime, this, _1));
+                boost::bind(&Player::updateRateTopicTime, this, boost::placeholders::_1));
 
         rate_control_sub_ = node_handle_.subscribe(ops);
 

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -184,7 +184,7 @@ int Recorder::run() {
         record_thread = boost::thread(boost::bind(&Recorder::doRecordSnapshotter, this));
 
         // Subscribe to the snapshot trigger
-        trigger_sub = nh.subscribe<std_msgs::Empty>("snapshot_trigger", 100, boost::bind(&Recorder::snapshotTrigger, this, _1));
+        trigger_sub = nh.subscribe<std_msgs::Empty>("snapshot_trigger", 100, boost::bind(&Recorder::snapshotTrigger, this, boost::placeholders::_1));
     }
     else
         record_thread = boost::thread(boost::bind(&Recorder::doRecord, this));
@@ -196,7 +196,7 @@ int Recorder::run() {
     {
         // check for master first
         doCheckMaster(ros::TimerEvent(), nh);
-        check_master_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&Recorder::doCheckMaster, this, _1, boost::ref(nh)));
+        check_master_timer = nh.createTimer(ros::Duration(1.0), boost::bind(&Recorder::doCheckMaster, this, boost::placeholders::_1, boost::ref(nh)));
     }
 
     ros::AsyncSpinner s(10);
@@ -223,7 +223,7 @@ shared_ptr<ros::Subscriber> Recorder::subscribe(string const& topic) {
     ops.datatype = ros::message_traits::datatype<topic_tools::ShapeShifter>();
     ops.helper = boost::make_shared<ros::SubscriptionCallbackHelperT<
         const ros::MessageEvent<topic_tools::ShapeShifter const> &> >(
-            boost::bind(&Recorder::doQueue, this, _1, topic, sub, count));
+            boost::bind(&Recorder::doQueue, this, boost::placeholders::_1, topic, sub, count));
     ops.transport_hints = options_.transport_hints;
     *sub = nh.subscribe(ops);
 

--- a/tools/rosbag_storage/src/bag.cpp
+++ b/tools/rosbag_storage/src/bag.cpp
@@ -673,12 +673,12 @@ void Bag::writeConnectionRecord(ConnectionInfo const* connection_info, const boo
     header[CONNECTION_FIELD_NAME] = toHeaderString(&connection_info->id);
 
     if (encrypt)
-        encryptor_->writeEncryptedHeader(boost::bind(&Bag::writeHeader, this, _1), header, file_);
+        encryptor_->writeEncryptedHeader(boost::bind(&Bag::writeHeader, this, boost::placeholders::_1), header, file_);
     else
         writeHeader(header);
 
     if (encrypt)
-        encryptor_->writeEncryptedHeader(boost::bind(&Bag::writeHeader, this, _1), *connection_info->header, file_);
+        encryptor_->writeEncryptedHeader(boost::bind(&Bag::writeHeader, this, boost::placeholders::_1), *connection_info->header, file_);
     else
         writeHeader(*connection_info->header);
 }
@@ -695,7 +695,7 @@ void Bag::appendConnectionRecordToBuffer(Buffer& buf, ConnectionInfo const* conn
 
 void Bag::readConnectionRecord() {
     ros::Header header;
-    if (!encryptor_->readEncryptedHeader(boost::bind(&Bag::readHeader, this, _1), header, header_buffer_, file_))
+    if (!encryptor_->readEncryptedHeader(boost::bind(&Bag::readHeader, this, boost::placeholders::_1), header, header_buffer_, file_))
         throw BagFormatException("Error reading CONNECTION header");
     M_string& fields = *header.getValues();
 
@@ -708,7 +708,7 @@ void Bag::readConnectionRecord() {
     readField(fields, TOPIC_FIELD_NAME,      true, topic);
 
     ros::Header connection_header;
-    if (!encryptor_->readEncryptedHeader(boost::bind(&Bag::readHeader, this, _1), connection_header, header_buffer_, file_))
+    if (!encryptor_->readEncryptedHeader(boost::bind(&Bag::readHeader, this, boost::placeholders::_1), connection_header, header_buffer_, file_))
         throw BagFormatException("Error reading connection header");
 
     // If this is a new connection, update connections

--- a/tools/topic_tools/src/demux.cpp
+++ b/tools/topic_tools/src/demux.cpp
@@ -285,7 +285,7 @@ int main(int argc, char **argv)
   g_pub_selected.publish(t);
 
   // Create the one subscriber
-  g_sub = ros::Subscriber(n.subscribe<ShapeShifter>(g_input_topic, 10, boost::bind(in_cb, _1)));
+  g_sub = ros::Subscriber(n.subscribe<ShapeShifter>(g_input_topic, 10, boost::bind(in_cb, boost::placeholders::_1)));
 
 
   // New service

--- a/tools/topic_tools/src/mux.cpp
+++ b/tools/topic_tools/src/mux.cpp
@@ -75,7 +75,7 @@ void conn_cb(const ros::SingleSubscriberPublisher&)
   if(g_lazy && g_selected != g_subs.end() && !g_selected->sub)
   {
     ROS_DEBUG("lazy mode; resubscribing to %s", g_selected->topic_name.c_str());
-    g_selected->sub = new ros::Subscriber(g_node->subscribe<ShapeShifter>(g_selected->topic_name, 10, boost::bind(in_cb, _1, g_selected->msg)));
+    g_selected->sub = new ros::Subscriber(g_node->subscribe<ShapeShifter>(g_selected->topic_name, 10, boost::bind(in_cb, boost::placeholders::_1, g_selected->msg)));
   }
 }
 
@@ -121,7 +121,7 @@ bool sel_srv_cb( topic_tools::MuxSelect::Request  &req,
         ret = true;
         
         if (!g_selected->sub && (!g_advertised || (g_advertised && g_pub.getNumSubscribers()))) {
-          g_selected->sub = new ros::Subscriber(g_node->subscribe<ShapeShifter>(g_selected->topic_name, 10, boost::bind(in_cb, _1, g_selected->msg)));
+          g_selected->sub = new ros::Subscriber(g_node->subscribe<ShapeShifter>(g_selected->topic_name, 10, boost::bind(in_cb, boost::placeholders::_1, g_selected->msg)));
         }
       }
     }
@@ -232,7 +232,7 @@ bool add_topic_cb(topic_tools::MuxAdd::Request& req,
     if (g_lazy)
       sub_info.sub = NULL;
     else
-      sub_info.sub = new ros::Subscriber(g_node->subscribe<ShapeShifter>(sub_info.topic_name, 10, boost::bind(in_cb, _1, sub_info.msg)));
+      sub_info.sub = new ros::Subscriber(g_node->subscribe<ShapeShifter>(sub_info.topic_name, 10, boost::bind(in_cb, boost::placeholders::_1, sub_info.msg)));
   }
   catch(ros::InvalidNameException& e)
   {
@@ -315,7 +315,7 @@ int main(int argc, char **argv)
     struct sub_info_t sub_info;
     sub_info.msg = new ShapeShifter;
     sub_info.topic_name = ros::names::resolve(topics[i]);
-    sub_info.sub = new ros::Subscriber(n.subscribe<ShapeShifter>(sub_info.topic_name, 10, boost::bind(in_cb, _1, sub_info.msg)));
+    sub_info.sub = new ros::Subscriber(n.subscribe<ShapeShifter>(sub_info.topic_name, 10, boost::bind(in_cb, boost::placeholders::_1, sub_info.msg)));
 
     g_subs.push_back(sub_info);
   }

--- a/utilities/message_filters/include/message_filters/cache.h
+++ b/utilities/message_filters/include/message_filters/cache.h
@@ -89,7 +89,7 @@ public:
   template<class F>
   void connectInput(F& f)
   {
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&Cache::callback, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&Cache::callback, this, boost::placeholders::_1)));
   }
 
   ~Cache()

--- a/utilities/message_filters/include/message_filters/chain.h
+++ b/utilities/message_filters/include/message_filters/chain.h
@@ -154,13 +154,13 @@ public:
   size_t addFilter(const boost::shared_ptr<F>& filter)
   {
     FilterInfo info;
-    info.add_func = boost::bind((void(F::*)(const EventType&))&F::add, filter.get(), _1);
+    info.add_func = boost::bind((void(F::*)(const EventType&))&F::add, filter.get(), boost::placeholders::_1);
     info.filter = filter;
     info.passthrough = boost::make_shared<PassThrough<M> >();
 
     last_filter_connection_.disconnect();
     info.passthrough->connectInput(*filter);
-    last_filter_connection_ = info.passthrough->registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&Chain::lastFilterCB, this, _1)));
+    last_filter_connection_ = info.passthrough->registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&Chain::lastFilterCB, this, boost::placeholders::_1)));
     if (!filters_.empty())
     {
       filter->connectInput(*filters_.back().passthrough);
@@ -196,7 +196,7 @@ public:
   void connectInput(F& f)
   {
     incoming_connection_.disconnect();
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&Chain::incomingCB, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&Chain::incomingCB, this, boost::placeholders::_1)));
   }
 
   /**

--- a/utilities/message_filters/include/message_filters/pass_through.h
+++ b/utilities/message_filters/include/message_filters/pass_through.h
@@ -65,7 +65,7 @@ public:
   void connectInput(F& f)
   {
     incoming_connection_.disconnect();
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&PassThrough::cb, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&PassThrough::cb, this, boost::placeholders::_1)));
   }
 
   void add(const MConstPtr& msg)

--- a/utilities/message_filters/include/message_filters/signal9.h
+++ b/utilities/message_filters/include/message_filters/signal9.h
@@ -180,91 +180,91 @@ public:
   template<typename P0, typename P1>
   Connection addCallback(void(*callback)(P0, P1))
   {
-    return addCallback(boost::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, _1, _2)));
+    return addCallback(boost::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2)));
   }
 
   template<typename P0, typename P1, typename P2>
   Connection addCallback(void(*callback)(P0, P1, P2))
   {
-    return addCallback(boost::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, _1, _2, _3)));
+    return addCallback(boost::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3>
   Connection addCallback(void(*callback)(P0, P1, P2, P3))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, _1, _2, _3, _4)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(boost::bind(callback, _1, _2, _3, _4, _5)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(boost::bind(callback, _1, _2, _3, _4, _5, _6)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(boost::bind(callback, _1, _2, _3, _4, _5, _6, _7)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6, boost::placeholders::_7)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6, P7))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(boost::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6, _7, boost::placeholders::_8)));
   }
 
   template<typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7, typename P8>
   Connection addCallback(void(*callback)(P0, P1, P2, P3, P4, P5, P6, P7, P8))
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>(boost::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, P8)>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6, _7, boost::placeholders::_8, boost::placeholders::_9)));
   }
 
   template<typename T, typename P0, typename P1>
   Connection addCallback(void(T::*callback)(P0, P1), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2)));
+    return addCallback(boost::function<void(P0, P1, NullP, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, boost::placeholders::_1, boost::placeholders::_2)));
   }
 
   template<typename T, typename P0, typename P1, typename P2>
   Connection addCallback(void(T::*callback)(P0, P1, P2), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3)));
+    return addCallback(boost::function<void(P0, P1, P2, NullP, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3, _4)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, NullP, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3, _4, _5)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, NullP, NullP, NullP, NullP)>(boost::bind(callback, t, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3, _4, _5, _6)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, NullP, NullP, NullP)>(boost::bind(callback, t, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5, P6), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(boost::bind(callback, t, _1, _2, _3, _4, _5, _6, _7)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, NullP, NullP)>(boost::bind(callback, t, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6, boost::placeholders::_7)));
   }
 
   template<typename T, typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
   Connection addCallback(void(T::*callback)(P0, P1, P2, P3, P4, P5, P6, P7), T* t)
   {
-    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(boost::bind(callback, t, _1, _2, _3, _4, _5, _6, _7, _8)));
+    return addCallback(boost::function<void(P0, P1, P2, P3, P4, P5, P6, P7, NullP)>(boost::bind(callback, t, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6, _7, boost::placeholders::_8)));
   }
 
   template<typename C>
@@ -278,7 +278,7 @@ public:
                      const M5ConstPtr&,
                      const M6ConstPtr&,
                      const M7ConstPtr&,
-                     const M8ConstPtr&>(boost::bind(callback, _1, _2, _3, _4, _5, _6, _7, _8, _9));
+                     const M8ConstPtr&>(boost::bind(callback, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5, boost::placeholders::_6, _7, boost::placeholders::_8, boost::placeholders::_9));
   }
 
   void removeCallback(const CallbackHelper9Ptr& helper)

--- a/utilities/message_filters/include/message_filters/simple_filter.h
+++ b/utilities/message_filters/include/message_filters/simple_filter.h
@@ -93,7 +93,7 @@ public:
   template<typename P>
   Connection registerCallback(void(*callback)(P))
   {
-    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(boost::bind(callback, _1));
+    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(boost::bind(callback, boost::placeholders::_1));
     return Connection(boost::bind(&Signal::removeCallback, &signal_, helper));
   }
 
@@ -104,7 +104,7 @@ public:
   template<typename T, typename P>
   Connection registerCallback(void(T::*callback)(P), T* t)
   {
-    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(boost::bind(callback, t, _1));
+    typename CallbackHelper1<M>::Ptr helper = signal_.template addCallback<P>(boost::bind(callback, t, boost::placeholders::_1));
     return Connection(boost::bind(&Signal::removeCallback, &signal_, helper));
   }
 

--- a/utilities/message_filters/include/message_filters/subscriber.h
+++ b/utilities/message_filters/include/message_filters/subscriber.h
@@ -143,7 +143,7 @@ public:
 
     if (!topic.empty())
     {
-      ops_.template initByFullCallbackType<const EventType&>(topic, queue_size, boost::bind(&Subscriber<M>::cb, this, _1));
+      ops_.template initByFullCallbackType<const EventType&>(topic, queue_size, boost::bind(&Subscriber<M>::cb, this, boost::placeholders::_1));
       ops_.callback_queue = callback_queue;
       ops_.transport_hints = transport_hints;
       sub_ = nh.subscribe(ops_);

--- a/utilities/message_filters/include/message_filters/synchronizer.h
+++ b/utilities/message_filters/include/message_filters/synchronizer.h
@@ -287,15 +287,15 @@ public:
   {
     disconnectAll();
 
-    input_connections_[0] = f0.registerCallback(boost::function<void(const M0Event&)>(boost::bind(&Synchronizer::template cb<0>, this, _1)));
-    input_connections_[1] = f1.registerCallback(boost::function<void(const M1Event&)>(boost::bind(&Synchronizer::template cb<1>, this, _1)));
-    input_connections_[2] = f2.registerCallback(boost::function<void(const M2Event&)>(boost::bind(&Synchronizer::template cb<2>, this, _1)));
-    input_connections_[3] = f3.registerCallback(boost::function<void(const M3Event&)>(boost::bind(&Synchronizer::template cb<3>, this, _1)));
-    input_connections_[4] = f4.registerCallback(boost::function<void(const M4Event&)>(boost::bind(&Synchronizer::template cb<4>, this, _1)));
-    input_connections_[5] = f5.registerCallback(boost::function<void(const M5Event&)>(boost::bind(&Synchronizer::template cb<5>, this, _1)));
-    input_connections_[6] = f6.registerCallback(boost::function<void(const M6Event&)>(boost::bind(&Synchronizer::template cb<6>, this, _1)));
-    input_connections_[7] = f7.registerCallback(boost::function<void(const M7Event&)>(boost::bind(&Synchronizer::template cb<7>, this, _1)));
-    input_connections_[8] = f8.registerCallback(boost::function<void(const M8Event&)>(boost::bind(&Synchronizer::template cb<8>, this, _1)));
+    input_connections_[0] = f0.registerCallback(boost::function<void(const M0Event&)>(boost::bind(&Synchronizer::template cb<0>, this, boost::placeholders::_1)));
+    input_connections_[1] = f1.registerCallback(boost::function<void(const M1Event&)>(boost::bind(&Synchronizer::template cb<1>, this, boost::placeholders::_1)));
+    input_connections_[2] = f2.registerCallback(boost::function<void(const M2Event&)>(boost::bind(&Synchronizer::template cb<2>, this, boost::placeholders::_1)));
+    input_connections_[3] = f3.registerCallback(boost::function<void(const M3Event&)>(boost::bind(&Synchronizer::template cb<3>, this, boost::placeholders::_1)));
+    input_connections_[4] = f4.registerCallback(boost::function<void(const M4Event&)>(boost::bind(&Synchronizer::template cb<4>, this, boost::placeholders::_1)));
+    input_connections_[5] = f5.registerCallback(boost::function<void(const M5Event&)>(boost::bind(&Synchronizer::template cb<5>, this, boost::placeholders::_1)));
+    input_connections_[6] = f6.registerCallback(boost::function<void(const M6Event&)>(boost::bind(&Synchronizer::template cb<6>, this, boost::placeholders::_1)));
+    input_connections_[7] = f7.registerCallback(boost::function<void(const M7Event&)>(boost::bind(&Synchronizer::template cb<7>, this, boost::placeholders::_1)));
+    input_connections_[8] = f8.registerCallback(boost::function<void(const M8Event&)>(boost::bind(&Synchronizer::template cb<8>, this, boost::placeholders::_1)));
   }
 
   template<class C>

--- a/utilities/message_filters/include/message_filters/time_sequencer.h
+++ b/utilities/message_filters/include/message_filters/time_sequencer.h
@@ -123,7 +123,7 @@ public:
   void connectInput(F& f)
   {
     incoming_connection_.disconnect();
-    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&TimeSequencer::cb, this, _1)));
+    incoming_connection_ = f.registerCallback(typename SimpleFilter<M>::EventCallback(boost::bind(&TimeSequencer::cb, this, boost::placeholders::_1)));
   }
 
   ~TimeSequencer()

--- a/utilities/message_filters/test/directed.py
+++ b/utilities/message_filters/test/directed.py
@@ -11,7 +11,7 @@
 #    wide_right_info(nh_, "/wide_stereo/right/camera_info", 10),
 #    wide(wide_left, wide_left_info, wide_right, wide_right_info, 4),
 #
-#    wide.registerCallback(boost::bind(&PersonDataRecorder::wideCB, this, _1, _2, _3, _4));
+#    wide.registerCallback(boost::bind(&PersonDataRecorder::wideCB, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
 
 import rostest
 import rospy

--- a/utilities/message_filters/test/test_approximate_time_policy.cpp
+++ b/utilities/message_filters/test/test_approximate_time_policy.cpp
@@ -99,7 +99,7 @@ public:
 				  uint32_t queue_size) :
     input_(input), output_(output), output_position_(0), sync_(queue_size)
   {
-    sync_.registerCallback(boost::bind(&ApproximateTimeSynchronizerTest::callback, this, _1, _2));
+    sync_.registerCallback(boost::bind(&ApproximateTimeSynchronizerTest::callback, this, boost::placeholders::_1, boost::placeholders::_2));
   }
 
   void callback(const MsgConstPtr& p, const MsgConstPtr& q)
@@ -157,7 +157,7 @@ public:
 				      uint32_t queue_size) :
     input_(input), output_(output), output_position_(0), sync_(queue_size)
   {
-    sync_.registerCallback(boost::bind(&ApproximateTimeSynchronizerTestQuad::callback, this, _1, _2, _3, _4));
+    sync_.registerCallback(boost::bind(&ApproximateTimeSynchronizerTestQuad::callback, this, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4));
   }
 
     void callback(const MsgConstPtr& p, const MsgConstPtr& q, const MsgConstPtr& r, const MsgConstPtr& s)

--- a/utilities/message_filters/test/test_simple.cpp
+++ b/utilities/message_filters/test/test_simple.cpp
@@ -111,14 +111,14 @@ TEST(SimpleFilter, callbackTypes)
 {
   Helper h;
   Filter f;
-  f.registerCallback(boost::bind(&Helper::cb0, &h, _1));
-  f.registerCallback<const Msg&>(boost::bind(&Helper::cb1, &h, _1));
-  f.registerCallback<MsgConstPtr>(boost::bind(&Helper::cb2, &h, _1));
-  f.registerCallback<const ros::MessageEvent<Msg const>&>(boost::bind(&Helper::cb3, &h, _1));
-  f.registerCallback<Msg>(boost::bind(&Helper::cb4, &h, _1));
-  f.registerCallback<const MsgPtr&>(boost::bind(&Helper::cb5, &h, _1));
-  f.registerCallback<MsgPtr>(boost::bind(&Helper::cb6, &h, _1));
-  f.registerCallback<const ros::MessageEvent<Msg>&>(boost::bind(&Helper::cb7, &h, _1));
+  f.registerCallback(boost::bind(&Helper::cb0, &h, boost::placeholders::_1));
+  f.registerCallback<const Msg&>(boost::bind(&Helper::cb1, &h, boost::placeholders::_1));
+  f.registerCallback<MsgConstPtr>(boost::bind(&Helper::cb2, &h, boost::placeholders::_1));
+  f.registerCallback<const ros::MessageEvent<Msg const>&>(boost::bind(&Helper::cb3, &h, boost::placeholders::_1));
+  f.registerCallback<Msg>(boost::bind(&Helper::cb4, &h, boost::placeholders::_1));
+  f.registerCallback<const MsgPtr&>(boost::bind(&Helper::cb5, &h, boost::placeholders::_1));
+  f.registerCallback<MsgPtr>(boost::bind(&Helper::cb6, &h, boost::placeholders::_1));
+  f.registerCallback<const ros::MessageEvent<Msg>&>(boost::bind(&Helper::cb7, &h, boost::placeholders::_1));
 
   f.add(Filter::EventType(boost::make_shared<Msg>()));
   EXPECT_EQ(h.counts_[0], 1);
@@ -143,7 +143,7 @@ TEST(SimpleFilter, oldRegisterWithNewFilter)
 {
   OldFilter f;
   Helper h;
-  f.registerCallback(boost::bind(&Helper::cb3, &h, _1));
+  f.registerCallback(boost::bind(&Helper::cb3, &h, boost::placeholders::_1));
 }
 
 int main(int argc, char **argv){

--- a/utilities/message_filters/test/test_subscriber.cpp
+++ b/utilities/message_filters/test/test_subscriber.cpp
@@ -64,7 +64,7 @@ TEST(Subscriber, simple)
   ros::NodeHandle nh;
   Helper h;
   Subscriber<Msg> sub(nh, "test_topic", 0);
-  sub.registerCallback(boost::bind(&Helper::cb, &h, _1));
+  sub.registerCallback(boost::bind(&Helper::cb, &h, boost::placeholders::_1));
   ros::Publisher pub = nh.advertise<Msg>("test_topic", 0);
 
   ros::Time start = ros::Time::now();
@@ -83,7 +83,7 @@ TEST(Subscriber, subUnsubSub)
   ros::NodeHandle nh;
   Helper h;
   Subscriber<Msg> sub(nh, "test_topic", 0);
-  sub.registerCallback(boost::bind(&Helper::cb, &h, _1));
+  sub.registerCallback(boost::bind(&Helper::cb, &h, boost::placeholders::_1));
   ros::Publisher pub = nh.advertise<Msg>("test_topic", 0);
 
   sub.unsubscribe();
@@ -106,7 +106,7 @@ TEST(Subscriber, subInChain)
   Helper h;
   Chain<Msg> c;
   c.addFilter(boost::make_shared<Subscriber<Msg> >(boost::ref(nh), "test_topic", 0));
-  c.registerCallback(boost::bind(&Helper::cb, &h, _1));
+  c.registerCallback(boost::bind(&Helper::cb, &h, boost::placeholders::_1));
   ros::Publisher pub = nh.advertise<Msg>("test_topic", 0);
 
   ros::Time start = ros::Time::now();

--- a/utilities/message_filters/test/time_sequencer_unittest.cpp
+++ b/utilities/message_filters/test/time_sequencer_unittest.cpp
@@ -87,7 +87,7 @@ TEST(TimeSequencer, simple)
 {
   TimeSequencer<Msg> seq(ros::Duration(1.0), ros::Duration(0.01), 10);
   Helper h;
-  seq.registerCallback(boost::bind(&Helper::cb, &h, _1));
+  seq.registerCallback(boost::bind(&Helper::cb, &h, boost::placeholders::_1));
   MsgPtr msg(boost::make_shared<Msg>());
   msg->header.stamp = ros::Time::now();
   seq.add(msg);


### PR DESCRIPTION
cherry-pick of https://github.com/ros/ros_comm/commit/3d137ca91109a9f229d0701e618758ef7f817218.