### PR TITLE
Portable fix to recent Windows build breaks.

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -11,6 +11,7 @@
 	# include <strings.h>
 #endif
 #include <string.h>
+#include <climits>
 
 
 using namespace XmlRpc;

--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -313,9 +313,9 @@ XmlRpcClient::generateRequest(const char* methodName, XmlRpcValue const& params)
 
   _request = header + body;
   // Limit the size of the request to avoid integer overruns
-  if (_request.length() > size_t(__INT_MAX__)) {
+  if (_request.length() > size_t(INT_MAX)) {
     XmlRpcUtil::error("XmlRpcClient::generateRequest: request length (%u) exceeds maximum allowed size (%u).",
-                      _request.length(), __INT_MAX__);
+                      _request.length(), INT_MAX);
     _request.clear();
     return false;
   }
@@ -441,7 +441,7 @@ XmlRpcClient::readHeader()
   // avoid overly large or improperly formatted content-length
   long int clength = 0;
   clength = strtol(lp, nullptr, 10);
-  if ((clength <= 0) || (clength > __INT_MAX__)) {
+  if ((clength <= 0) || (clength > INT_MAX)) {
     XmlRpcUtil::error("Error in XmlRpcClient::readHeader: Invalid Content-length specified.");
     // Close the socket because we can't make further use of it.
     close();
@@ -475,9 +475,9 @@ XmlRpcClient::readResponse()
     _response += buff;
 
     // Avoid an overly large response
-    if (_response.length() > size_t(__INT_MAX__)) {
+    if (_response.length() > size_t(INT_MAX)) {
       XmlRpcUtil::error("XmlRpcClient::readResponse: response length (%u) exceeds the maximum allowed size (%u).",
-                        _response.length(), __INT_MAX__);
+                        _response.length(), INT_MAX);
       _response.clear();
       close();
       return false;

--- a/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
@@ -11,6 +11,7 @@
 #endif
 # include <string.h>
 #endif
+#include <climits>
 
 using namespace XmlRpc;
 

--- a/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServerConnection.cpp
@@ -122,7 +122,7 @@ XmlRpcServerConnection::readHeader()
   // avoid overly large or improperly formatted content-length
   long int clength = 0;
   clength = strtol(lp, nullptr, 10);
-  if ((clength < 0) || (clength > __INT_MAX__)) {
+  if ((clength < 0) || (clength > INT_MAX)) {
     XmlRpcUtil::error("XmlRpcServerConnection::readHeader: Invalid Content-length specified.");
     return false;
   }
@@ -161,10 +161,10 @@ XmlRpcServerConnection::readRequest()
       return false;
     }
     // Avoid an overly large request
-    if (_request.length() > size_t(__INT_MAX__)) {
+    if (_request.length() > size_t(INT_MAX)) {
       XmlRpcUtil::error("XmlRpcServerConnection::readRequest: request length (%u) exceeds the maximum allowed size (%u)",
-                        _request.length(), __INT_MAX__);
-      _request.resize(__INT_MAX__);
+                        _request.length(), INT_MAX);
+      _request.resize(INT_MAX);
       return false;
     }
 
@@ -345,9 +345,9 @@ XmlRpcServerConnection::generateResponse(std::string const& resultXml)
   std::string header = generateHeader(body);
 
   // Avoid an overly large response
-  if ((header.length() + body.length()) > size_t(__INT_MAX__)) {
+  if ((header.length() + body.length()) > size_t(INT_MAX)) {
     XmlRpcUtil::error("XmlRpcServerConnection::generateResponse: response length (%u) exceeds the maximum allowed size (%u).",
-                      _response.length(), __INT_MAX__);
+                      _response.length(), INT_MAX);
     _response = "";
   }
   else {

--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -318,9 +318,9 @@ XmlRpcSocket::nbRead(int fd, std::string& s, bool *eof)
     }
   }
   // Watch for integer overrun
-  if (s.length() > size_t(__INT_MAX__)) {
+  if (s.length() > size_t(INT_MAX)) {
     XmlRpcUtil::error("XmlRpcSocket::nbRead: text size (%u) exceeds the maximum allowed size (%s).",
-                      s.length(), __INT_MAX__);
+                      s.length(), INT_MAX);
     s.clear();
     return false;
   }
@@ -333,9 +333,9 @@ bool
 XmlRpcSocket::nbWrite(int fd, const std::string& s, int *bytesSoFar)
 {
   // Watch for integer overrun
-  if (s.length() > size_t(__INT_MAX__)) {
+  if (s.length() > size_t(INT_MAX)) {
     XmlRpcUtil::error("XmlRpcSocket::nbWrite: text size (%u) exceeds the maximum allowed size(%s)",
-                      s.length(), __INT_MAX__);
+                      s.length(), INT_MAX);
     return false;
   }
   int nToWrite = int(s.length()) - *bytesSoFar;

--- a/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcSocket.cpp
@@ -51,6 +51,8 @@ extern "C" {
 }
 #endif  // _WINDOWS
 
+#include <climits>
+
 #endif // MAKEDEPEND
 
 // MSG_NOSIGNAL does not exists on OS X

--- a/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
@@ -109,7 +109,7 @@ std::string
 XmlRpcUtil::parseTag(const char* tag, std::string const& xml, int* offset)
 {
   // avoid attempting to parse overly long xml input
-  if (xml.length() > size_t(__INT_MAX__)) return std::string();
+  if (xml.length() > size_t(INT_MAX)) return std::string();
   if (*offset >= int(xml.length())) return std::string();
   size_t istart = xml.find(tag, *offset);
   if (istart == std::string::npos) return std::string();
@@ -128,7 +128,7 @@ XmlRpcUtil::parseTag(const char* tag, std::string const& xml, int* offset)
 bool 
 XmlRpcUtil::findTag(const char* tag, std::string const& xml, int* offset)
 {
-  if (xml.length() > size_t(__INT_MAX__)) return false;
+  if (xml.length() > size_t(INT_MAX)) return false;
   if (*offset >= int(xml.length())) return false;
   size_t istart = xml.find(tag, *offset);
   if (istart == std::string::npos)
@@ -144,7 +144,7 @@ XmlRpcUtil::findTag(const char* tag, std::string const& xml, int* offset)
 bool 
 XmlRpcUtil::nextTagIs(const char* tag, std::string const& xml, int* offset)
 {
-  if (xml.length() > size_t(__INT_MAX__)) return false;
+  if (xml.length() > size_t(INT_MAX)) return false;
   if (*offset >= int(xml.length())) return false;
   const char* cp = xml.c_str() + *offset;
   int nc = 0;
@@ -166,7 +166,7 @@ XmlRpcUtil::nextTagIs(const char* tag, std::string const& xml, int* offset)
 std::string 
 XmlRpcUtil::getNextTag(std::string const& xml, int* offset)
 {
-  if (xml.length() > size_t(__INT_MAX__)) return std::string();
+  if (xml.length() > size_t(INT_MAX)) return std::string();
   if (*offset >= int(xml.length())) return std::string();
 
   size_t pos = *offset;

--- a/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcUtil.cpp
@@ -7,6 +7,7 @@
 # include <stdarg.h>
 # include <stdio.h>
 # include <string.h>
+# include <climits>
 #endif
 
 #include "xmlrpcpp/XmlRpc.h"

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -15,6 +15,7 @@
 
 #include <sstream>
 #include <mutex>
+#include <vector>
 
 namespace XmlRpc {
 

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -625,11 +625,11 @@ namespace XmlRpc {
             buf[sizeof(buf)-1] = 0;
             os << buf;
           } else { // required_size >= static_cast<int>(sizeof(buf)
-            char required_buf[required_size+1];
-            std::snprintf(required_buf, required_size,
+            std::vector<char> required_buf(required_size+1);
+            std::snprintf(required_buf.data(), required_size,
               getDoubleFormat().c_str(), _value.asDouble);
             required_buf[required_size] = 0;
-            os << required_buf;
+            os << required_buf.data();
           }
           break;
         }

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -26,6 +26,7 @@
 
 #include <stdlib.h>
 #include <string>
+#include <climits>
 
 #include "xmlrpcpp/XmlRpcValue.h"
 #include "xmlrpcpp/XmlRpcException.h"

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -213,7 +213,7 @@ TEST(XmlRpc, testString) {
 TEST(XmlRpc, testOversizeString) {
   try {
     std::string xml = "<tag><nexttag>";
-    xml += std::string(__INT_MAX__, 'a');
+    xml += std::string(INT_MAX, 'a');
     xml += "a</nextag></tag>";
     int offset;
 

--- a/utilities/xmlrpcpp/test/test_client.cpp
+++ b/utilities/xmlrpcpp/test/test_client.cpp
@@ -26,6 +26,7 @@
 
 #include "mock_socket.h"
 #include <errno.h>
+#include <climits>
 
 #include <gtest/gtest.h>
 

--- a/utilities/xmlrpcpp/test/test_client.cpp
+++ b/utilities/xmlrpcpp/test/test_client.cpp
@@ -935,7 +935,7 @@ TEST_F(MockSocketTest, readHeader_oversize) {
 
   // Add a large content-length to the standard header
   std::string header_cl = header3;
-  header_cl += std::to_string(size_t(__INT_MAX__) + 1);
+  header_cl += std::to_string(size_t(INT_MAX) + 1);
   header_cl += "\r\n\r\n ";
 
   Expect_nbRead(7, header_cl, false, true);


### PR DESCRIPTION
This pull request is to address recent Windows build breaks:

* In favor of using `INT_MAX` macro (a more common choice for portability.) https://www.cplusplus.com/reference/climits/
* Use std::vector for variable length array instead of GCC-specific feature.