### PR TITLE
Unroll parameters when using type="yaml" with the param tag.

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -274,9 +274,7 @@ class XmlLoader(loader.Loader):
                 p = Param(name, value)
                 context.add_param(p)
             else:
-                p = Param(ns_join(context.ns, name), value)
-                ros_config.add_param(Param(ns_join(context.ns, name), value), filename=context.filename, verbose=verbose)
-            return p
+                self.add_param(ros_config, ns_join(context.ns, name), value, verbose=verbose)
 
         except KeyError as e:
             raise XmlParseException(

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -205,6 +205,8 @@ class TestXmlLoader(unittest.TestCase):
         self.assertEquals("a child namespace parameter 1", param_d['/wg/wgchildparam'], p.value)
         self.assertEquals("a child namespace parameter 2", param_d['/wg2/wg2childparam1'], p.value)
         self.assertEquals("a child namespace parameter 3", param_d['/wg2/wg2childparam2'], p.value)
+        self.assertEquals([0, 1, 2], param_d['/someyaml1'])
+        self.assertEquals('bar2', param_d['/someyaml2/string1'])
 
         try:
             from xmlrpc.client import Binary
@@ -439,6 +441,7 @@ class TestXmlLoader(unittest.TestCase):
     def test_node_param(self):
         mock = self._load(os.path.join(self.xml_dir, 'test-node-valid.xml'))
         tests = [('/test_private_param1/foo1', 'bar1'),
+                 ('/test_private_param1/foo2/baz', 'quz'),
                  ('/ns_test/test_private_param2/foo2', 'bar2'),
                  ('/test_private_param3/foo3', 'bar3'), ]
         for k, v in tests:

--- a/tools/roslaunch/test/xml/test-node-valid.xml
+++ b/tools/roslaunch/test/xml/test-node-valid.xml
@@ -37,6 +37,7 @@
   <!-- base test of private parameter -->
   <node name="test_private_param1" pkg="package" type="test_param">
     <param name="foo1" value="bar1" />
+    <param name="foo2" type="yaml" value="{baz: quz}"/>
   </node>
 
   <!-- test ns attribute -->


### PR DESCRIPTION
Make the `<param>` tag unrolls the parameters when using `type="yaml"`, just like the `<rosparam>` tag does.

Closes ##2115