### PR TITLE
Added warning to sleep() when ROS Time Clock is not set.

### DIFF
--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -146,6 +146,7 @@ def sleep(duration):
                       not rospy.core.is_shutdown():
                 with rostime_cond:
                     rostime_cond.wait(0.3)
+                rospy.core.logwarn("ROS Time clock is not set.")
                 initial_rostime = rospy.rostime.get_rostime()
 
         sleep_t = initial_rostime + duration


### PR DESCRIPTION
Added warning to sleep() when ROS Time clock is not set. Previously sleep would block indefinitely without any error or warning, which is confusing. 

If this is acceptable I'll submit a similar PR for roscpp.