### PR TITLE
Change error message

### DIFF
--- a/tools/roslaunch/src/roslaunch/server.py
+++ b/tools/roslaunch/src/roslaunch/server.py
@@ -404,7 +404,7 @@ class ROSLaunchNode(xmlrpc.XmlRpcNode):
             raise RLException("""Unable to contact my own server at [%s].
 This usually means that the network is not configured properly.
 
-A common cause is that the machine cannot ping itself.  Please check
+A common cause is that the machine cannot connect to itself.  Please check
 for errors by running:
 
 \tping %s


### PR DESCRIPTION
As far as I can tell, not being able to ping itself does not *cause* the issue (at least if ping refers to using the `ping` program to check if a host can be reached).

Not sure if this wording is the optimal.

The old wording caused me to spend quite a bit of time being confused about why `ping` was a dependency of ROS (launch) when the official ROS docker containers do not come with `ping` installed.