### PR TITLE
Changes between 1.14.9 and 1.14.10 for backporting to Kinetic

### DIFF
--- a/clients/roscpp/include/ros/param.h
+++ b/clients/roscpp/include/ros/param.h
@@ -591,6 +591,17 @@ ROSCPP_DECL bool search(const std::string& key, std::string& result);
  */
 ROSCPP_DECL bool getParamNames(std::vector<std::string>& keys);
 
+/**
+ * \brief Unsubscribe cached parameter from the master
+ * \param key the cached parameter to be unsubscribed
+ */
+ROSCPP_DECL void unsubscribeCachedParam(const std::string& key);
+
+/**
+ * \brief Unsubscribe all cached parameter from the master
+ */
+ROSCPP_DECL void unsubscribeCachedParam(void);
+
 /** \brief Assign value from parameter server, with default.
  *
  * This method tries to retrieve the indicated parameter value from the

--- a/clients/roscpp/package.xml
+++ b/clients/roscpp/package.xml
@@ -12,7 +12,9 @@
     roscpp is the most widely used ROS client library and is designed to
     be the high-performance library for ROS.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/roscpp</url>
@@ -20,6 +22,7 @@
   <author>Josh Faust</author>
   <author>Brian Gerkey</author>
   <author>Troy Straszheim</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 

--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -232,7 +232,11 @@ bool del(const std::string& key)
   {
     boost::mutex::scoped_lock lock(g_params_mutex);
 
-    g_subscribed_params.erase(mapped_key);
+    if (g_subscribed_params.find(mapped_key) != g_subscribed_params.end())
+    {
+      g_subscribed_params.erase(mapped_key);
+      unsubscribeCachedParam(mapped_key);
+    }
     g_params.erase(mapped_key);
   }
 
@@ -805,6 +809,28 @@ void paramUpdateCallback(XmlRpc::XmlRpcValue& params, XmlRpc::XmlRpcValue& resul
   result[2] = 0;
 
   ros::param::update((std::string)params[1], params[2]);
+}
+
+void unsubscribeCachedParam(const std::string& key)
+{
+  XmlRpc::XmlRpcValue params, result, payload;
+  params[0] = this_node::getName();
+  params[1] = XMLRPCManager::instance()->getServerURI();
+  params[2] = key;
+  master::execute("unsubscribeParam", params, result, payload, false);
+}
+
+void unsubscribeCachedParam(void)
+{
+  // lock required, all of the cached parameter will be unsubscribed.
+  boost::mutex::scoped_lock lock(g_params_mutex);
+
+  for(S_string::iterator itr = g_subscribed_params.begin();
+    itr != g_subscribed_params.end(); ++itr)
+  {
+    const std::string mapped_key(*itr);
+    unsubscribeCachedParam(mapped_key);
+  }
 }
 
 void init(const M_string& remappings)

--- a/clients/roscpp/src/libros/rosout_appender.cpp
+++ b/clients/roscpp/src/libros/rosout_appender.cpp
@@ -128,7 +128,10 @@ void ROSOutAppender::logThread()
         return;
       }
 
-      queue_condition_.wait(lock);
+      if (log_queue_.empty())
+      {
+        queue_condition_.wait(lock);
+      }
 
       if (shutting_down_)
       {

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -262,6 +262,7 @@ void ServiceServerLink::callFinished()
 
     current_call_->finished_ = true;
     current_call_->finished_condition_.notify_all();
+    current_call_->call_finished_ = true;
 
     saved_call = current_call_;
     current_call_ = CallInfoPtr();

--- a/clients/roscpp/src/libros/xmlrpc_manager.cpp
+++ b/clients/roscpp/src/libros/xmlrpc_manager.cpp
@@ -139,6 +139,9 @@ void XMLRPCManager::shutdown()
     return;
   }
 
+  // before shutting down, unsubscribe all the cached parameter
+  ros::param::unsubscribeCachedParam();
+
   shutting_down_ = true;
   server_thread_.join();
 

--- a/clients/rospy/package.xml
+++ b/clients/rospy/package.xml
@@ -19,11 +19,14 @@
     and <a href="http://ros.org/wiki/rosservice">rosservice</a>, are
     built on top of rospy.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rospy</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -176,6 +176,10 @@ class LoggingThrottle(object):
               (now - last_logging_time) > rospy.Duration(period)):
             logging_func(msg)
             self.last_logging_time_table[caller_id] = now
+        elif last_logging_time > now:
+            logging_func(msg)
+            self.last_logging_time_table = {}
+            self.last_logging_time_table[caller_id] = now
 
 
 _logging_throttle = LoggingThrottle()

--- a/clients/rospy/src/rospy/msproxy.py
+++ b/clients/rospy/src/rospy/msproxy.py
@@ -144,8 +144,14 @@ class MasterProxy(object):
         @param val: parameter value
         @type val: XMLRPC legal value
         """
+        resolved_key = rospy.names.resolve_name(key)
+
         with self._lock:
-            self.target.setParam(rospy.names.get_caller_id(), rospy.names.resolve_name(key), val)
+            self.target.setParam(rospy.names.get_caller_id(), resolved_key, val)
+        try:
+            rospy.impl.paramserver.get_param_server_cache().update(resolved_key, val)
+        except KeyError:
+            pass
         
     def search_param(self, key):
         """

--- a/ros_comm/package.xml
+++ b/ros_comm/package.xml
@@ -4,7 +4,9 @@
   <description>
     ROS communications-related packages, including core client libraries (roscpp, rospy) and graph introspection tools (rostopic, rosnode, rosservice, rosparam).
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://www.ros.org/wiki/ros_comm</url>
@@ -20,6 +22,7 @@
   <author email="bhaskara@willowgarage.com">Bhaskara Marthi</author>
   <author email="straszheim@willowgarage.com">Troy Straszheim</author>
   <author email="wheeler@willowgarage.com">Rob Wheeler</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/test/test_rosbag/CMakeLists.txt
+++ b/test/test_rosbag/CMakeLists.txt
@@ -50,6 +50,8 @@ if(CATKIN_ENABLE_TESTING)
   add_rostest(${PROJECT_BINARY_DIR}/test/latched_sub.test)
   add_rostest(test/record_two_publishers.test)
   add_rostest(test/record_one_publisher_two_topics.test)
+  add_rostest(test/record_sigint_cleanup.test)
+  add_rostest(test/record_sigterm_cleanup.test)
 
   include_directories(${GTEST_INCLUDE_DIRS})
   add_executable(double_pub EXCLUDE_FROM_ALL test/double_pub.cpp)

--- a/test/test_rosbag/package.xml
+++ b/test/test_rosbag/package.xml
@@ -4,13 +4,16 @@
   <description>
     A package containing the unit tests for rosbag.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosbag</url>
   <author>Tim Field</author>
   <author>Jeremy Leibs</author>
   <author>James Bowman</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_rosbag/test/record_sigint_cleanup.py
+++ b/test/test_rosbag/test/record_sigint_cleanup.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020 Amazon.com, Inc. or its affiliates.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import roslib
+roslib.load_manifest('rosbag')
+
+import os
+import unittest
+import rostest
+import sys
+import signal
+from record_signal_cleanup_helper import test_signal_cleanup
+
+TEST_BAG_FILE_NAME = '/tmp/record_sigint_cleanup_test.bag'
+
+class RecordSigintCleanup(unittest.TestCase):
+
+  def test_sigint_cleanup(self):
+    """
+    Test that rosbag cleans up after handling SIGINT
+    """
+    test_signal_cleanup(TEST_BAG_FILE_NAME, signal.SIGINT)
+
+    # check that the recorded file is no longer active
+    self.assertTrue(os.path.isfile(TEST_BAG_FILE_NAME))
+    self.assertFalse(os.path.isfile(TEST_BAG_FILE_NAME+ '.active'))
+
+
+if __name__ == '__main__':
+  rostest.unitrun('test_rosbag', 'test_sigint_cleanup', RecordSigintCleanup, sys.argv)

--- a/test/test_rosbag/test/record_sigint_cleanup.test
+++ b/test/test_rosbag/test/record_sigint_cleanup.test
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub1"
+        args="pub -r 10 chatter std_msgs/String chatter1"/>
+  <test test-name="test_sigint_cleanup" pkg="test_rosbag" type="record_sigint_cleanup.py"/>
+</launch>

--- a/test/test_rosbag/test/record_signal_cleanup_helper.py
+++ b/test/test_rosbag/test/record_signal_cleanup_helper.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020 Amazon.com, Inc. or its affiliates.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import time
+import subprocess
+
+RECORD_COMMAND = ['rosbag',
+                  'record',
+                  'chatter',
+                  '-O',
+                  '--duration=5']
+SLEEP_TIME_SEC = 10
+
+def test_signal_cleanup(test_bag_file_name, test_signal):
+    """
+    Run rosbag record and send a signal to it after some time.
+
+    :param test_bag_file_name: bag name for recorded output
+    :param test_signal: signal to send to rosbag
+    """
+    test_command = list(RECORD_COMMAND)
+    test_command.insert(4, test_bag_file_name)
+
+    p = subprocess.Popen(test_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # wait while the recorder creates a bag for us to examine
+    time.sleep(SLEEP_TIME_SEC)
+    p.send_signal(test_signal)
+    p.wait()

--- a/test/test_rosbag/test/record_sigterm_cleanup.py
+++ b/test/test_rosbag/test/record_sigterm_cleanup.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020 Amazon.com, Inc. or its affiliates.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of Willow Garage, Inc. nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import roslib
+roslib.load_manifest('rosbag')
+
+import os
+import unittest
+import rostest
+import sys
+import signal
+from record_signal_cleanup_helper import test_signal_cleanup
+
+TEST_BAG_FILE_NAME = '/tmp/record_sigterm_cleanup_test.bag'
+
+class RecordSigtermCleanup(unittest.TestCase):
+
+  def test_sigterm_cleanup(self):
+    """
+    Test that rosbag cleans up after handling SIGTERM
+    """
+    test_signal_cleanup(TEST_BAG_FILE_NAME, signal.SIGTERM)
+
+    # check that the recorded file is no longer active
+    self.assertTrue(os.path.isfile(TEST_BAG_FILE_NAME))
+    self.assertFalse(os.path.isfile(TEST_BAG_FILE_NAME+ '.active'))
+
+
+if __name__ == '__main__':
+  rostest.unitrun('test_rosbag', 'test_sigterm_cleanup', RecordSigtermCleanup, sys.argv)

--- a/test/test_rosbag/test/record_sigterm_cleanup.test
+++ b/test/test_rosbag/test/record_sigterm_cleanup.test
@@ -1,0 +1,5 @@
+<launch>
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub1"
+        args="pub -r 10 chatter std_msgs/String chatter1"/>
+  <test test-name="test_sigterm_cleanup" pkg="test_rosbag" type="record_sigterm_cleanup.py"/>
+</launch>

--- a/test/test_rosbag_storage/package.xml
+++ b/test/test_rosbag_storage/package.xml
@@ -4,8 +4,11 @@
   <description>
     A package containing the unit tests for rosbag_storage.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/test/test_roscpp/package.xml
+++ b/test/test_roscpp/package.xml
@@ -4,7 +4,9 @@
   <description>
     Tests for roscpp which depend on rostest.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/roscpp</url>
@@ -12,6 +14,7 @@
   <author>Josh Faust</author>
   <author>Brian Gerkey</author>
   <author>Troy Straszheim</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_rosgraph/package.xml
+++ b/test/test_rosgraph/package.xml
@@ -4,11 +4,14 @@
   <description>
     Tests for rosgraph which depend on rostest.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosgraph</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_roslaunch/package.xml
+++ b/test/test_roslaunch/package.xml
@@ -4,11 +4,14 @@
   <description>
     Tests for roslaunch which depend on rostest.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/roslaunch</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_roslib_comm/package.xml
+++ b/test/test_roslib_comm/package.xml
@@ -4,12 +4,15 @@
   <description>
     Unit tests verifying that roslib is operating as expected.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/roslib</url>
   <author>Jeremy Leibs</author>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_rosmaster/package.xml
+++ b/test/test_rosmaster/package.xml
@@ -4,11 +4,14 @@
   <description>
     Tests for rosmaster which depend on rostest.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosmaster</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_rosparam/package.xml
+++ b/test/test_rosparam/package.xml
@@ -4,11 +4,14 @@
   <description>
     A package containing the unit tests for rosparam.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosparam</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_rosparam/test/test_dump.yaml
+++ b/test/test_rosparam/test/test_dump.yaml
@@ -1,1 +1,1 @@
-{foo: bar}
+foo: bar

--- a/test/test_rospy/package.xml
+++ b/test/test_rospy/package.xml
@@ -4,11 +4,14 @@
   <description>
     rospy unit and integration test framework.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rospy</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_rosservice/package.xml
+++ b/test/test_rosservice/package.xml
@@ -4,11 +4,14 @@
   <description>
     Tests for the rosservice tool.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosservice</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/test/test_rostopic/package.xml
+++ b/test/test_rostopic/package.xml
@@ -4,11 +4,14 @@
   <description>
     Tests for rostopic.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rostopic</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/tools/rosbag/package.xml
+++ b/tools/rosbag/package.xml
@@ -6,13 +6,16 @@
     topics.  It is intended to be high performance and avoids
     deserialization and reserialization of the messages. 
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosbag</url>
   <author>Tim Field</author>
   <author>Jeremy Leibs</author>
   <author>James Bowman</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -36,6 +36,7 @@
 #include "rosbag/exceptions.h"
 
 #include "boost/program_options.hpp"
+#include <signal.h>
 #include <string>
 #include <sstream>
 
@@ -273,8 +274,21 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     return opts;
 }
 
+/**
+ * Handle SIGTERM to allow the recorder to cleanup by requesting a shutdown.
+ * \param signal
+ */
+void signal_handler(int signal)
+{
+  (void) signal;
+  ros::requestShutdown();
+}
+
 int main(int argc, char** argv) {
     ros::init(argc, argv, "record", ros::init_options::AnonymousName);
+
+    // handle SIGTERM signals
+    signal(SIGTERM, signal_handler);
 
     // Parse the command-line options
     rosbag::RecorderOptions opts;

--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -72,6 +72,12 @@ def _stop_process(signum, frame, old_handler, process):
         old_handler(signum, frame)
 
 
+def _send_process_sigint(signum, frame, old_handler, process):
+    process.send_signal(signal.SIGINT)
+    if old_handler:
+        old_handler(signum, frame)
+
+
 def record_cmd(argv):
     parser = optparse.OptionParser(usage="rosbag record TOPIC1 [TOPIC2 TOPIC3 ...]",
                                    description="Record a bag file with the contents of specified topics.",
@@ -139,6 +145,12 @@ def record_cmd(argv):
         signal.SIGTERM,
         lambda signum, frame: _stop_process(signum, frame, old_handler, process)
     )
+
+    old_handler = signal.signal(
+        signal.SIGINT,
+        lambda signum, frame: _send_process_sigint(signum, frame, old_handler, process)
+    )
+
     # Better way of handling it than os.execv
     # This makes sure stdin handles are passed to the process.
     process = subprocess.Popen(cmd)

--- a/tools/rosbag_storage/package.xml
+++ b/tools/rosbag_storage/package.xml
@@ -5,8 +5,11 @@
     This is a set of tools for recording from and playing back ROS
     message without relying on the ROS client library.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/tools/rosgraph/package.xml
+++ b/tools/rosgraph/package.xml
@@ -6,11 +6,14 @@
     information about the ROS Computation Graph. It also provides an
     internal library that can be used by graphical tools.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosgraph</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 

--- a/tools/roslaunch/package.xml
+++ b/tools/roslaunch/package.xml
@@ -12,11 +12,14 @@
     specify the parameters to set and nodes to launch, as well as the
     machines that they should be run on.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/roslaunch</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 

--- a/tools/roslaunch/src/roslaunch/server.py
+++ b/tools/roslaunch/src/roslaunch/server.py
@@ -394,7 +394,7 @@ class ROSLaunchNode(xmlrpc.XmlRpcNode):
             raise RLException("""Unable to contact my own server at [%s].
 This usually means that the network is not configured properly.
 
-A common cause is that the machine cannot ping itself.  Please check
+A common cause is that the machine cannot connect to itself.  Please check
 for errors by running:
 
 \tping %s

--- a/tools/rosmaster/package.xml
+++ b/tools/rosmaster/package.xml
@@ -4,11 +4,14 @@
   <description>
     ROS <a href="http://ros.org/wiki/Master">Master</a> implementation.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosmaster</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/tools/rosmaster/src/rosmaster/master_api.py
+++ b/tools/rosmaster/src/rosmaster/master_api.py
@@ -462,6 +462,7 @@ class ROSMasterHandler(object):
             val = self.param_server.subscribe_param(key, (caller_id, caller_api))
         finally:
             self.ps_lock.release()
+        mloginfo("+CACHEDPARAM [%s] by %s",key, caller_id)
         return 1, "Subscribed to parameter [%s]"%key, val
 
     @apivalidate(0, (is_api('caller_api'), non_empty_str('key'),))
@@ -486,6 +487,7 @@ class ROSMasterHandler(object):
             retval = self.param_server.unsubscribe_param(key, (caller_id, caller_api))
         finally:
             self.ps_lock.release()
+        mloginfo("-CACHEDPARAM [%s] by %s",key, caller_id)
         return 1, "Unsubscribe to parameter [%s]"%key, 1
 
 

--- a/tools/rosmsg/package.xml
+++ b/tools/rosmsg/package.xml
@@ -10,12 +10,15 @@
     information about <a href="http://www.ros.org/wiki/srv">ROS
     Service types</a>.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosmsg</url>
   <author>Ken Conley</author>
   <author>Tully Foote</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/tools/rosnode/package.xml
+++ b/tools/rosnode/package.xml
@@ -8,11 +8,14 @@
     contains an experimental library for retrieving node
     information. This library is intended for internal use only.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosnode</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -291,7 +291,7 @@ def rosnode_listnodes(namespace=None, list_uri=False, list_all=False):
     """
     print(_sub_rosnode_listnodes(namespace=namespace, list_uri=list_uri, list_all=list_all))
     
-def rosnode_ping(node_name, max_count=None, verbose=False):
+def rosnode_ping(node_name, max_count=None, verbose=False, skip_cache=False):
     """
     Test connectivity to node by calling its XMLRPC API
     @param node_name: name of node to ping
@@ -300,12 +300,14 @@ def rosnode_ping(node_name, max_count=None, verbose=False):
     @type  max_count: int
     @param verbose: print ping information to screen
     @type  verbose: bool
+    @param skip_cache: flag to skip cached data and force to lookup from master
+    @type  skip_cache: bool
     @return: True if node pinged
     @rtype: bool
     @raise ROSNodeIOException: if unable to communicate with master
     """
     master = rosgraph.Master(ID)
-    node_api = get_api_uri(master,node_name)
+    node_api = get_api_uri(master, node_name, skip_cache=skip_cache)
     if not node_api:
         print("cannot ping [%s]: unknown node"%node_name, file=sys.stderr)
         return False
@@ -372,7 +374,7 @@ def rosnode_ping(node_name, max_count=None, verbose=False):
         print("ping average: %fms"%(acc/count))
     return True
 
-def rosnode_ping_all(verbose=False):
+def rosnode_ping_all(verbose=False, skip_cache=False):
     """
     Ping all running nodes
     @return [str], [str]: pinged nodes, un-pingable nodes
@@ -394,7 +396,7 @@ def rosnode_ping_all(verbose=False):
     pinged = []
     unpinged = []
     for node in nodes:
-        if rosnode_ping(node, max_count=1, verbose=verbose):
+        if rosnode_ping(node, max_count=1, verbose=verbose, skip_cache=skip_cache):
             pinged.append(node)
         else:
             unpinged.append(node)

--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -404,7 +404,7 @@ def rosnode_ping_all(verbose=False, skip_cache=False):
     
 def cleanup_master_blacklist(master, blacklist):
     """
-    Remove registrations from ROS Master that match blacklist.    
+    Remove registrations from ROS Master and node cache (_caller_apis) that match blacklist.    
     @param master: rosgraph Master instance
     @type  master: rosgraph.Master
     @param blacklist: list of nodes to scrub
@@ -427,6 +427,7 @@ def cleanup_master_blacklist(master, blacklist):
                 service_api = master.lookupService(s)
                 master_n = rosgraph.Master(n)
                 master_n.unregisterService(s, service_api)
+        _caller_apis.pop(n, None)
 
 def cleanup_master_whitelist(master, whitelist):
     """

--- a/tools/rosout/package.xml
+++ b/tools/rosout/package.xml
@@ -4,11 +4,14 @@
   <description>
      System-wide logging mechanism for messages sent to the /rosout topic.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosout</url>
   <author>Josh Faust</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/tools/rosparam/package.xml
+++ b/tools/rosparam/package.xml
@@ -11,11 +11,14 @@
 
     rosparam can be invoked within a <a href="http://www.ros.org/wiki/roslaunch">roslaunch</a> file.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosparam</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/tools/rosservice/package.xml
+++ b/tools/rosservice/package.xml
@@ -9,11 +9,14 @@
     Services and dynamically invoking them. The Python library is
     experimental and is for internal-use only.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rosservice</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 

--- a/tools/rostest/nodes/paramtest
+++ b/tools/rostest/nodes/paramtest
@@ -90,7 +90,7 @@ class ParamTest(unittest.TestCase):
 
         wallclock_timeout_t = time.time() + wait_time
         param_obtained = None
-        while not param_obtained and time.time() < wallclock_timeout_t:
+        while param_obtained is None and time.time() < wallclock_timeout_t:
             try:
                 param_obtained = rospy.get_param(testattr_paramname_target)
             except KeyError as e:

--- a/tools/rostest/package.xml
+++ b/tools/rostest/package.xml
@@ -4,11 +4,14 @@
   <description>
      Integration test suite based on roslaunch that is compatible with xUnit frameworks.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rostest</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.7.9">catkin</buildtool_depend>
 

--- a/tools/rostopic/package.xml
+++ b/tools/rostopic/package.xml
@@ -13,11 +13,14 @@
     examples of how to implement dynamic subscription and publication
     behaviors in ROS.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/rostopic</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 

--- a/tools/topic_tools/package.xml
+++ b/tools/topic_tools/package.xml
@@ -8,12 +8,15 @@
     tools deal with messages as generic binary blobs. This means they can be
     applied to any ROS topic.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/topic_tools</url>
   <author>Morgan Quigley</author>
   <author>Brian Gerkey</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.78">catkin</buildtool_depend>
 

--- a/utilities/message_filters/package.xml
+++ b/utilities/message_filters/package.xml
@@ -4,13 +4,16 @@
   <description>
     A set of message filters which take in messages and may output those messages at a later time, based on the conditions that filter needs met.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/message_filters</url>
 
   <author>Josh Faust</author>
   <author>Vijay Pradeep</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/utilities/roslz4/package.xml
+++ b/utilities/roslz4/package.xml
@@ -7,8 +7,9 @@
     streams are split into blocks which are compressed using the very fast LZ4
     compression algorithm.
   </description>
-
-  <maintainer email="bcharrow@seas.upenn.edu">Ben Charrow</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
   <author email="bcharrow@seas.upenn.edu">Ben Charrow</author>
 

--- a/utilities/roswtf/package.xml
+++ b/utilities/roswtf/package.xml
@@ -4,11 +4,14 @@
   <description>
      roswtf is a tool for diagnosing issues with a running ROS system. Think of it as a FAQ implemented in code.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>BSD</license>
 
   <url>http://ros.org/wiki/roswtf</url>
   <author>Ken Conley</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend version_gte="0.5.68">catkin</buildtool_depend>
 

--- a/utilities/xmlrpcpp/package.xml
+++ b/utilities/xmlrpcpp/package.xml
@@ -7,13 +7,17 @@
     support roscpp's threading model. As such, we are maintaining our
     own fork.
   </description>
-  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
+  <maintainer email="michael@openrobotics.org">Michael Carroll</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <license>LGPL-2.1</license>
 
   <url>http://xmlrpcpp.sourceforge.net</url>
   <author>Chris Morley</author>
   <author>Konstantin Pilipchuk</author>
   <author>Morgan Quigley</author>
+  <author>Austin Hendrix</author>
+  <author email="dthomas@osrfoundation.org">Dirk Thomas</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
@@ -119,11 +119,14 @@ XmlRpcServerConnection::readHeader()
     return false;   // We could try to figure it out by parsing as we read, but for now...
   }
 
-  _contentLength = atoi(lp);
-  if (_contentLength <= 0) {
-    XmlRpcUtil::error("XmlRpcServerConnection::readHeader: Invalid Content-length specified (%d).", _contentLength);
+  // avoid overly large or improperly formatted content-length
+  long int clength = 0;
+  clength = strtol(lp, NULL, 10);
+  if ((clength < 0) || (clength > __INT_MAX__)) {
+    XmlRpcUtil::error("XmlRpcServerConnection::readHeader: Invalid Content-length specified.");
     return false;
   }
+  _contentLength = int(clength);
   	
   XmlRpcUtil::log(3, "XmlRpcServerConnection::readHeader: specified content length is %d.", _contentLength);
 
@@ -155,6 +158,13 @@ XmlRpcServerConnection::readRequest()
     bool eof;
     if ( ! XmlRpcSocket::nbRead(this->getfd(), _request, &eof)) {
       XmlRpcUtil::error("XmlRpcServerConnection::readRequest: read error (%s).",XmlRpcSocket::getErrorMsg().c_str());
+      return false;
+    }
+    // Avoid an overly large request
+    if (_request.length() > size_t(__INT_MAX__)) {
+      XmlRpcUtil::error("XmlRpcServerConnection::readRequest: request length (%u) exceeds the maximum allowed size (%u)",
+                        _request.length(), __INT_MAX__);
+      _request.resize(__INT_MAX__);
       return false;
     }
 
@@ -334,8 +344,16 @@ XmlRpcServerConnection::generateResponse(std::string const& resultXml)
   std::string body = RESPONSE_1 + resultXml + RESPONSE_2;
   std::string header = generateHeader(body);
 
-  _response = header + body;
-  XmlRpcUtil::log(5, "XmlRpcServerConnection::generateResponse:\n%s\n", _response.c_str()); 
+  // Avoid an overly large response
+  if ((header.length() + body.length()) > size_t(__INT_MAX__)) {
+    XmlRpcUtil::error("XmlRpcServerConnection::generateResponse: response length (%u) exceeds the maximum allowed size (%u).",
+                      _response.length(), __INT_MAX__);
+    _response = "";
+  }
+  else {
+    _response = header + body;
+    XmlRpcUtil::log(5, "XmlRpcServerConnection::generateResponse:\n%s\n", _response.c_str());
+  }
 }
 
 // Prepend http headers

--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -302,6 +302,13 @@ XmlRpcSocket::nbRead(int fd, std::string& s, bool *eof)
       return false;   // Error
     }
   }
+  // Watch for integer overrun
+  if (s.length() > size_t(__INT_MAX__)) {
+    XmlRpcUtil::error("XmlRpcSocket::nbRead: text size (%u) exceeds the maximum allowed size (%s).",
+                      s.length(), __INT_MAX__);
+    s.clear();
+    return false;
+  }
   return true;
 }
 
@@ -310,6 +317,12 @@ XmlRpcSocket::nbRead(int fd, std::string& s, bool *eof)
 bool
 XmlRpcSocket::nbWrite(int fd, std::string& s, int *bytesSoFar)
 {
+  // Watch for integer overrun
+  if (s.length() > size_t(__INT_MAX__)) {
+    XmlRpcUtil::error("XmlRpcSocket::nbWrite: text size (%u) exceeds the maximum allowed size(%s)",
+                      s.length(), __INT_MAX__);
+    return false;
+  }
   int nToWrite = int(s.length()) - *bytesSoFar;
   char *sp = const_cast<char*>(s.c_str()) + *bytesSoFar;
   bool wouldBlock = false;

--- a/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
@@ -108,6 +108,8 @@ void XmlRpcUtil::error(const char* fmt, ...)
 std::string 
 XmlRpcUtil::parseTag(const char* tag, std::string const& xml, int* offset)
 {
+  // avoid attempting to parse overly long xml input
+  if (xml.length() > size_t(__INT_MAX__)) return std::string();
   if (*offset >= int(xml.length())) return std::string();
   size_t istart = xml.find(tag, *offset);
   if (istart == std::string::npos) return std::string();
@@ -126,6 +128,7 @@ XmlRpcUtil::parseTag(const char* tag, std::string const& xml, int* offset)
 bool 
 XmlRpcUtil::findTag(const char* tag, std::string const& xml, int* offset)
 {
+  if (xml.length() > size_t(__INT_MAX__)) return false;
   if (*offset >= int(xml.length())) return false;
   size_t istart = xml.find(tag, *offset);
   if (istart == std::string::npos)
@@ -141,6 +144,7 @@ XmlRpcUtil::findTag(const char* tag, std::string const& xml, int* offset)
 bool 
 XmlRpcUtil::nextTagIs(const char* tag, std::string const& xml, int* offset)
 {
+  if (xml.length() > size_t(__INT_MAX__)) return false;
   if (*offset >= int(xml.length())) return false;
   const char* cp = xml.c_str() + *offset;
   int nc = 0;
@@ -162,6 +166,7 @@ XmlRpcUtil::nextTagIs(const char* tag, std::string const& xml, int* offset)
 std::string 
 XmlRpcUtil::getNextTag(std::string const& xml, int* offset)
 {
+  if (xml.length() > size_t(__INT_MAX__)) return std::string();
   if (*offset >= int(xml.length())) return std::string();
 
   size_t pos = *offset;

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 
 #include "xmlrpcpp/XmlRpcValue.h"
+#include "xmlrpcpp/XmlRpcUtil.h"
 
 
 #include <assert.h>
@@ -84,6 +85,35 @@ void testString()
   offset = 0;
   XmlRpcValue blankStringVal(emptyStringXml, &offset);
   assert(std::string(blankStringVal) == "  ");
+}
+
+//Test decoding of a well-formed but overly large XML input
+testOversizeString() {
+  try {
+    std::string xml = "<tag><nexttag>";
+    xml += std::string(__INT_MAX__, 'a');
+    xml += "a</nextag></tag>";
+    int offset;
+
+    offset = 0;
+    assert(XmlRpcUtil::parseTag("<tag>", xml, &offset) == std::string());
+    assert(offset == 0);
+
+    offset = 0;
+    assert(!XmlRpcUtil::findTag("<tag>", xml, &offset));
+    assert(offset == 0);
+
+    offset = 0;
+    assert(!XmlRpcUtil::nextTagIs("<tag>", xml, &offset));
+    assert(offset == 0);
+
+    offset = 0;
+    assert(XmlRpcUtil::getNextTag(xml, &offset) == std::string());
+    assert(offset == 0);
+  }
+  catch (std::bad_alloc& err) {
+    std::cerr << "[ SKIPPED  ] XmlRpc.testOversizeString Unable to allocate memory to run test\n";
+  }
 }
 
 
@@ -219,6 +249,9 @@ int main(int argc, char* argv[])
 
 
   testString();
+
+
+  testOversizeString();
 
 
   testDateTime();


### PR DESCRIPTION
The following list of changes has been integrated into ros_comm between 1.14.9 and 1.14.10 since the last Kinetic release (1.12.16).

**Backported** (in this PR):

* Add skip_cache parameter to rosnode_ping() (#2009)
  * Useful enhancement

* Remove unavailable nodes from local node cache _caller_apis (#2010)
  * Bug fix 

* Update local parameter cache on set_param (#2021)
  * Bug fix 

* Fix Lost Wake Bug in ROSOutAppender (#2033)
  * Bug fix 

* Change error message (#2035)
  * Useful enhancement

* Fix log*_throttle with sim time (#2044)
  * Bug fix

* Gracefully stop recording upon SIGTERM and SIGINT (#2038)
  * Bug fix

* Trap for overly large input to XmlRPCPP (#2065)
  * Bug fix
  * **Note:** this particular change could use a closer look since it involved dealing with significant Git conflicts (1594bf9)
    * I don't know why the diff for the test file is so terrible...

* Cached parameter should be unsubscribed (#2068)
  * Bug fix

* Update maintainers (#2075)

* Fix paramtest for empty values of a parameter (#2054)
  * Bug fix

* Set call_finished_ with true for each call inside callFinished (#2074)
  * Bug fix

**Not backported**:

* Fix issue with rospy.set_param('') (#2024)
  * Not applicable

* XmlRpcValue::_doubleFormat should be used during write (#2003)
  * Not necessary

* Fix spelling (#2066)
  * Not necessary

* Install advertisetest (#2045)
  * Not applicable

* [Windows] Single quote string fix-up (#2051)
  * Not necessary

