### PR TITLE
[melodic] Retry socket.recv() when interrupted (Python 2)

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -101,7 +101,13 @@ def recv_buff(sock, b, buff_size):
     @return: number of bytes read
     @rtype: int
     """
-    d = sock.recv(buff_size)
+    d = None
+    while not d and not rospy.is_shutdown():
+        try:
+            d = sock.recv(buff_size)
+        except socket.error as why:
+            if not why.args or why.args[0] != errno.EINTR:
+                raise
     if d:
         b.write(d)
         return len(d)

--- a/tools/rosgraph/src/rosgraph/network.py
+++ b/tools/rosgraph/src/rosgraph/network.py
@@ -40,6 +40,7 @@ are necessary for correctly retrieving local IP address
 information.
 """
 
+import errno
 import logging
 import os
 import socket
@@ -354,7 +355,13 @@ def read_ros_handshake_header(sock, b, buff_size):
     """
     header_str = None
     while not header_str:
-        d = sock.recv(buff_size)
+        d = None
+        while not d:
+          try:
+            d = sock.recv(buff_size)
+          except socket.error as why:
+              if not why.args or why.args[0] != errno.EINTR:
+                  raise
         if not d:
             raise ROSHandshakeException("connection from sender terminated before handshake header received. %s bytes were received. Please check sender for additional details."%b.tell())
         b.write(d)


### PR DESCRIPTION
When a signal handler is executed while rospy or rosgraph waits for
socket data, an exception is raised by socket.recv():

```
  [rospy.internal][ERROR] 2020-08-31 22:35:47,320: Traceback (most recent call last):
    File ".../lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 730, in receive_once
      self.stat_bytes += recv_buff(sock, b, p.buff_size)
    File ".../lib/python2.7/dist-packages/rospy/impl/tcpros_base.py", line 103, in recv_buff
      d = sock.recv(buff_size)
  error: [Errno 4] Interrupted system call
```

rospy does not catch the exception causing the program to crash. This,
in turn, causes other rospy nodes to crash with an exception "Connection
reset by peer".

However, this exception is not the sign of an error, it is a mechanism
to interrupt system calls so that the call site has a chance to react to
the reception of the signal. In the two modified call sites, recv()
should be retried unless ROS is existing (i.e. rospy.is_shutdown() == False).

After the application of this patch, rospy is more robust to receiving
signals when executing a system call. This is only a fix for the two
locations where we saw EINTR being raised frequently. A complete fix
would require extensive modification of rospy as many syscalls can
actually "fail" with EINTR, including open(), and close().

A full fix for this issue is outside the scope of this patch.

Note: PEP-475 (https://www.python.org/dev/peps/pep-0475/) proposes an
improvement preventing this issue. As such, this patch is not needed for
Python>=3.5.

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>