### PR TITLE
Fix throttle publish first message

### DIFF
--- a/tools/topic_tools/CMakeLists.txt
+++ b/tools/topic_tools/CMakeLists.txt
@@ -98,6 +98,7 @@ if(CATKIN_ENABLE_TESTING)
 
   add_rostest(test/shapeshifter.test)
   add_rostest(test/throttle.test)
+  add_rostest(test/throttle_first.test)
   add_rostest(test/throttle_simtime.test)
   add_rostest(test/throttle_simtime_loop.test)
   add_rostest(test/drop.test)

--- a/tools/topic_tools/src/throttle.cpp
+++ b/tools/topic_tools/src/throttle.cpp
@@ -138,6 +138,8 @@ void wait_for_subscribers()
                [](const std::string& subscriber) { return subscriber != "*"; });
 
   // Wait for the explicit pending subscribers to subscribe
+  const auto output_topic_name = g_node->resolveName(g_output_topic);
+
   std::set<std::string> pending_subscribers(explicit_subscribers.begin(), explicit_subscribers.end());
   while (!pending_subscribers.empty() && ros::WallTime::now() < advertise_time + g_wait_for_subscribers_timeout)
   {
@@ -154,7 +156,7 @@ void wait_for_subscribers()
     for (int i = 0; i < sub_info.size(); ++i)
     {
       const auto& topic_name = sub_info[i][0];
-      if (topic_name != g_output_topic)
+      if (topic_name != output_topic_name)
       {
         continue;
       }
@@ -171,7 +173,7 @@ void wait_for_subscribers()
       }
     }
 
-    ROS_DEBUG_STREAM("Waiting for explicit subscribers [" << pending_subscribers << "] to " << g_output_topic);
+    ROS_DEBUG_STREAM("Waiting for explicit subscribers [" << pending_subscribers << "] to " << output_topic_name);
     ros::WallDuration(0.1).sleep();
   }
 
@@ -187,7 +189,7 @@ void wait_for_subscribers()
   while (g_pub.getNumSubscribers() < num_subscribers &&
          ros::WallTime::now() < advertise_time + g_wait_for_subscribers_timeout)
   {
-    ROS_DEBUG_STREAM("Waiting for subscribers to " << g_output_topic);
+    ROS_DEBUG_STREAM("Waiting for subscribers to " << output_topic_name);
     ros::WallDuration(0.1).sleep();
   }
 

--- a/tools/topic_tools/test/throttle_first.test
+++ b/tools/topic_tools/test/throttle_first.test
@@ -1,0 +1,17 @@
+<launch>
+  <node pkg="rostopic" type="rostopic" name="rostopic_pub"
+        args="pub -r 10.0 input std_msgs/String chatter"/>
+
+  <node pkg="topic_tools" type="throttle" name="throttle"
+        args="messages input 0.001"/>
+
+  <test test-name="throttle_publishtest" pkg="rostest" type="publishtest">
+    <rosparam>
+      topics:
+        - name: input
+          timeout: 2.0
+        - name: input_throttle
+          timeout: 2.0
+    </rosparam>
+  </test>
+</launch>

--- a/tools/topic_tools/test/throttle_first.test
+++ b/tools/topic_tools/test/throttle_first.test
@@ -3,7 +3,9 @@
         args="pub -r 10.0 input std_msgs/String chatter"/>
 
   <node pkg="topic_tools" type="throttle" name="throttle"
-        args="messages input 0.001"/>
+        args="messages input 0.001">
+    <rosparam param="wait_for_subscribers">['/throttle_publishtest']</rosparam>
+  </node>
 
   <test test-name="throttle_publishtest" pkg="rostest" type="publishtest">
     <rosparam>


### PR DESCRIPTION
Follow up PR for https://github.com/ros/ros_comm/pull/1943

This adds two more commits that fix the test and a potential bug:
* Wait for `throttle_publishtest` subscriber
* Resolve output topic name when waiting for subscribers