### PR TITLE
Fix AttributeError: 'ProcessMonitor' object has no attrib…

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -595,7 +595,7 @@ def signal_shutdown(reason):
         threads = _shutdown_threads[:]
 
     for t in threads:
-        if t.isAlive():
+        if t.is_alive():
             t.join(_TIMEOUT_SHUTDOWN_JOIN)
     del _shutdown_threads[:]
     try:

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -113,7 +113,7 @@ def shutdown_process_monitor(process_monitor):
         process_monitor.shutdown()
         #logger.debug("shutdown_process_monitor: joining ProcessMonitor")
         process_monitor.join(20.0)
-        if process_monitor.isAlive():
+        if process_monitor.is_alive():
             logger.error("shutdown_process_monitor: ProcessMonitor shutdown failed!")
             return False
         else:


### PR DESCRIPTION
starting roscore results in:

```
exception in shutdown_process_monitor: 'ProcessMonitor' object has no attribute 'isAlive'
Traceback (most recent call last):
  File "/Users/brutustt/ros_catkin_ws/install_isolated/lib/python3.9/site-packages/roslaunch/pmon.py", line 116, in shutdown_process_monitor
    if process_monitor.isAlive():
AttributeError: 'ProcessMonitor' object has no attribute 'isAlive'
```

However, the ProcessMonitor has a `is_alive` method so I assume this is what was meant here.