### PR TITLE
Replace message assertion with logging in order to have release modes…

### DIFF
--- a/clients/roscpp/include/ros/publisher.h
+++ b/clients/roscpp/include/ros/publisher.h
@@ -77,11 +77,14 @@ namespace ros
           ROS_ASSERT_MSG(false, "Call to publish() on an invalid Publisher (topic [%s])", impl_->topic_.c_str());
           return;
         }
-
-      ROS_ASSERT_MSG(impl_->md5sum_ == "*" || std::string(mt::md5sum<M>(*message)) == "*" || impl_->md5sum_ == mt::md5sum<M>(*message),
-                     "Trying to publish message of type [%s/%s] on a publisher with type [%s/%s]",
-                     mt::datatype<M>(*message), mt::md5sum<M>(*message),
-                     impl_->datatype_.c_str(), impl_->md5sum_.c_str());
+        if (impl_->md5sum_ == "*" ||
+            std::string(mt::md5sum<M>(*message)) == "*" ||
+            impl_->md5sum_ == mt::md5sum<M>(*message)) {
+          ROS_DEBUG_ONCE("Trying to publish message of type [%s/%s] on a "
+                    "publisher with type [%s/%s]",
+                    mt::datatype<M>(*message), mt::md5sum<M>(*message),
+                    impl_->datatype_.c_str(), impl_->md5sum_.c_str());
+        }
 
       SerializedMessage m;
       m.type_info = &typeid(M);
@@ -110,11 +113,14 @@ namespace ros
           ROS_ASSERT_MSG(false, "Call to publish() on an invalid Publisher (topic [%s])", impl_->topic_.c_str());
           return;
         }
-
-      ROS_ASSERT_MSG(impl_->md5sum_ == "*" || std::string(mt::md5sum<M>(message)) == "*" || impl_->md5sum_ == mt::md5sum<M>(message),
-                     "Trying to publish message of type [%s/%s] on a publisher with type [%s/%s]",
-                     mt::datatype<M>(message), mt::md5sum<M>(message),
-                     impl_->datatype_.c_str(), impl_->md5sum_.c_str());
+        if (impl_->md5sum_ == "*" ||
+            std::string(mt::md5sum<M>(message)) == "*" ||
+            impl_->md5sum_ == mt::md5sum<M>(message)) {
+          ROS_DEBUG_ONCE("Trying to publish message of type [%s/%s] on a "
+                    "publisher with type [%s/%s]",
+                    mt::datatype<M>(message), mt::md5sum<M>(message),
+                    impl_->datatype_.c_str(), impl_->md5sum_.c_str());
+        }
 
       SerializedMessage m;
       publish(boost::bind(serializeMessage<M>, boost::ref(message)), m);


### PR DESCRIPTION
… to fail in compilation when msg type mismatches occur.

Fixes https://github.com/ros/ros_comm/issues/2095.
