### PR TITLE
rostest: add service and filter testing (noetic)

### DIFF
--- a/tools/rostest/CMakeLists.txt
+++ b/tools/rostest/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(rostest)
 
-find_package(catkin COMPONENTS rosunit)
+find_package(catkin COMPONENTS rosunit rospy_message_converter)
 find_package(Boost COMPONENTS thread)
 
 include_directories(include ${Boost_INCLUDE_DIRS})
@@ -13,7 +13,7 @@ catkin_package(DEPENDS Boost
 catkin_python_setup()
 
 catkin_install_python(
-  PROGRAMS nodes/hztest nodes/paramtest nodes/publishtest
+  PROGRAMS nodes/hztest nodes/paramtest nodes/publishtest nodes/advertisetest nodes/filtertest nodes/servicetest
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/nodes)
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
@@ -34,4 +34,6 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(test/distro_version.test)
   add_rostest(test/param.test)
   add_rostest(test/advertisetest.test)
+  add_rostest(test/msg_filter.test)
+  add_rostest(test/service_call.test)
 endif()

--- a/tools/rostest/nodes/advertisetest
+++ b/tools/rostest/nodes/advertisetest
@@ -110,7 +110,7 @@ class AdvertiseTest(unittest.TestCase):
                 use_sim_time and (rospy.Time.now() == rospy.Time(0)):
             rospy.logwarn_throttle(
                 1, '/use_sim_time is specified and rostime is 0, /clock is published?')
-            if time.time() - t_start > 10:
+            if time.time() - self.t_start > 10:
                 self.fail('Timed out (10s) of /clock publication.')
             # must use time.sleep because /clock isn't yet published, so rospy.sleep hangs.
             time.sleep(0.1)

--- a/tools/rostest/nodes/filtertest
+++ b/tools/rostest/nodes/filtertest
@@ -60,6 +60,7 @@ If the input or the output message should be empty, place None.
 """
 
 import sys
+import time
 import unittest
 import rospy
 import rostopic
@@ -81,6 +82,18 @@ class FilterMsgTest(unittest.TestCase):
 
     def setUp(self):
         rospy.init_node(CLASSNAME)
+
+        # warn on /use_sim_time is true
+        use_sim_time = rospy.get_param('/use_sim_time', False)
+        t_start = time.time()
+        while not rospy.is_shutdown() and \
+                use_sim_time and (rospy.Time.now() == rospy.Time(0)):
+            rospy.logwarn_throttle(
+                1, '/use_sim_time is specified and rostime is 0, /clock is published?')
+            if time.time() - t_start > 10:
+                self.fail('Timed out (10s) of /clock publication.')
+            # must use time.sleep because /clock isn't yet published, so rospy.sleep hangs.
+            time.sleep(0.1)
 
     def test_filter(self):
         self.filters = list()

--- a/tools/rostest/nodes/filtertest
+++ b/tools/rostest/nodes/filtertest
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020, Tecnalia.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tecnalia nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+@file filtertest
+@author Anthony Remazeilles
+@brief perform a unittest on a ROS message filter-like behavior
+
+Copyright (C) 2020 Tecnalia Research and Innovation
+Distributed under the BSD license.
+
+Verify that a component, when receiving a specific message,
+generates thes expected topic
+
+Test to be defined as follows:
+
+<test test-name="filter_test" pkg="rostest" type="filtertest">
+    <rosparam>
+        filters:
+            - topic_in: topic to which the filter node is subscribed to
+              topic_out: topic to which the filter node will pubish filter output
+              msg_in: message to publish on topic_in, in python dictionary format
+              msg_out: message to be received on topic_out, in python dictionary format
+              timeout: limit time [s] for receiving the filter output 
+    </rosparam>
+</test>
+
+Several filter calls can be added.
+If the input or the output message should be empty, place None.
+"""
+
+import sys
+import unittest
+import rospy
+import rostopic
+import rosmsg
+import rostest
+import genpy
+from rospy_message_converter import message_converter
+
+CLASSNAME = 'filterTest'
+
+
+class FilterMsgTest(unittest.TestCase):
+    def __init__(self, *args):
+        super(FilterMsgTest, self).__init__(*args)
+
+        self.filter_msg = None
+        self.filter_stamp = None
+        self.is_received = False
+
+    def setUp(self):
+        rospy.init_node(CLASSNAME)
+
+    def test_filter(self):
+        self.filters = list()
+        try:
+
+            filters = rospy.get_param("~filters")
+
+            for one_filter in filters:
+                keys = ['topic_in', 'topic_out', 'msg_in', 'msg_out', 'timeout']
+
+                for item in keys:
+                    if item not in keys:
+                        self.fail("{} field required, but not specified in {}".format(item, call))
+
+            if one_filter['topic_in'] == 'None':
+                rospy.logwarn('None input converted to empty input')
+                one_filter['topic_in'] = dict()
+            if one_filter['topic_out'] == 'None':
+                rospy.logwarn('None output converted to empty output')
+                one_filter['topic_out'] = dict()
+
+            self.filters = filters
+
+        except KeyError as err:
+            msg_err = "filter_test not initialized properly \n"
+            msg_err += " Parameter [%s] not set. \n" % (str(err))
+            msg_err += " Caller ID: [%s] Resolved name: [%s]\n" % (
+                rospy.get_caller_id(),
+                rospy.resolve_name(err.args[0]))
+            self.fail(msg_err)
+
+        for item in self.filters:
+            rospy.loginfo("Testing filtering {}-{}".format(item['topic_in'], item['topic_out']))
+            self._test_filter(item['topic_in'], item['topic_out'], item['msg_in'], item['msg_out'], item['timeout'])
+            rospy.loginfo("So far so good")
+
+    def _filter_cb(self, msg):
+        self.filter_msg = msg
+        self.filter_stamp = rospy.get_time()
+        rospy.loginfo("Message received!")
+        self.is_received = True
+
+    def _test_filter(self, topic_in, topic_out, msg_in, msg_out, timeout):
+        self.assert_(topic_in)
+        self.assert_(topic_out)
+        self.assert_(msg_in)
+        self.assert_(msg_out)
+
+        l_pub = rospy.get_published_topics()
+        rospy.loginfo("Detected topics: {}".format(l_pub))
+
+        # getting message to send
+        msg_in_type = rostopic.get_topic_type(topic_in)[0]
+        rospy.loginfo("Type transiting on {}: {}".format(topic_in, msg_in_type))
+        self.assert_(msg_in_type is not None)
+
+        rospy.loginfo("Converting {} into {}".format(msg_in, msg_in_type))
+        try:
+            ros_msg_in = message_converter.convert_dictionary_to_ros_message(msg_in_type, msg_in)
+            rospy.loginfo("Generated message: [%s]" % (ros_msg_in))
+        except ValueError as err:
+            msg_err = "Prb in message in contruction \n"
+            msg_err += "Expected type: [%s]\n" % (msg_in_type)
+            msg_err += "dictionary: [%s]\n" % (msg_in)
+            msg_err += "Erorr: [%s]\n" % (str(err))
+            self.fail(msg_err)
+
+        # getting message to receive
+        msg_out_type = rostopic.get_topic_type(topic_out)[0]
+        rospy.loginfo("Type transiting on {}: {}".format(topic_out, msg_out_type))
+        self.assert_(msg_out_type is not None)
+
+        rospy.loginfo("Converting {} into {}".format(msg_out, msg_out_type))
+        try:
+            ros_msg_out = message_converter.convert_dictionary_to_ros_message(msg_out_type, msg_out)
+            rospy.loginfo("Generated message: [%s]" % (ros_msg_out))
+        except ValueError as err:
+            msg_err = "Prb in message in contruction \n"
+            msg_err += "Expected type: [%s]\n" % (msg_out_type)
+            msg_err += "dictionary: [%s]\n" % (msg_out)
+            msg_err += "Erorr: [%s]\n" % (str(err))
+            self.fail(msg_err)
+
+        # subscription
+        # make sure no reception done before publication
+        self.is_received = False
+        pub = rospy.Publisher(topic_in, ros_msg_in.__class__, queue_size=1)
+        sub = rospy.Subscriber(topic_out, ros_msg_out.__class__, self._filter_cb, queue_size=1)
+        rospy.sleep(0.5)
+        self.assert_(not self.is_received, "No message should be received before publication!")
+        time_pub = rospy.get_time()
+        pub.publish(ros_msg_in)
+        # make sure one message gets received in the defined time.
+        is_too_long = False
+        while not self.is_received:
+            if timeout is not None:
+                if rospy.get_time() - time_pub > timeout:
+                    is_too_long = True
+                    break
+            rospy.sleep(0.1)
+
+        self.assert_(not is_too_long, 'filter out not received within indicated duration: [%s]' % timeout)
+
+        rospy.loginfo("A message has been received!")
+        rospy.loginfo("{} at {}".format(self.filter_msg, self.filter_stamp))
+        duration = self.filter_stamp - time_pub
+        rospy.loginfo("Filter duration: {}".format(duration))
+        # check the receive message
+        self.assertEqual(self.filter_msg, ros_msg_out)
+
+
+def main():
+    try:
+        rostest.run('rostest', CLASSNAME, FilterMsgTest, sys.argv)
+    except KeyboardInterrupt:
+        pass
+    print("{} exiting".format(CLASSNAME))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/rostest/nodes/filtertest
+++ b/tools/rostest/nodes/filtertest
@@ -137,10 +137,10 @@ class FilterMsgTest(unittest.TestCase):
         self.is_received = True
 
     def _test_filter(self, topic_in, topic_out, msg_in, msg_out, timeout):
-        self.assert_(topic_in)
-        self.assert_(topic_out)
-        self.assert_(msg_in)
-        self.assert_(msg_out)
+        self.assertTrue(topic_in)
+        self.assertTrue(topic_out)
+        self.assertTrue(msg_in)
+        self.assertTrue(msg_out)
 
         l_pub = rospy.get_published_topics()
         rospy.loginfo("Detected topics: {}".format(l_pub))
@@ -148,7 +148,7 @@ class FilterMsgTest(unittest.TestCase):
         # getting message to send
         msg_in_type = rostopic.get_topic_type(topic_in)[0]
         rospy.loginfo("Type transiting on {}: {}".format(topic_in, msg_in_type))
-        self.assert_(msg_in_type is not None)
+        self.assertTrue(msg_in_type is not None)
 
         rospy.loginfo("Converting {} into {}".format(msg_in, msg_in_type))
         try:
@@ -164,7 +164,7 @@ class FilterMsgTest(unittest.TestCase):
         # getting message to receive
         msg_out_type = rostopic.get_topic_type(topic_out)[0]
         rospy.loginfo("Type transiting on {}: {}".format(topic_out, msg_out_type))
-        self.assert_(msg_out_type is not None)
+        self.assertTrue(msg_out_type is not None)
 
         rospy.loginfo("Converting {} into {}".format(msg_out, msg_out_type))
         try:
@@ -183,7 +183,7 @@ class FilterMsgTest(unittest.TestCase):
         pub = rospy.Publisher(topic_in, ros_msg_in.__class__, queue_size=1)
         sub = rospy.Subscriber(topic_out, ros_msg_out.__class__, self._filter_cb, queue_size=1)
         rospy.sleep(0.5)
-        self.assert_(not self.is_received, "No message should be received before publication!")
+        self.assertTrue(not self.is_received, "No message should be received before publication!")
         time_pub = rospy.get_time()
         pub.publish(ros_msg_in)
         # make sure one message gets received in the defined time.
@@ -195,7 +195,7 @@ class FilterMsgTest(unittest.TestCase):
                     break
             rospy.sleep(0.1)
 
-        self.assert_(not is_too_long, 'filter out not received within indicated duration: [%s]' % timeout)
+        self.assertTrue(not is_too_long, 'filter out not received within indicated duration: [%s]' % timeout)
 
         rospy.loginfo("A message has been received!")
         rospy.loginfo("{} at {}".format(self.filter_msg, self.filter_stamp))

--- a/tools/rostest/nodes/servicetest
+++ b/tools/rostest/nodes/servicetest
@@ -172,7 +172,7 @@ class ServiceTest(unittest.TestCase):
             else:
                 srv_resp = srv_proxy()
 
-        except (genpy.SerializationError, rospy.ROSException), err:
+        except (genpy.SerializationError, rospy.ROSException) as err:
             msg_err = "Service proxy error: {}".format(err.message)
             self.fail(msg_err)
         srv_dic = message_converter.convert_ros_message_to_dictionary(srv_resp)

--- a/tools/rostest/nodes/servicetest
+++ b/tools/rostest/nodes/servicetest
@@ -57,6 +57,7 @@ If the input or the output should be empty, place None.
 """
 
 import sys
+import time
 import unittest
 import rospy
 import rosservice
@@ -70,11 +71,8 @@ CLASSNAME = 'servicetest'
 class ServiceTest(unittest.TestCase):
     def __init__(self, *args):
         super(ServiceTest, self).__init__(*args)
-
-    def setUp(self):
         rospy.init_node(CLASSNAME)
 
-    def test_service(self):
         self.calls = list()
 
         try:
@@ -99,6 +97,7 @@ class ServiceTest(unittest.TestCase):
                 if srv_data['output'] == 'None':
                     rospy.logwarn('None output converted to empty output')
                     srv_data['output'] = dict()
+
                 self.calls.append(srv_data)
         except KeyError as err:
             msg_err = "service_test not initialized properly"
@@ -107,6 +106,46 @@ class ServiceTest(unittest.TestCase):
                 rospy.get_caller_id(),
                 rospy.resolve_name(err.args[0]))
             self.fail(msg_err)
+
+    def setUp(self):
+        # warn on /use_sim_time is true
+        use_sim_time = rospy.get_param('/use_sim_time', False)
+        self.t_start = time.time()
+        while not rospy.is_shutdown() and \
+                use_sim_time and (rospy.Time.now() == rospy.Time(0)):
+            rospy.logwarn_throttle(
+                1, '/use_sim_time is specified and rostime is 0, /clock is published?')
+            if time.time() - self.t_start > 10:
+                self.fail('Timed out (10s) of /clock publication.')
+            # must use time.sleep because /clock isn't yet published, so rospy.sleep hangs.
+            time.sleep(0.1)
+
+    def test_advertise_service(self):
+        """Test services are advertised"""
+        t_start = self.t_start
+        s_name_set = set([ item['name'] for item in self.calls])
+        t_timeout_max = 10.0
+
+        while not rospy.is_shutdown():
+            t_now = time.time()
+            t_elapsed = t_now - t_start
+            if not s_name_set:
+                break
+            if t_elapsed > t_timeout_max:
+                break
+
+            for s_name in rosservice.get_service_list():
+                if s_name in s_name_set:
+                    s_name_set.remove(s_name)
+            time.sleep(0.05)
+
+        # All services should have been detected
+        assert not s_name_set, \
+            'services [%s] not advertized on time' % (s_name_set)
+
+        rospy.loginfo("All services advertized on time")
+
+    def test_service_call(self):
 
         for item in self.calls:
             rospy.loginfo("Testing service {} with input parameters {}".format(
@@ -117,10 +156,8 @@ class ServiceTest(unittest.TestCase):
 
     def _test_service(self, srv_name, srv_input, srv_output):
         self.assert_(srv_name)
-
         all_services = rosservice.get_service_list()
         self.assertIn(srv_name, all_services)
-
         srv_class = rosservice.get_service_class_by_name(srv_name)
 
         try:

--- a/tools/rostest/nodes/servicetest
+++ b/tools/rostest/nodes/servicetest
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020, Tecnalia.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tecnalia nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+@file servicetest
+@author Anthony Remazeilles
+@brief perform a unittest on a ROS service call
+
+Copyright (C) 2020 Tecnalia Research and Innovation
+Distributed under the Apache 2.0 license.
+
+Test files should set the following parameters:
+
+<test test-name="test_service" pkg="rostest" type="servicetest" >
+    <rosparam>
+        calls:
+            - name: service name
+              input: input parameter of the message, in dictionary format
+              output: output parameter of the message, in dictionary format
+    </rosparam>
+</test>
+
+Several calls can be added.
+If the input or the output should be empty, place None.
+
+"""
+
+import sys
+import unittest
+import rospy
+import rosservice
+import rostest
+import genpy
+from rospy_message_converter import message_converter
+
+CLASSNAME = 'servicetest'
+
+
+class ServiceTest(unittest.TestCase):
+    def __init__(self, *args):
+        super(ServiceTest, self).__init__(*args)
+
+    def setUp(self):
+        rospy.init_node(CLASSNAME)
+
+    def test_service(self):
+        self.calls = list()
+
+        try:
+            calls = rospy.get_param('~calls')
+
+            for call in calls:
+
+                keys = ['name', 'input', 'output']
+                for item in keys:
+                    if item not in call:
+                        self.fail("{} field required, but not specified in {}".format(item, call))
+
+                srv_data = dict()
+
+                srv_data['name'] = call['name']
+                srv_data['input'] = call['input']
+                srv_data['output'] = call['output']
+
+                if srv_data['input'] == 'None':
+                    rospy.logwarn('None input converted to empty input')
+                    srv_data['input'] = dict()
+                if srv_data['output'] == 'None':
+                    rospy.logwarn('None output converted to empty output')
+                    srv_data['output'] = dict()
+                self.calls.append(srv_data)
+        except KeyError as err:
+            msg_err = "service_test not initialized properly"
+            msg_err += " Parameter [%s] not set." % (str(err))
+            msg_err += " Caller ID: [%s] Resolved name: [%s]" % (
+                rospy.get_caller_id(),
+                rospy.resolve_name(err.args[0]))
+            self.fail(msg_err)
+
+        for item in self.calls:
+            rospy.loginfo("Testing service {} with input parameters {}".format(
+                item['name'],
+                item['input']))
+            self._test_service(item['name'], item['input'], item['output'])
+            rospy.loginfo("So far so good")
+
+    def _test_service(self, srv_name, srv_input, srv_output):
+        self.assert_(srv_name)
+
+        all_services = rosservice.get_service_list()
+        self.assertIn(srv_name, all_services)
+
+        srv_class = rosservice.get_service_class_by_name(srv_name)
+
+        try:
+            srv_proxy = rospy.ServiceProxy(srv_name, srv_class)
+        except KeyError as err:
+            msg_err = "Service proxy could not be created"
+            self.fail(msg_err)
+
+        try:
+            if srv_input:
+                srv_resp = srv_proxy(**srv_input)
+            else:
+                srv_resp = srv_proxy()
+
+        except (genpy.SerializationError, rospy.ROSException), err:
+            msg_err = "Service proxy error: {}".format(err.message)
+            self.fail(msg_err)
+        srv_dic = message_converter.convert_ros_message_to_dictionary(srv_resp)
+
+        self.assertDictEqual(srv_dic, srv_output)
+
+
+def main():
+    try:
+        rostest.run('rostest', CLASSNAME, ServiceTest, sys.argv)
+    except KeyboardInterrupt:
+        pass
+    print("{} exiting".format(CLASSNAME))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/rostest/nodes/servicetest
+++ b/tools/rostest/nodes/servicetest
@@ -155,7 +155,7 @@ class ServiceTest(unittest.TestCase):
             rospy.loginfo("So far so good")
 
     def _test_service(self, srv_name, srv_input, srv_output):
-        self.assert_(srv_name)
+        self.assertTrue(srv_name)
         all_services = rosservice.get_service_list()
         self.assertIn(srv_name, all_services)
         srv_class = rosservice.get_service_class_by_name(srv_name)

--- a/tools/rostest/package.xml
+++ b/tools/rostest/package.xml
@@ -21,7 +21,7 @@
   <run_depend>rosmaster</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>rosunit</run_depend>
-
+  <run_depend>rospy_message_converter</run_depend>
   <export>
     <rosdoc config="rosdoc.yaml"/>
     <architecture_independent/>

--- a/tools/rostest/test/msg_filter.test
+++ b/tools/rostest/test/msg_filter.test
@@ -1,6 +1,6 @@
 <launch>
 
-    <node name="dummy_node" pkg="rostest" type="dummy_filter.py">
+    <node name="dummy_node" pkg="rostest" type="dummy_filter.py" output="screen">
         <param name="wait" value="0.2" />
     </node>
     <test test-name="filter_test" pkg="rostest" type="filtertest">

--- a/tools/rostest/test/msg_filter.test
+++ b/tools/rostest/test/msg_filter.test
@@ -1,0 +1,21 @@
+<launch>
+
+    <node name="dummy_node" pkg="rostest" type="dummy_filter.py">
+        <param name="wait" value="0.2" />
+    </node>
+    <test test-name="filter_test" pkg="rostest" type="filtertest">
+        <rosparam>
+            filters:
+                - topic_in: /filter_in
+                  topic_out: /filter_out
+                  msg_in: {'data': 2.0}
+                  msg_out: {'data': 4.0}
+                  timeout: 1.0
+                - topic_in: /filter_in
+                  topic_out: /filter_out
+                  msg_in: {'data': -1.0}
+                  msg_out: {'data': -2.0}
+                  timeout: 1.0
+        </rosparam>
+    </test>
+</launch>

--- a/tools/rostest/test/service_call.test
+++ b/tools/rostest/test/service_call.test
@@ -1,0 +1,21 @@
+<launch>
+  <node pkg="rostest" type="service_server.py" name="service_server"/>
+
+    <test test-name="test_service" pkg="rostest" type="servicetest" >
+      <rosparam>
+        calls:
+          - name: /trigger_spec
+            input: None
+            output: {'success': True, 'message': 'well done!'}
+          - name: /trigger
+            input: None
+            output: {'success': False, 'message': ''}
+          - name: /empty
+            input: None
+            output: None
+          - name: /set_bool
+            input: {'data': True}
+            output: {'success': True, 'message': 'True'}
+      </rosparam>
+    </test>
+</launch>

--- a/tools/rostest/test_nodes/dummy_filter.py
+++ b/tools/rostest/test_nodes/dummy_filter.py
@@ -56,14 +56,13 @@ class DummyFilterNode():
         rospy.init_node('dummy_filter', anonymous=True)
 
         self.wait = rospy.get_param('~wait', self.wait)
-        print "waiting time: {}".format(self.wait)
+        rospy.loginfo("waiting time: {}".format(self.wait))
 
     def callback(self, data):
-        rospy.loginfo(rospy.get_caller_id() + "I heard %s", data.data)
+        rospy.loginfo(rospy.get_caller_id() + " I heard %s", data.data)
         data.data = data.data * 2.0
-        print self.wait
         if self.wait is not None:
-            print "Sleeping!"
+            rospy.loginfo("Sleeping!")
             duration = rospy.Duration(self.wait)
             rospy.sleep(duration)
         self.pub.publish(data)

--- a/tools/rostest/test_nodes/dummy_filter.py
+++ b/tools/rostest/test_nodes/dummy_filter.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# Software License Agreement (Apache 2.0 License)
+#
+# Copyright (c) 2020, Tecnalia.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Tecnalia nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+@package node_test
+@file dummy filter
+@author Anthony Remazeilles <anthony.remazeilles@tecnalia.com>
+@brief dummy prb to check filter testing
+
+Copyright (C) 2020 Tecnalia Research and Innovation
+Distributed under the Apache 2.0 license.
+
+"""
+
+
+import rospy
+from std_msgs.msg import Float32
+
+
+class DummyFilterNode():
+    def __init__(self):
+        self.pub = None
+        self.sub = None
+        self.wait = None
+
+        rospy.init_node('dummy_filter', anonymous=True)
+
+        self.wait = rospy.get_param('~wait', self.wait)
+        print "waiting time: {}".format(self.wait)
+
+    def callback(self, data):
+        rospy.loginfo(rospy.get_caller_id() + "I heard %s", data.data)
+        data.data = data.data * 2.0
+        print self.wait
+        if self.wait is not None:
+            print "Sleeping!"
+            duration = rospy.Duration(self.wait)
+            rospy.sleep(duration)
+        self.pub.publish(data)
+
+    def run(self):
+        self.pub = rospy.Publisher('filter_out', Float32, queue_size=10)
+        self.sub = rospy.Subscriber('filter_in', Float32, self.callback)
+
+        rospy.spin()
+
+
+if __name__ == '__main__':
+    try:
+        dummy = DummyFilterNode()
+        dummy.run()
+    except rospy.ROSInterruptException:
+        pass

--- a/tools/rostest/test_nodes/service_server.py
+++ b/tools/rostest/test_nodes/service_server.py
@@ -14,10 +14,19 @@ def empty_cb(req):
     return EmptyResponse()
 
 def set_bool_cb(req):
-    return SetBoolResponse()
+    response = SetBoolResponse()
+    response.success = True
+    response.message = str(req.data)
+    return response
 
 def trigger_cb(req):
     return TriggerResponse()
+
+def trigger2_cb(req):
+    response = TriggerResponse()
+    response.success = True
+    response.message = 'well done!'
+    return response
 
 def main():
     rospy.init_node('service_server')
@@ -25,6 +34,7 @@ def main():
     empty_service = rospy.Service('empty', Empty, empty_cb)
     set_bool_service = rospy.Service('set_bool', SetBool, set_bool_cb)
     trigger_service = rospy.Service('trigger', Trigger, trigger_cb)
+    trigger2_service = rospy.Service('trigger_spec', Trigger, trigger2_cb)
 
     rospy.spin()
 


### PR DESCRIPTION
Following the discussion in this [previous request](https://github.com/ros/ros_comm/pull/2036), This new pull request targets the latest branch `noetic-devel`.

This PR extends `rostest` tools for checking if:

* a service server provides appropriate reply for a given request
* a filter-like node generates and publishes appropriate message after having received a given message.

The usage is aligned with the other `rostest` tools:
For service test:

```xml
<test test-name="test_service" pkg="node_test" type="test_service" >
        <rosparam>
          calls:
            - name: /trigger_spec
              input: None
              output: {'success': True, 'message': 'well done!'}
        </rosparam>
</test>
```

For filter test:

```xml
<test test-name="test_service" pkg="node_test" type="test_service" >
    <rosparam>
      calls:
        - name: /add_two_ints
          input: {'a': 0, 'b': 5.0}
          output: {'sum': 5}
    </rosparam>      
 </test>
```

In both cases, Input and output are provided as a _python dictionnary_, and it is then converted to the appropriate message format using [rospy_message_converter](https://github.com/uos/rospy_message_converter).

More description is available at the repository [ros_node_test](https://github.com/tecnalia-advancedmanufacturing-robotics/ros_node_test) that I created before considering proposing that PR to the upstream respository.
