### PR TITLE
Trap for overly large input to XmlRPCPP

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -458,7 +458,7 @@ XmlRpcClient::readHeader()
   return true;    // Continue monitoring this source
 }
 
-
+    
 bool
 XmlRpcClient::readResponse()
 {

--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -458,6 +458,7 @@ XmlRpcClient::readHeader()
   return true;    // Continue monitoring this source
 }
 
+
 bool
 XmlRpcClient::readResponse()
 {

--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -312,6 +312,13 @@ XmlRpcClient::generateRequest(const char* methodName, XmlRpcValue const& params)
                   header.length(), body.length());
 
   _request = header + body;
+  // Limit the size of the request to avoid integer overruns
+  if (_request.length() > size_t(__INT_MAX__)) {
+    XmlRpcUtil::error("XmlRpcClient::generateRequest: request length (%u) exceeds maximum allowed size (%u).",
+                      _request.length(), __INT_MAX__);
+    _request.clear();
+    return false;
+  }
   return true;
 }
 
@@ -431,13 +438,16 @@ XmlRpcClient::readHeader()
     return false;   // We could try to figure it out by parsing as we read, but for now...
   }
 
-  _contentLength = atoi(lp);
-  if (_contentLength <= 0) {
-    XmlRpcUtil::error("Error in XmlRpcClient::readHeader: Invalid Content-length specified (%d).", _contentLength);
+  // avoid overly large or improperly formatted content-length
+  long int clength = 0;
+  clength = strtol(lp, nullptr, 10);
+  if ((clength <= 0) || (clength > __INT_MAX__)) {
+    XmlRpcUtil::error("Error in XmlRpcClient::readHeader: Invalid Content-length specified.");
     // Close the socket because we can't make further use of it.
     close();
     return false;
   }
+  _contentLength = int(clength);
   	
   XmlRpcUtil::log(4, "client read content length: %d", _contentLength);
 
@@ -448,7 +458,6 @@ XmlRpcClient::readHeader()
   return true;    // Continue monitoring this source
 }
 
-    
 bool
 XmlRpcClient::readResponse()
 {
@@ -464,6 +473,14 @@ XmlRpcClient::readResponse()
     }
     _response += buff;
 
+    // Avoid an overly large response
+    if (_response.length() > size_t(__INT_MAX__)) {
+      XmlRpcUtil::error("XmlRpcClient::readResponse: response length (%u) exceeds the maximum allowed size (%u).",
+                        _response.length(), __INT_MAX__);
+      _response.clear();
+      close();
+      return false;
+    }
     // If we haven't gotten the entire _response yet, return (keep reading)
     if (int(_response.length()) < _contentLength) {
       if (_eof) {

--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -317,6 +317,13 @@ XmlRpcSocket::nbRead(int fd, std::string& s, bool *eof)
       return false;   // Error
     }
   }
+  // Watch for integer overrun
+  if (s.length() > size_t(__INT_MAX__)) {
+    XmlRpcUtil::error("XmlRpcSocket::nbRead: text size (%u) exceeds the maximum allowed size (%s).",
+                      s.length(), __INT_MAX__);
+    s.clear();
+    return false;
+  }
   return true;
 }
 
@@ -325,6 +332,12 @@ XmlRpcSocket::nbRead(int fd, std::string& s, bool *eof)
 bool
 XmlRpcSocket::nbWrite(int fd, const std::string& s, int *bytesSoFar)
 {
+  // Watch for integer overrun
+  if (s.length() > size_t(__INT_MAX__)) {
+    XmlRpcUtil::error("XmlRpcSocket::nbWrite: text size (%u) exceeds the maximum allowed size(%s)",
+                      s.length(), __INT_MAX__);
+    return false;
+  }
   int nToWrite = int(s.length()) - *bytesSoFar;
   char *sp = const_cast<char*>(s.c_str()) + *bytesSoFar;
   bool wouldBlock = false;

--- a/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
@@ -108,6 +108,8 @@ void XmlRpcUtil::error(const char* fmt, ...)
 std::string 
 XmlRpcUtil::parseTag(const char* tag, std::string const& xml, int* offset)
 {
+  // avoid attempting to parse overly long xml input
+  if (xml.length() > size_t(__INT_MAX__)) return std::string();
   if (*offset >= int(xml.length())) return std::string();
   size_t istart = xml.find(tag, *offset);
   if (istart == std::string::npos) return std::string();
@@ -126,6 +128,7 @@ XmlRpcUtil::parseTag(const char* tag, std::string const& xml, int* offset)
 bool 
 XmlRpcUtil::findTag(const char* tag, std::string const& xml, int* offset)
 {
+  if (xml.length() > size_t(__INT_MAX__)) return false;
   if (*offset >= int(xml.length())) return false;
   size_t istart = xml.find(tag, *offset);
   if (istart == std::string::npos)
@@ -141,6 +144,7 @@ XmlRpcUtil::findTag(const char* tag, std::string const& xml, int* offset)
 bool 
 XmlRpcUtil::nextTagIs(const char* tag, std::string const& xml, int* offset)
 {
+  if (xml.length() > size_t(__INT_MAX__)) return false;
   if (*offset >= int(xml.length())) return false;
   const char* cp = xml.c_str() + *offset;
   int nc = 0;
@@ -162,6 +166,7 @@ XmlRpcUtil::nextTagIs(const char* tag, std::string const& xml, int* offset)
 std::string 
 XmlRpcUtil::getNextTag(std::string const& xml, int* offset)
 {
+  if (xml.length() > size_t(__INT_MAX__)) return std::string();
   if (*offset >= int(xml.length())) return std::string();
 
   size_t pos = *offset;

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -27,8 +27,9 @@
 #include <stdlib.h>
 #include <string>
 
-#include "xmlrpcpp/XmlRpcValue.h"
 #include "xmlrpcpp/XmlRpcException.h"
+#include "xmlrpcpp/XmlRpcUtil.h"
+#include "xmlrpcpp/XmlRpcValue.h"
 
 #include <gtest/gtest.h>
 
@@ -172,6 +173,30 @@ TEST(XmlRpc, testString) {
   std::stringstream ss;
   ss << s;
   EXPECT_EQ("Now is the time <&", ss.str());
+}
+
+//Test decoding of a well-formed but overly large XML input
+TEST(XmlRpc, testOversizeString) {
+  std::string xml = "<tag><nexttag>";
+  xml += std::string(__INT_MAX__, 'a');
+  xml += "a</nextag></tag>";
+  int offset;
+
+  offset = 0;
+  EXPECT_EQ(XmlRpcUtil::parseTag("<tag>", xml, &offset), std::string());
+  EXPECT_EQ(offset, 0);
+
+  offset = 0;
+  EXPECT_FALSE(XmlRpcUtil::findTag("<tag>", xml, &offset));
+  EXPECT_EQ(offset, 0);
+
+  offset = 0;
+  EXPECT_FALSE(XmlRpcUtil::nextTagIs("<tag>", xml, &offset));
+  EXPECT_EQ(offset, 0);
+
+  offset = 0;
+  EXPECT_EQ(XmlRpcUtil::getNextTag(xml, &offset), std::string());
+  EXPECT_EQ(offset, 0);
 }
 
 TEST(XmlRpc, testDateTime) {

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -200,7 +200,11 @@ TEST(XmlRpc, testOversizeString) {
     EXPECT_EQ(offset, 0);
   }
   catch (std::bad_alloc& err) {
-    std::cerr << "[ SKIPPED  ] Unable to allocate memory for test testOversizeString\n";
+#ifdef GTEST_SKIP
+    GTEST_SKIP() << "Unable to allocate memory to run test\n";
+#else
+    std::cerr << "[ SKIPPED  ] XmlRpc.testOversizeString Unable to allocate memory to run test\n";
+#endif
   }
 }
 

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -27,9 +27,9 @@
 #include <stdlib.h>
 #include <string>
 
+#include "xmlrpcpp/XmlRpcValue.h"
 #include "xmlrpcpp/XmlRpcException.h"
 #include "xmlrpcpp/XmlRpcUtil.h"
-#include "xmlrpcpp/XmlRpcValue.h"
 
 #include <gtest/gtest.h>
 
@@ -177,26 +177,31 @@ TEST(XmlRpc, testString) {
 
 //Test decoding of a well-formed but overly large XML input
 TEST(XmlRpc, testOversizeString) {
-  std::string xml = "<tag><nexttag>";
-  xml += std::string(__INT_MAX__, 'a');
-  xml += "a</nextag></tag>";
-  int offset;
+  try {
+    std::string xml = "<tag><nexttag>";
+    xml += std::string(__INT_MAX__, 'a');
+    xml += "a</nextag></tag>";
+    int offset;
 
-  offset = 0;
-  EXPECT_EQ(XmlRpcUtil::parseTag("<tag>", xml, &offset), std::string());
-  EXPECT_EQ(offset, 0);
+    offset = 0;
+    EXPECT_EQ(XmlRpcUtil::parseTag("<tag>", xml, &offset), std::string());
+    EXPECT_EQ(offset, 0);
 
-  offset = 0;
-  EXPECT_FALSE(XmlRpcUtil::findTag("<tag>", xml, &offset));
-  EXPECT_EQ(offset, 0);
+    offset = 0;
+    EXPECT_FALSE(XmlRpcUtil::findTag("<tag>", xml, &offset));
+    EXPECT_EQ(offset, 0);
 
-  offset = 0;
-  EXPECT_FALSE(XmlRpcUtil::nextTagIs("<tag>", xml, &offset));
-  EXPECT_EQ(offset, 0);
+    offset = 0;
+    EXPECT_FALSE(XmlRpcUtil::nextTagIs("<tag>", xml, &offset));
+    EXPECT_EQ(offset, 0);
 
-  offset = 0;
-  EXPECT_EQ(XmlRpcUtil::getNextTag(xml, &offset), std::string());
-  EXPECT_EQ(offset, 0);
+    offset = 0;
+    EXPECT_EQ(XmlRpcUtil::getNextTag(xml, &offset), std::string());
+    EXPECT_EQ(offset, 0);
+  }
+  catch (std::bad_alloc& err) {
+    GTEST_SKIP() << "Unable to allocate memory for overflow tests\n";
+  }
 }
 
 TEST(XmlRpc, testDateTime) {

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -200,7 +200,7 @@ TEST(XmlRpc, testOversizeString) {
     EXPECT_EQ(offset, 0);
   }
   catch (std::bad_alloc& err) {
-    GTEST_SKIP() << "Unable to allocate memory for overflow tests\n";
+    std::cerr << "[ SKIPPED  ] Unable to allocate memory for test testOversizeString\n";
   }
 }
 

--- a/utilities/xmlrpcpp/test/test_client.cpp
+++ b/utilities/xmlrpcpp/test/test_client.cpp
@@ -494,20 +494,6 @@ TEST(XmlRpcClient, generateRequest) {
             a._request);
 }
 
-// create a request where content fits but the message will overflow and gets truncated
-TEST(XmlRpcClient, generateOversizeRequest) {
-  XmlRpcClientForTest a("localhost", 42);
-  // Gracefully skip this test if there's not enough memory to run it
-  try {
-    XmlRpcValue toolarge(std::string(__INT_MAX__ - 10, 'a'));
-    EXPECT_FALSE(a.generateRequest("DoFoo", toolarge));
-    EXPECT_EQ(a._request.length(), 0);
-  }
-  catch (std::bad_alloc& err) {
-    std::cerr << "[ SKIPPED  ] Unable to allocate memory for test generateOversizeRequest\n";
-  }
-}
-
 // Test generateHeader()
 //  Correct header is generated for various sizes and content of request body.
 TEST(XmlRpcClient, generateHeader) {

--- a/utilities/xmlrpcpp/test/test_client.cpp
+++ b/utilities/xmlrpcpp/test/test_client.cpp
@@ -504,7 +504,7 @@ TEST(XmlRpcClient, generateOversizeRequest) {
     EXPECT_EQ(a._request.length(), 0);
   }
   catch (std::bad_alloc& err) {
-    GTEST_SKIP() << "Unable to allocate memory for overflow test\n";
+    std::cerr << "[ SKIPPED  ] Unable to allocate memory for test generateOversizeRequest\n";
   }
 }
 
@@ -939,7 +939,7 @@ TEST_F(MockSocketTest, readHeader_partial_err) {
   Expect_close(8);
 }
 
-// Test to fail when content-length is too large
+// Test that the read will fail when content-length is too large
 TEST_F(MockSocketTest, readHeader_oversize) {
   XmlRpcClientForTest a("localhost", 42);
 
@@ -961,8 +961,6 @@ TEST_F(MockSocketTest, readHeader_oversize) {
   // Check that all expected function calls were made before destruction.
   CheckCalls();
 }
-
-
 
 // Test readResponse()
 //  Test read of response in a single read call
@@ -1133,42 +1131,6 @@ TEST_F(MockSocketTest, readResponse_eof) {
   // Check that all expected function calls were made before destruction.
   CheckCalls();
 }
-
-// Test that readResponse closes the socket and truncates the response when too
-// much data is received (even when content-length is legitimate)
-TEST_F(MockSocketTest, readResponse_oversize) {
-  XmlRpcClientForTest a("localhost", 42);
-
-  // Hack us into the correct initial state.
-  a.setfd(8);
-  a._connectionState = XmlRpcClientForTest::READ_RESPONSE;
-
-  try {
-    // Create an overflow response
-    std::string response = std::string(__INT_MAX__, 'a');
-    response += "a";
-
-    // Start with a pre-populated content-length that is within bounds
-    a._contentLength = __INT_MAX__;
-
-    // Expect to read the socket
-    Expect_nbRead(8, response, true, true);
-    // Expect the socket to close
-    Expect_close(8);
-
-    // Expect readResponse to return false because the response is too long, and
-    // truncate the response.
-    EXPECT_FALSE(a.readResponse());
-    EXPECT_EQ(a._response.size(), 0);
-
-    CheckCalls();
-  }
-  catch (std::bad_alloc& err) {
-    GTEST_SKIP() << "Unable to allocate memory for overflow test\n";
-  }
-
-}
-
 
 // Test parseResponse
 //  Test correct parsing of various response types: empty, int, double,


### PR DESCRIPTION
Oversize input to XmlRPCPP could cause problems with int <-> size_t conversions.

 - Recognize when incoming or outgoing data is too large, generate an error and discard the data when practical.
 - Use the safe strtol() rather than atoi() to decode an incoming content-length header and generate an error if the length is invalid or too large.
 - Prevent attempts to parse overly large XML input.
 - Add tests where they can reasonably be inserted into existing test routines.

Although this fix could be cleaner the update is written to make the update ABI compatible.

This fix addresses CVE-2020-16124 / Integer overflow in ros_comm.

Signed-off-by: Sid Faber <sid.faber@canonical.com>