### PR TITLE
[Melodic Backport] set call_finished_ with true for each call inside callFinished (#2074)

### DIFF
--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -262,6 +262,7 @@ void ServiceServerLink::callFinished()
 
     current_call_->finished_ = true;
     current_call_->finished_condition_.notify_all();
+    current_call_->call_finished_ = true;
 
     saved_call = current_call_;
     current_call_ = CallInfoPtr();


### PR DESCRIPTION
* set call_finished_ with true for each call inside callFinished

and also set current_call flags when failure happens

Signed-off-by: Chen Lihui <lihui.chen@sony.com>

* Update based on review

Co-authored-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>
Signed-off-by: Chen Lihui <lihui.chen@sony.com>

* set the flag with true again even if it is true already

Signed-off-by: Chen Lihui <lihui.chen@sony.com>

Co-authored-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>