### PR TITLE
Fix HTTP for kernel < 4.16

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -79,25 +79,23 @@ def isstring(s):
 
 
 def _support_http_1_1():
-    """Linux kernels 4.15 and older encounter performance issues with HTTP/1.1
-    This function returns true if the Linux kernel version is greater than the
-    input or if the platform is not Linux.
     """
-    # HTTP/1.1 performance issue only detected on Linux
+    Determine whether HTTP 1.1 should be enabled for XMLRPC communications.
+
+    This will be true on non-Linux systems, and on Linux kernels at least as
+    new as 4.16. Linux kernels 4.15 and older cause significance performance
+    degradation in the roscore when using HTTP 1.1
+    """
     if platform.system() != 'Linux':
         return True
-
+    minimum_supported_major, minimum_supported_minor = (4, 16)
     release = platform.release().split('.')
-
-    major = 4
-    minor = 15
-
     platform_major = int(release[0])
     platform_minor = int(release[1])
-
-    if platform_major < major:
+    if platform_major < minimum_supported_major:
         return False
-    if platform_major == major and platform_minor <= minor:
+    if (platform_major == minimum_supported_major and
+        platform_minor < minimum_supported_minor):
         return False
     return True
 

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -44,6 +44,7 @@ The common entry point for most libraries is the L{XmlRpcNode} class.
 
 import errno
 import logging
+import platform
 import select
 import socket
 
@@ -78,12 +79,9 @@ def isstring(s):
 
 
 def check_linux_kernel(major, minor):
-    """Small helper version to check that the current platform kernel is a
-    newer or the same as the input
+    """Small helper version to check that the current Linux kernel is a
+    newer or the same as the input.
     """
-    if platform.system()!='Linux':
-        return True
-
     release = platform.release().split('.')
 
     platform_major = int(release[0])
@@ -104,7 +102,7 @@ def check_linux_kernel(major, minor):
 
 class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
     # Linux kernels 4.15 and older encounter performance issues with HTTP/1.1
-    if check_linux_kernel(4,16):
+    if platform.system() == 'Linux' and check_linux_kernel(4,16):
         protocol_version = 'HTTP/1.1'
 
     def log_message(self, format, *args):
@@ -117,7 +115,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     requests via threading. Also makes logging toggleable.
     """
 
-    if check_linux_kernel(4,16):
+    if platform.system() == 'Linux' and check_linux_kernel(4,16):
         daemon_threads = True
 
     def __init__(self, addr, log_requests=1):

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -95,21 +95,15 @@ def _support_http_1_1():
     platform_major = int(release[0])
     platform_minor = int(release[1])
 
-    if platform_major > major:
-        return True
-    elif platform_major < major:
+    if platform_major < major:
         return False
-
-    if platform_minor > minor:
-        return True
-    elif platform_minor < minor:
+    if platform_major == major and platform_minor <= minor:
         return False
-
-    return False
+    return True
 
 
 class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
-    if _support_http_1_1:
+    if _support_http_1_1():
         protocol_version = 'HTTP/1.1'
 
     def log_message(self, format, *args):
@@ -122,7 +116,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     requests via threading. Also makes logging toggleable.
     """
 
-    if _support_http_1_1:
+    if _support_http_1_1():
         daemon_threads = True
 
     def __init__(self, addr, log_requests=1):

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -76,9 +76,32 @@ def isstring(s):
     except NameError:
         return isinstance(s, str)
 
-class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
 
-    protocol_version = 'HTTP/1.1'
+def check_kernel(major, minor):
+    """Small helper version to check that the current platform kernel is a
+    newer or the same as the input
+    """
+    release = platform.release().split('.')
+
+    platform_major = int(release[0])
+    platform_minor = int(release[1])
+
+    if platform_major > major:
+        return True
+    elif platform_major < major:
+        return False
+
+    if platform_minor > minor:
+        return True
+    elif platform_minor < minor:
+        return False
+
+    return True
+
+
+class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
+    if check_kernel(4,16):
+        protocol_version = 'HTTP/1.1'
 
     def log_message(self, format, *args):
         if 0:
@@ -90,7 +113,8 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     requests via threading. Also makes logging toggleable.
     """
 
-    daemon_threads = True
+    if check_kernel(4,16):
+        daemon_threads = True
 
     def __init__(self, addr, log_requests=1):
         """

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -77,10 +77,13 @@ def isstring(s):
         return isinstance(s, str)
 
 
-def check_kernel(major, minor):
+def check_linux_kernel(major, minor):
     """Small helper version to check that the current platform kernel is a
     newer or the same as the input
     """
+    if platform.system()!='Linux':
+        return True
+
     release = platform.release().split('.')
 
     platform_major = int(release[0])
@@ -100,7 +103,8 @@ def check_kernel(major, minor):
 
 
 class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
-    if check_kernel(4,16):
+    # Linux kernels 4.15 and older encounter performance issues with HTTP/1.1
+    if check_linux_kernel(4,16):
         protocol_version = 'HTTP/1.1'
 
     def log_message(self, format, *args):
@@ -113,7 +117,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     requests via threading. Also makes logging toggleable.
     """
 
-    if check_kernel(4,16):
+    if check_linux_kernel(4,16):
         daemon_threads = True
 
     def __init__(self, addr, log_requests=1):

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -78,7 +78,7 @@ def isstring(s):
         return isinstance(s, str)
 
 
-def _support_http_1_1(major, minor):
+def _support_http_1_1():
     """Linux kernels 4.15 and older encounter performance issues with HTTP/1.1
     This function returns true if the Linux kernel version is greater than the
     input or if the platform is not Linux.
@@ -88,6 +88,9 @@ def _support_http_1_1(major, minor):
         return True
 
     release = platform.release().split('.')
+
+    major = 4
+    minor = 15
 
     platform_major = int(release[0])
     platform_minor = int(release[1])
@@ -106,7 +109,7 @@ def _support_http_1_1(major, minor):
 
 
 class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
-    if _support_http_1_1(4,15):
+    if _support_http_1_1:
         protocol_version = 'HTTP/1.1'
 
     def log_message(self, format, *args):
@@ -119,7 +122,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     requests via threading. Also makes logging toggleable.
     """
 
-    if _support_http_1_1(4,15):
+    if _support_http_1_1:
         daemon_threads = True
 
     def __init__(self, addr, log_requests=1):

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -83,7 +83,7 @@ def _support_http_1_1():
     Determine whether HTTP 1.1 should be enabled for XMLRPC communications.
 
     This will be true on non-Linux systems, and on Linux kernels at least as
-    new as 4.16. Linux kernels 4.15 and older cause significance performance
+    new as 4.16. Linux kernels 4.15 and older cause significant performance
     degradation in the roscore when using HTTP 1.1
     """
     if platform.system() != 'Linux':

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -78,31 +78,34 @@ def isstring(s):
         return isinstance(s, str)
 
 
-def check_linux_kernel(major, minor):
-    """Small helper version to check that the current Linux kernel is a
-    newer or the same as the input.
+def _check_linux_kernel(major, minor):
+    """Small helper version to check if the current Linux kernel is older than
+    the input version and return true. If not Linux return false.
     """
+    if platform.system() != 'Linux':
+        return False
+
     release = platform.release().split('.')
 
     platform_major = int(release[0])
     platform_minor = int(release[1])
 
-    if platform_major > major:
+    if platform_major < major:
         return True
-    elif platform_major < major:
+    elif platform_major > major:
         return False
 
-    if platform_minor > minor:
+    if platform_minor < minor:
         return True
-    elif platform_minor < minor:
+    elif platform_minor > minor:
         return False
 
-    return True
+    return False
 
 
 class SilenceableXMLRPCRequestHandler(SimpleXMLRPCRequestHandler):
     # Linux kernels 4.15 and older encounter performance issues with HTTP/1.1
-    if platform.system() == 'Linux' and check_linux_kernel(4,16):
+    if not _check_linux_kernel(4,15):
         protocol_version = 'HTTP/1.1'
 
     def log_message(self, format, *args):
@@ -115,7 +118,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     requests via threading. Also makes logging toggleable.
     """
 
-    if platform.system() == 'Linux' and check_linux_kernel(4,16):
+    if not _check_linux_kernel(4,15):
         daemon_threads = True
 
     def __init__(self, addr, log_requests=1):


### PR DESCRIPTION
Fixes bug #2118

Linux kernels 4.15 and older encounter performance issues with HTTP/1.1
I have tested this with a customer's 4.14 kernel workflow and it addressed their performance issues.
Will need to be backported to Melodic.

Signed-off-by: Jesse Ikawa <jikawa@amazon.com>