### PR TITLE
rosbag: start player in paused state

### DIFF
--- a/tools/rosbag/src/player.cpp
+++ b/tools/rosbag/src/player.cpp
@@ -109,7 +109,7 @@ void PlayerOptions::check() {
 
 Player::Player(PlayerOptions const& options) :
     options_(options),
-    paused_(false),
+    paused_(options.start_paused),
     // If we were given a list of topics to pause on, then go into that mode
     // by default (it can be toggled later via 't' from the keyboard).
     pause_for_topics_(options_.pause_topics.size() > 0),
@@ -225,8 +225,6 @@ void Player::publish() {
     std::cout << " done." << std::endl;
 
     std::cout << std::endl << "Hit space to toggle paused, or 's' to step." << std::endl;
-
-    paused_ = options_.start_paused;
 
     // Publish last message from latch topics if the options_.time > 0.0:
     if (options_.time > 0.0) {


### PR DESCRIPTION
- Initializes the rosbag player correctly in paused mode in case the `options.start_paused` parameter is set to true.

Otherwise one could run into timing issues because the `paused_` member variable was only set at a later stage when publishing messages from the bag:

https://github.com/ros/ros_comm/blob/090daa56f57d18c39946f107bcee5e3efefb2cac/tools/rosbag/src/player.cpp#L229

For instance: if one would set `options.start_paused = true` and immediately call the  `~/pause_playback` service, the service call could return an error stating that the bag was already being replayed.
