### PR TITLE
Fix for deadlock issue 1980

### DIFF
--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -166,19 +166,36 @@ void CallbackQueue::removeByID(uint64_t removal_id)
     }
 
     {
-      boost::unique_lock<boost::shared_mutex> rw_lock(id_info->calling_rw_mutex);
-      boost::mutex::scoped_lock lock(mutex_);
-      D_CallbackInfo::iterator it = callbacks_.begin();
-      for (; it != callbacks_.end();)
+      boost::unique_lock<boost::shared_mutex> rw_lock(id_info->calling_rw_mutex, boost::defer_lock);
+      if (rw_lock.try_lock())
       {
-        CallbackInfo& info = *it;
-        if (info.removal_id == removal_id)
+        boost::mutex::scoped_lock lock(mutex_);
+        D_CallbackInfo::iterator it = callbacks_.begin();
+        for (; it != callbacks_.end();)
         {
-          it = callbacks_.erase(it);
+          CallbackInfo& info = *it;
+          if (info.removal_id == removal_id)
+          {
+            it = callbacks_.erase(it);
+          }
+          else
+          {
+            ++it;
+          }
         }
-        else
+      }
+      else
+      {
+        // We failed to acquire the lock, it can be that we are trying to remove something from the callback queue
+        // while it is being executed. Mark it for removal and let it be cleaned up later.
+        boost::mutex::scoped_lock lock(mutex_);
+        for (D_CallbackInfo::iterator it = callbacks_.begin(); it != callbacks_.end(); it++)
         {
-          ++it;
+          CallbackInfo& info = *it;
+          if (info.removal_id == removal_id)
+          {
+            info.marked_for_removal = true;
+          }
         }
       }
     }


### PR DESCRIPTION
We encountered the issue sketched in #1980 in a production system last week.

To understand the issue at hand I've made a minimal-non-working example [here](https://gist.github.com/iwanders/ede48fb649fd47f9b1f9a52c527b463c). Looking at the source code it seems that the callback queue is actually at fault, not the timer code. The `removeByID` deadlocks when a callback by that id is currently being executed.

The first commit introduces a unit test that demonstrates this deadlock in a unit test.

The second commit is the proposed fix for this problem. We try to obtain the lock, if we fail to obtain the lock we defer removal until the next callback queue cycle using the already existing `marked_for_removal` boolean.

FYI @guillaumeautran , @mikepurvis , @jasonimercer 