### PR TITLE
Fix AttributeError isAlive

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -509,7 +509,7 @@ def _add_shutdown_thread(t):
         # last thread may not get reaped until shutdown, but this is
         # relatively minor
         for other in _shutdown_threads[:]:
-            if not other.isAlive():
+            if not other.is_alive():
                 _shutdown_threads.remove(other)
         _shutdown_threads.append(t)
 

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -595,7 +595,7 @@ def signal_shutdown(reason):
         threads = _shutdown_threads[:]
 
     for t in threads:
-        if t.isAlive():
+        if t.is_alive():
             t.join(_TIMEOUT_SHUTDOWN_JOIN)
     del _shutdown_threads[:]
     try:

--- a/tools/roslaunch/src/roslaunch/pmon.py
+++ b/tools/roslaunch/src/roslaunch/pmon.py
@@ -113,7 +113,7 @@ def shutdown_process_monitor(process_monitor):
         process_monitor.shutdown()
         #logger.debug("shutdown_process_monitor: joining ProcessMonitor")
         process_monitor.join(20.0)
-        if process_monitor.isAlive():
+        if process_monitor.is_alive():
             logger.error("shutdown_process_monitor: ProcessMonitor shutdown failed!")
             return False
         else:

--- a/tools/roslaunch/test/unit/test_roslaunch_pmon.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_pmon.py
@@ -54,7 +54,12 @@ class ProcessMonitorMock(object):
         self.alive = False
         self.is_shutdown = False
         
+    # The preferred method is 'is_alive'
+    # Keep this method around for backwards compatibility
     def isAlive(self):
+        return self.alive
+
+    def is_alive(self):
         return self.alive
 
     def join(self, *args):
@@ -302,9 +307,9 @@ class TestRoslaunchPmon(unittest.TestCase):
         
         # Test with a real process monitor
         pmon = roslaunch.pmon.start_process_monitor()
-        self.assert_(pmon.isAlive())
+        self.assert_(pmon.is_alive())
         self.assert_(roslaunch.pmon.shutdown_process_monitor(pmon))
-        self.failIf(pmon.isAlive())
+        self.failIf(pmon.is_alive())
 
         # fiddle around with some state that would shouldn't be
         roslaunch.pmon._shutting_down = True
@@ -321,13 +326,13 @@ class TestRoslaunchPmon(unittest.TestCase):
         # pmon_shutdown
         pmon1 = roslaunch.pmon.start_process_monitor()
         pmon2 = roslaunch.pmon.start_process_monitor()
-        self.assert_(pmon1.isAlive())
-        self.assert_(pmon2.isAlive())        
+        self.assert_(pmon1.is_alive())
+        self.assert_(pmon2.is_alive())
 
         roslaunch.pmon.pmon_shutdown()
         
-        self.failIf(pmon1.isAlive())
-        self.failIf(pmon2.isAlive())        
+        self.failIf(pmon1.is_alive())
+        self.failIf(pmon2.is_alive())
         
     def test_add_process_listener(self):
         # coverage test, not a functionality test as that would be much more difficult to simulate


### PR DESCRIPTION
starting roscore results in:

```
exception in shutdown_process_monitor: 'ProcessMonitor' object has no attribute 'isAlive'
Traceback (most recent call last):
  File "/Users/brutustt/ros_catkin_ws/install_isolated/lib/python3.9/site-packages/roslaunch/pmon.py", line 116, in shutdown_process_monitor
    if process_monitor.isAlive():
AttributeError: 'ProcessMonitor' object has no attribute 'isAlive'
```

However, the ProcessMonitor has a `is_alive` method so I assume this is what was meant here.

The same happens after closing rqt:

```
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/Users/ingo/ros_catkin_ws/src/ros_comm/rospy/src/rospy/core.py", line 615, in _ros_atexit
    signal_shutdown('atexit')
  File "/Users/ingo/ros_catkin_ws/src/ros_comm/rospy/src/rospy/core.py", line 598, in signal_shutdown
    if t.isAlive():
AttributeError: 'Thread' object has no attribute 'isAlive'
```

However, the Thread has a `is_alive` method so I assume this is what was meant here.