### PR TITLE
Fix log*_throttle with sim time

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -223,8 +223,9 @@ class LoggingThrottle(object):
               (now - last_logging_time) > rospy.Duration(period)):
             self.last_logging_time_table[caller_id] = now
             return True
-        elif (last_logging_time > now):
+        elif last_logging_time > now:
             self.last_logging_time_table = {}
+            self.last_logging_time_table[caller_id] = now
             return True
         return False
 

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -223,6 +223,9 @@ class LoggingThrottle(object):
               (now - last_logging_time) > rospy.Duration(period)):
             self.last_logging_time_table[caller_id] = now
             return True
+        elif (last_logging_time > now):
+            self.last_logging_time_table = {}
+            return True
         return False
 
 


### PR DESCRIPTION
When log*_throttle is used with bags or a simulation, logging stops when bag/simulation restarts. Solved this problem with resetting logging_time_table when ros time moved backward.

Testing code:
```py
import rospy

rospy.init_node('test_node')

while not rospy.is_shutdown():
    rospy.loginfo_throttle(100.0, "Throttled message!")
```