### PR TITLE
Add missing library depends

### DIFF
--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(play rosbag)
 
 if(NOT WIN32)
   add_executable(encrypt src/encrypt.cpp)
-  target_link_libraries(encrypt ${catkin_LIBRARIES})
+  target_link_libraries(encrypt ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/


### PR DESCRIPTION
The rosbag encrypt tool uses boost_program_options, but does not explicitly link against it. This is masked by the considerable overlinking that happens upstream in other ROS packages (in this case, rospack "helpfully" provides boost_program_options to all its dependencies). Nevertheless, it's a good idea to make such dependencies explicit.
