### PR TITLE
Add `filter` and `reduce` among the commands allowed in `$(eval)`

### DIFF
--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -302,7 +302,7 @@ def _arg(resolved, a, args, context):
 _eval_dict={
     'true': True, 'false': False,
     'True': True, 'False': False,
-    '__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'str', 'float', 'int']},
+    '__builtins__': {k: __builtins__[k] for k in ['list', 'dict', 'map', 'filter', 'reduce', 'str', 'float', 'int']},
     'env': _eval_env,
     'optenv': _eval_optenv,
     'find': _eval_find


### PR DESCRIPTION
`map` is already there and it seems to me that is makes sense to also add `filter` and `reduce`. They can be used with lambdas (verified with `map`).