### PR TITLE
Fix /use_sim_time parameter typo in roswtf error

### DIFF
--- a/utilities/roswtf/src/roswtf/graph.py
+++ b/utilities/roswtf/src/roswtf/graph.py
@@ -166,7 +166,7 @@ graph_warnings = [
     ]
 
 graph_errors = [
-    (simtime_check, "/use_simtime is set but no publisher of /clock is present"),
+    (simtime_check, "/use_sim_time is set but no publisher of /clock is present"),
     (ping_check, "Could not contact the following nodes:"),
     (missing_edges, "The following nodes should be connected but aren't:"),
     (probe_all_services, "Errors connecting to the following services:"),


### PR DESCRIPTION
`roswtf` reports that `/use_simtime` is not set though it is actually checking for the parameter `/use_sim_time`