### PR TITLE
Return the exit code a required process through roslaunch

### DIFF
--- a/test/test_roslaunch/test/exit_with_code.py
+++ b/test/test_roslaunch/test/exit_with_code.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2014, The Johns Hopkins University
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import rospy
+import sys
+
+
+if __name__ == '__main__':
+    rospy.init_node('exit_with_code', anonymous=True)
+    exit_code = rospy.get_param("~exit_code", 0)
+    sys.exit(exit_code)

--- a/test/test_roslaunch/test/roslaunch.test
+++ b/test/test_roslaunch/test/roslaunch.test
@@ -1,4 +1,5 @@
 <launch>
   <test test-name="roslaunch_command_line_online" pkg="test_roslaunch" type="test_roslaunch_command_line_online.py" />
   <test test-name="roslaunch_ros_args" pkg="test_roslaunch" type="test_roslaunch_ros_args.py" />
+  <test test-name="roslaunch_exit_code" pkg="test_roslaunch" type="test_roslaunch_exit_code.py" />
 </launch>

--- a/test/test_roslaunch/test/test_roslaunch_exit_code.py
+++ b/test/test_roslaunch/test/test_roslaunch_exit_code.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2009, Willow Garage, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Revision $Id: test_roslaunch_command_line_online.py 6411 2009-10-02 21:32:01Z kwc $
+
+PKG = 'roslaunch'
+NAME = 'test_roslaunch_exit_code'
+
+# import os
+import sys
+# import time
+import unittest
+# import yaml
+
+import rostest
+
+from subprocess import CalledProcessError, Popen, PIPE, check_call, call
+
+class TestRoslaunchExit(unittest.TestCase):
+
+    def setUp(self):
+        self.vals = set()
+        self.msgs = {}
+
+    def test_roslaunch(self):
+        # network is initialized
+        cmd = 'roslaunch'
+        exit_code = 37
+
+        check_call([cmd, 'test_roslaunch', 'exit.launch',
+                    'exit_code:={}'.format(0), 'required:=true'])
+
+        try:
+            check_call([cmd, 'test_roslaunch', 'exit.launch',
+                        'exit_code:={}'.format(exit_code), 'required:=true'])
+        except CalledProcessError as ex:
+            if ex.returncode != exit_code:
+                raise(ex)
+
+        check_call([cmd, 'test_roslaunch', 'exit.launch',
+                    'exit_code:={}'.format(0), 'required:=false'])
+        check_call([cmd, 'test_roslaunch', 'exit.launch',
+                    'exit_code:={}'.format(exit_code), 'required:=false'])
+
+
+if __name__ == '__main__':
+    rostest.run(PKG, NAME, TestRoslaunchExit, sys.argv)

--- a/test/test_roslaunch/test/test_roslaunch_exit_code.py
+++ b/test/test_roslaunch/test/test_roslaunch_exit_code.py
@@ -30,21 +30,16 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-#
-# Revision $Id: test_roslaunch_command_line_online.py 6411 2009-10-02 21:32:01Z kwc $
+
+import sys
+import unittest
+from subprocess import CalledProcessError, check_call
+
+import rostest
 
 PKG = 'roslaunch'
 NAME = 'test_roslaunch_exit_code'
 
-# import os
-import sys
-# import time
-import unittest
-# import yaml
-
-import rostest
-
-from subprocess import CalledProcessError, Popen, PIPE, check_call, call
 
 class TestRoslaunchExit(unittest.TestCase):
 

--- a/test/test_roslaunch/test/xml/exit.launch
+++ b/test/test_roslaunch/test/xml/exit.launch
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="required" default="true"
+      doc="make the node here cause the launch to exit with the exit code of the required process" />
+  <arg name="exit_code" default="0" doc="exit with this code" />
+  <!-- roslaunch file that loads no nodes, and thus should exit immediately -->
+  <node name="exit_with_code" pkg="test_roslaunch" type="exit_with_code.py" required="$(arg required)" >
+    <param name="exit_code" value="$(arg exit_code)" />
+  </node>
+</launch>

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -304,7 +304,7 @@ def main(argv=sys.argv):
         logger.info("roslaunch env is %s"%os.environ)
             
         if options.child_name:
-            logger.info('starting in child mode {}'.format(options.child_name))
+            logger.info('starting {} in child mode'.format(options.child_name))
 
             # This is a roslaunch child, spin up client server.
             # client spins up an XML-RPC server that waits for
@@ -315,7 +315,7 @@ def main(argv=sys.argv):
                                                sigterm_timeout=options.sigterm_timeout)
             c.run()
             exit_code = c.exit_code
-            logger.warn('child node {} done {}'.format(options.child_name, exit_code))
+            logger.debug('child node {} done {}'.format(options.child_name, exit_code))
         else:
             logger.info('starting in server mode')
 
@@ -350,7 +350,6 @@ def main(argv=sys.argv):
             p.start()
             p.spin()
             exit_code = p.exit_code
-            print('ending server mode {}'.format(exit_code))
 
     except RLException as e:
         handle_exception(roslaunch_core, logger, "RLException: ", e)
@@ -368,7 +367,6 @@ def main(argv=sys.argv):
             try: os.unlink(options.pid_fn)
             except os.error: pass
 
-    print('exiting from main() {}'.format(exit_code))
     sys.exit(exit_code)
 
 if __name__ == '__main__':

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -250,6 +250,7 @@ def handle_exception(roslaunch_core, logger, msg, e):
 def main(argv=sys.argv):
     options = None
     logger = None
+    exit_code = 0
     try:
         from . import rlutil
         parser = _get_optparse()
@@ -303,7 +304,7 @@ def main(argv=sys.argv):
         logger.info("roslaunch env is %s"%os.environ)
             
         if options.child_name:
-            logger.info('starting in child mode')
+            logger.info('starting in child mode {}'.format(options.child_name))
 
             # This is a roslaunch child, spin up client server.
             # client spins up an XML-RPC server that waits for
@@ -313,6 +314,8 @@ def main(argv=sys.argv):
                                                sigint_timeout=options.sigint_timeout,
                                                sigterm_timeout=options.sigterm_timeout)
             c.run()
+            exit_code = c.exit_code
+            logger.warn('child node {} done {}'.format(options.child_name, exit_code))
         else:
             logger.info('starting in server mode')
 
@@ -346,6 +349,8 @@ def main(argv=sys.argv):
                     sigterm_timeout=options.sigterm_timeout)
             p.start()
             p.spin()
+            exit_code = p.exit_code
+            print('ending server mode {}'.format(exit_code))
 
     except RLException as e:
         handle_exception(roslaunch_core, logger, "RLException: ", e)
@@ -363,6 +368,8 @@ def main(argv=sys.argv):
             try: os.unlink(options.pid_fn)
             except os.error: pass
 
+    print('exiting from main() {}'.format(exit_code))
+    sys.exit(exit_code)
 
 if __name__ == '__main__':
     main()

--- a/tools/roslaunch/src/roslaunch/child.py
+++ b/tools/roslaunch/src/roslaunch/child.py
@@ -85,6 +85,7 @@ class ROSLaunchChild(object):
         self.pm = None
         self.sigint_timeout = sigint_timeout
         self.sigterm_timeout = sigterm_timeout
+        self.exit_code = 0
 
         roslaunch.pmon._init_signal_handlers()
 
@@ -126,6 +127,7 @@ class ROSLaunchChild(object):
             if self.pm:
                 self.pm.shutdown()
                 self.pm.join()
+                self.exit_code = self.pm.exit_code
             if self.child_server:
                 self.child_server.shutdown('roslaunch child complete')
 
@@ -133,3 +135,4 @@ class ROSLaunchChild(object):
         if self.pm:
             self.pm.shutdown()
             self.pm.join()
+            self.exit_code = self.pm.exit_code

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -292,6 +292,7 @@ class ROSLaunchRunner(object):
         self.is_child = is_child
         self.is_core = is_core
         self.is_rostest = is_rostest
+        self.exit_code = 0
         self.num_workers = num_workers
         self.timeout = timeout
         self.master_logger_level = master_logger_level
@@ -618,7 +619,7 @@ class ROSLaunchRunner(object):
         #self.pm.join()
         self.logger.info("process monitor is done spinning, initiating full shutdown")
         self.stop()
-        printlog_bold("done")
+        printlog_bold("roslaunch runner done")
     
     def stop(self):
         """
@@ -629,6 +630,7 @@ class ROSLaunchRunner(object):
             printlog("shutting down processing monitor...")
             self.logger.info("shutting down processing monitor %s"%self.pm)            
             self.pm.shutdown()
+            self.exit_code = self.pm.exit_code
             self.pm.join()
             self.pm = None
             printlog("... shutting down processing monitor complete")

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -619,7 +619,7 @@ class ROSLaunchRunner(object):
         #self.pm.join()
         self.logger.info("process monitor is done spinning, initiating full shutdown")
         self.stop()
-        printlog_bold("roslaunch runner done")
+        printlog_bold("done")
     
     def stop(self):
         """

--- a/tools/roslaunch/src/roslaunch/parent.py
+++ b/tools/roslaunch/src/roslaunch/parent.py
@@ -151,6 +151,7 @@ class ROSLaunchParent(object):
         self._shutting_down = False
         
         self.config = self.runner = self.server = self.pm = self.remote_runner = None
+        self.exit_code = 0
 
     def _load_config(self):
         self.config = roslaunch.config.load_config_default(self.roslaunch_files, self.port,
@@ -286,6 +287,7 @@ class ROSLaunchParent(object):
         if self.pm:
             self.pm.shutdown()
             self.pm.join()
+            self.exit_code = self.pm.exit_code
         
     def start(self, auto_terminate=True):
         """

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -312,6 +312,7 @@ class ProcessMonitor(Thread):
         self.procs = []
         self.plock = RLock()
         self.is_shutdown = False
+        self.exit_code = 0
         self.done = False        
         self.daemon = True
         self.reacquire_signals = set()
@@ -566,6 +567,10 @@ class ProcessMonitor(Thread):
                         if p.required:
                             printerrlog('='*80+"REQUIRED process [%s] has died!\n%s\nInitiating shutdown!\n"%(p.name, exit_code_str)+'='*80)
                             self.is_shutdown = True
+                            if p.exit_code != 0:
+                                msg = 'Going to exit due to code {}'.format(p.exit_code)
+                                printerrlog(msg)
+                                self.exit_code = p.exit_code
                         elif not p in respawn:
                             if p.exit_code:
                                 printerrlog("[%s] %s"%(p.name, exit_code_str))

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -568,7 +568,9 @@ class ProcessMonitor(Thread):
                             printerrlog('='*80+"REQUIRED process [%s] has died!\n%s\nInitiating shutdown!\n"%(p.name, exit_code_str)+'='*80)
                             self.is_shutdown = True
                             if p.exit_code != 0:
-                                msg = 'Going to exit due to code {}'.format(p.exit_code)
+                                msg = 'Going to exit due to non-zero exit code ({})'.format(p.exit_code)
+                                msg += 'of required process {}'.format(p.name)
+
                                 printerrlog(msg)
                                 self.exit_code = p.exit_code
                         elif not p in respawn:

--- a/tools/roslaunch/test/unit/test_roslaunch_child.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_child.py
@@ -53,6 +53,7 @@ class ProcessMonitorMock(object):
         self.core_procs = []
         self.procs = []
         self.listeners = []
+        self.exit_code = 0
         
     def join(self, timeout=0):
         pass

--- a/tools/roslaunch/test/unit/test_roslaunch_parent.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_parent.py
@@ -59,6 +59,7 @@ class ProcessMonitorMock(object):
         self.procs = []
         self.listeners = []
         self.is_shutdown = False
+        self.exit_code = 0
         
     def join(self, timeout=0):
         pass


### PR DESCRIPTION
Return the exit code to the caller of a required process at least for a regular parent launch process, child and remote processes need looking at.

May solve https://github.com/ros/ros_comm/issues/919