### PR TITLE
Add a rosbag tool 'transform' to split, merge and transform bag files

### DIFF
--- a/tools/rosbag/CMakeLists.txt
+++ b/tools/rosbag/CMakeLists.txt
@@ -26,7 +26,8 @@ catkin_package(
 add_library(rosbag
   src/player.cpp
   src/recorder.cpp
-  src/time_translator.cpp)
+  src/time_translator.cpp
+  src/transformer.cpp)
 
 target_link_libraries(rosbag ${catkin_LIBRARIES} ${Boost_LIBRARIES}
   ${BZIP2_LIBRARIES}
@@ -37,6 +38,9 @@ target_link_libraries(record rosbag)
 
 add_executable(play src/play.cpp)
 target_link_libraries(play rosbag)
+
+add_executable(transform src/transform.cpp)
+target_link_libraries(transform rosbag)
 
 if(NOT WIN32)
   add_executable(encrypt src/encrypt.cpp)
@@ -50,7 +54,7 @@ install(TARGETS rosbag
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
-install(TARGETS record play
+install(TARGETS record play transform
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/tools/rosbag/include/rosbag/transformer.h
+++ b/tools/rosbag/include/rosbag/transformer.h
@@ -1,0 +1,131 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2021, Robert Bosch GmbH
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef ROSBAG_TRANSFORMER_H
+#define ROSBAG_TRANSFORMER_H
+
+#include <fstream>
+#include <boost/filesystem.hpp>
+#include <vector>
+#include <map>
+#include <rosbag/bag.h>
+#include <rosbag/view.h>
+
+namespace rosbag
+{
+class Options
+{
+public:
+  void setQuiet(bool quiet);
+  bool quiet() const;
+  void setClobber(bool clobber);
+  bool clobber() const;
+
+private:
+  bool quiet_{ false };
+  bool clobber_{ true };
+};
+
+class FileOperation
+{
+public:
+  using BagPtr = std::shared_ptr<rosbag::Bag>;
+  using Path = boost::filesystem::path;
+
+  enum Type
+  {
+    Input,
+    Output
+  };
+
+  FileOperation(Path const& bag_file, Type type);
+  Path const& path() const;
+  Type type() const;
+  void setCompression(rosbag::compression::CompressionType compression);
+  rosbag::compression::CompressionType compression() const;
+  void addInclusionTopic(std::string const& topic);
+  void addExclusionTopic(std::string const& topic);
+  void addRenameTopic(std::string const& old_name, std::string const& new_name);
+  void setDuration(double duration_secs);
+  double duration() const;
+  void setStartOffset(double start_offset_secs);
+  double startOffset() const;
+  void setBag(BagPtr const& bag);
+  BagPtr const& bag() const;
+  BagPtr& bag();
+  bool read(rosbag::ConnectionInfo const* connection_info);
+  void write(rosbag::MessageInstance const& message);
+
+private:
+  bool keepTopic(std::string const& topic) const;
+  bool keepTime(ros::Time const& time);
+
+  Path path_;
+  Type type_;
+  BagPtr bag_;
+  rosbag::CompressionType compression_{ rosbag::compression::Uncompressed };
+  std::set<std::string> exclusion_topics_;
+  std::set<std::string> inclusion_topics_;
+  std::map<std::string, std::string> rename_topics_;
+  double duration_{ 0.0 };
+  double start_offset_{ 0.0 };
+  ros::Time start_time_{ ros::TIME_MAX };
+};
+
+using FileOperations = std::vector<FileOperation>;
+
+class Transformer
+{
+public:
+  Transformer(FileOperations const& input, FileOperations const& output, Options const& options);
+  bool process();
+
+private:
+  bool setupView(rosbag::View& view);
+  bool setupOutput();
+  bool write(rosbag::View& view);
+  bool rename();
+  std::ostream& logStream();
+
+  FileOperations input_;
+  FileOperations output_;
+  std::map<FileOperation::Path, FileOperation::Path> in_place_files_;
+  Options options_;
+  std::ofstream null_;
+  double progress_percent_{ 0.0 };
+};
+
+}  // namespace rosbag
+
+#endif

--- a/tools/rosbag/src/transform.cpp
+++ b/tools/rosbag/src/transform.cpp
@@ -1,0 +1,386 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2021, Robert Bosch GmbH
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <rosbag/transformer.h>
+#include <iostream>
+#include <iomanip>
+#include <ros/names.h>
+
+using namespace std;
+using namespace rosbag;
+namespace fs = boost::filesystem;
+
+ostream& indent(ostream& out)
+{
+  return out << "    ";
+}
+
+ostream& new_field(ostream& out)
+{
+  return out << left << setw(24u);
+}
+
+ostream& start_field(ostream& out)
+{
+  return out << indent << new_field;
+}
+
+bool startsWith(string const& value, string const& key)
+{
+  return value.find(key, 0) == 0;
+}
+
+void usage()
+{
+  cout << "Usage: transform [general options] [-i|-o file.bag [file operations]]+\n";
+  cout << indent << "Applies input operations to each input file, and passes results to all output files.\n";
+  cout << indent << "Each output file applies its operations and saves the results.\n";
+  cout << "\nGeneral options:\n";
+  cout << start_field << "-h, --help" << new_field << "Show these usage information\n";
+  cout << start_field << "-q, --quiet" << new_field << "Suppress non-error messages\n";
+  cout << start_field << "-n, --no-clobber" << new_field << "Do not overwrite existing output files\n";
+  cout << "\nFile type selection:\n";
+  cout << start_field << "-i, --input FILE" << new_field << "Read input from bag file FILE.\n";
+  cout << start_field << "-o, --output FILE" << new_field << "Write output to bag file FILE\n";
+  cout << "\nFile operations:\n";
+  cout << start_field << "-s, --start SEC" << new_field << "Start SEC seconds into the bag file\n";
+  cout << start_field << "-u, --duration SEC" << new_field << "Keep only SEC seconds from the bag file\n";
+  cout << start_field << "--exclude TOPICS" << new_field << "Exclude all given TOPICS (space separated list)\n";
+  cout << start_field << "--include TOPICS" << new_field << "Include only given TOPICS (space separated list)\n";
+  cout << "\nOutput-only file operations:\n";
+  cout << start_field << "-r, --rename TOPICS" << new_field << "Rename given TOPICS (space separated list of OLD:=NEW "
+                                                               "entries)\n";
+  cout << start_field << "--lz4" << new_field << "Use lz4 compression (lossless, high speed)\n";
+  cout << start_field << "-j, --bz2" << new_field << "Use BZ2 compression (lossless, high compression)\n";
+  cout.flush();
+}
+
+bool parseBagFile(FileOperations& operations, int argc, char* argv[], int& i)
+{
+  string const arg = argv[i];
+  bool const is_input = arg == "-i" || arg == "--input";
+  bool const is_output = arg == "-o" || arg == "--output";
+  if (is_input || is_output)
+  {
+    ++i;
+    if (i >= argc)
+    {
+      return false;
+    }
+    string const next_arg = argv[i];
+    auto const path = fs::path(next_arg);
+    if (is_input && !fs::exists(path))
+    {
+      cerr << "Error: File " << next_arg << " does not exist" << endl;
+      return false;
+    }
+    operations.emplace_back(path, is_input ? FileOperation::Input : FileOperation::Output);
+  }
+  return true;
+}
+
+bool parseCompression(FileOperations& operations, string const& arg)
+{
+  if (arg == "-j" || arg == "--bz2" || arg == "--lz4")
+  {
+    if (operations.empty())
+    {
+      cerr << "Error: Please set compression options after output bag files." << endl;
+      return false;
+    }
+    auto& operation = operations.back();
+    if (operation.type() != FileOperation::Output)
+    {
+      cerr << "Error: Compression options can only be set for output files" << endl;
+      return false;
+    }
+    auto const compression = arg == "--lz4" ? rosbag::compression::LZ4 : rosbag::compression::BZ2;
+    operation.setCompression(compression);
+  }
+  return true;
+}
+
+bool parseTopicFilter(FileOperations& operations, string const& arg, bool& read_inclusion, bool& read_exclusion,
+                      bool& read_rename)
+{
+  if (read_inclusion || read_exclusion || read_rename)
+  {
+    if (startsWith(arg, "-"))
+    {
+      read_inclusion = false;
+      read_exclusion = false;
+      read_rename = false;
+    }
+    else
+    {
+      if (read_inclusion)
+      {
+        operations.back().addInclusionTopic(arg);
+      }
+      else if (read_exclusion)
+      {
+        operations.back().addExclusionTopic(arg);
+      }
+      else if (read_rename)
+      {
+        auto& operation = operations.back();
+        if (operation.type() != FileOperation::Output)
+        {
+          cerr << "Error: Topics can only be renamed in output files" << endl;
+          return false;
+        }
+        auto const index = arg.find(":=", 0);
+        if (index == string::npos)
+        {
+          cerr << "Error: Invalid topic rename entry: '" << arg << "'. Please use 'old_name:=new_name'." << endl;
+          return false;
+        }
+        auto const old_name = arg.substr(0u, index);
+        auto const new_name = arg.substr(index + 2);
+        string error;
+        if (!ros::names::validate(new_name, error))
+        {
+          cerr << "Error: Invalid topic rename entry: '" << arg << "'. Please use 'old_name:=new_name'.\n";
+          cerr << "Error message: " << error << endl;
+          return false;
+        }
+        operation.addRenameTopic(old_name, new_name);
+      }
+    }
+  }
+  else if (arg == "--exclude")
+  {
+    if (operations.empty())
+    {
+      cerr << "Error: Please set topic filters after bag files." << endl;
+      return false;
+    }
+    read_exclusion = true;
+  }
+  else if (arg == "--include")
+  {
+    if (operations.empty())
+    {
+      cerr << "Error: Please set topic filters after bag files." << endl;
+      return false;
+    }
+    read_inclusion = true;
+  }
+  else if (arg == "-r" || arg == "--rename")
+  {
+    if (operations.empty())
+    {
+      cerr << "Error: Please set topic rename after bag files." << endl;
+      return false;
+    }
+    read_rename = true;
+  }
+
+  return true;
+}
+
+bool parseTime(FileOperations& operations, int argc, char* argv[], int& i)
+{
+  string const arg = argv[i];
+  bool const is_duration = arg == "-u" || arg == "--duration";
+  bool const is_start_offset = arg == "-s" || arg == "--start";
+  if (is_duration || is_start_offset)
+  {
+    string const key = is_duration ? "duration" : "start offset";
+    if (operations.empty())
+    {
+      cerr << "Error: Please set " << key << " after bag files." << endl;
+      return false;
+    }
+    double value{ 0.0 };
+    ++i;
+    if (i >= argc)
+    {
+      return false;
+    }
+    string const next_arg = argv[i];
+    try
+    {
+      value = stod(next_arg);
+    }
+    catch (invalid_argument const& e)
+    {
+      cerr << "Error: Cannot parse " << key << " value " << next_arg << ": " << e.what() << endl;
+      return false;
+    }
+    catch (out_of_range const& e)
+    {
+      cerr << "Error: Cannot parse " << key << " value " << next_arg << ": " << e.what() << endl;
+      return false;
+    }
+    if (is_duration)
+    {
+      operations.back().setDuration(value);
+    }
+    else if (is_start_offset)
+    {
+      operations.back().setStartOffset(value);
+    }
+  }
+  return true;
+}
+
+bool writeConflict(fs::path const& a, fs::path const& b)
+{
+  if (fs::exists(a) && fs::exists(b))
+  {
+    return fs::equivalent(a, b);
+  }
+
+  if (fs::exists(a.parent_path()) && fs::exists(b.parent_path()))
+  {
+    return fs::equivalent(a.parent_path(), b.parent_path()) && a.filename() == b.filename();
+  }
+
+  return false;
+}
+
+bool allPathsAreUnique(FileOperations& output)
+{
+  for (size_t i = 0, n = output.size(); i < n; ++i)
+  {
+    for (size_t j = i + 1; j < n; ++j)
+    {
+      if (writeConflict(output[i].path(), output[j].path()))
+      {
+        cerr << "Cannot write to output file " << output[i].path().string() << " multiple times" << endl;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+bool parse(int argc, char* argv[], Options& options, FileOperations& input, FileOperations& output)
+{
+  FileOperations operations;
+  if (argc < 2)
+  {
+    return false;
+  }
+  bool read_inclusion{ false };
+  bool read_exclusion{ false };
+  bool read_rename{ false };
+  for (int i = 1; i < argc; ++i)
+  {
+    string const arg = argv[i];
+    if (arg == "-h" || arg == "--help")
+    {
+      input.clear();
+      output.clear();
+      return true;
+    }
+    if (arg == "-q" || arg == "--quiet")
+    {
+      options.setQuiet(true);
+    }
+    if (arg == "-n" || arg == "--no-clobber")
+    {
+      options.setClobber(false);
+    }
+    if (!parseTopicFilter(operations, arg, read_inclusion, read_exclusion, read_rename))
+    {
+      return false;
+    }
+    if (!parseBagFile(operations, argc, argv, i))
+    {
+      return false;
+    }
+    if (!parseTime(operations, argc, argv, i))
+    {
+      return false;
+    }
+    if (!parseCompression(operations, arg))
+    {
+      return false;
+    }
+  }
+
+  for (auto const& operation : operations)
+  {
+    switch (operation.type())
+    {
+      case FileOperation::Input:
+        input.push_back(operation);
+        break;
+      case FileOperation::Output:
+        output.push_back(operation);
+        break;
+    }
+  }
+
+  return allPathsAreUnique(output);
+}
+
+int main(int argc, char* argv[])
+{
+  Options options;
+  FileOperations input, output;
+  if (parse(argc, argv, options, input, output))
+  {
+    if (input.empty() || output.empty())
+    {
+      usage();
+      return 0;
+    }
+
+    if (!options.clobber())
+    {
+      for (auto iter = output.begin(); iter != output.end();)
+      {
+        if (fs::exists(iter->path()))
+        {
+          iter = output.erase(iter);
+        }
+        else
+        {
+          ++iter;
+        }
+      }
+    }
+    if (output.empty())
+    {
+      return 0;
+    }
+
+    return Transformer(input, output, options).process() ? 0 : 2;
+  }
+  usage();
+  return 1;
+}

--- a/tools/rosbag/src/transformer.cpp
+++ b/tools/rosbag/src/transformer.cpp
@@ -1,0 +1,378 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2021, Robert Bosch GmbH
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#include <rosbag/transformer.h>
+#include <memory>
+#include <boost/bind.hpp>
+#include <algorithm>
+
+using namespace std;
+namespace fs = boost::filesystem;
+
+namespace rosbag
+{
+string humanReadableSize(FileOperation::Path const& path)
+{
+  array<string, 8u> const units{ "B", "K", "M", "G", "T", "P", "E", "Z" };
+  double value = fs::file_size(path);
+  size_t i = 0;
+  size_t const base = 1024;
+  for (auto const n = units.size() - 1; value >= base && i < n; ++i)
+  {
+    value /= base;
+  }
+  stringstream stream;
+  stream << fixed << setprecision(1) << value << units[i];
+  return stream.str();
+}
+
+void Options::setQuiet(bool quiet)
+{
+  quiet_ = quiet;
+}
+
+bool Options::quiet() const
+{
+  return quiet_;
+}
+
+void Options::setClobber(bool clobber)
+{
+  clobber_ = clobber;
+}
+
+bool Options::clobber() const
+{
+  return clobber_;
+}
+
+FileOperation::FileOperation(Path const& path, Type type) : path_(path), type_(type)
+{
+  // does nothing
+}
+
+FileOperation::Path const& FileOperation::path() const
+{
+  return path_;
+}
+
+FileOperation::Type FileOperation::type() const
+{
+  return type_;
+}
+
+void FileOperation::setCompression(rosbag::compression::CompressionType compression)
+{
+  compression_ = compression;
+}
+
+rosbag::compression::CompressionType FileOperation::compression() const
+{
+  return compression_;
+}
+
+void FileOperation::addInclusionTopic(std::string const& topic)
+{
+  inclusion_topics_.insert(topic);
+}
+
+void FileOperation::addExclusionTopic(std::string const& topic)
+{
+  exclusion_topics_.insert(topic);
+}
+
+void FileOperation::addRenameTopic(std::string const& old_name, std::string const& new_name)
+{
+  rename_topics_[old_name] = new_name;
+}
+
+void FileOperation::setDuration(double duration)
+{
+  duration_ = duration;
+}
+
+double FileOperation::duration() const
+{
+  return duration_;
+}
+
+void FileOperation::setStartOffset(double start_offset)
+{
+  start_offset_ = start_offset;
+}
+
+double FileOperation::startOffset() const
+{
+  return start_offset_;
+}
+
+void FileOperation::setBag(BagPtr const& bag)
+{
+  bag_ = bag;
+}
+
+FileOperation::BagPtr const& FileOperation::bag() const
+{
+  return bag_;
+}
+
+FileOperation::BagPtr& FileOperation::bag()
+{
+  return bag_;
+}
+
+bool FileOperation::keepTopic(std::string const& topic) const
+{
+  if (!inclusion_topics_.empty())
+  {
+    return inclusion_topics_.count(topic) == 1;
+  }
+  if (!exclusion_topics_.empty())
+  {
+    return exclusion_topics_.count(topic) == 0;
+  }
+  return true;
+}
+
+bool FileOperation::keepTime(ros::Time const& time)
+{
+  start_time_ = std::min(start_time_, time);
+  if (duration_ > 0.0 || start_offset_ > 0.0)
+  {
+    auto const begin = start_time_ + ros::Duration(start_offset_);
+    auto const end = begin + ros::Duration(duration_);
+    if (time < begin || time > end)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool FileOperation::read(rosbag::ConnectionInfo const* connection_info)
+{
+  if (type_ == Input && bag_ && bag_->getMode() == rosbag::BagMode::Read)
+  {
+    if (keepTopic(connection_info->topic))
+    {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void FileOperation::write(rosbag::MessageInstance const& message)
+{
+  if (type_ == Output && bag_ && bag_->getMode() != rosbag::BagMode::Read)
+  {
+    auto iter = rename_topics_.find(message.getTopic());
+    auto const topic = iter == rename_topics_.end() ? message.getTopic() : iter->second;
+    if (keepTopic(topic) && keepTime(message.getTime()))
+    {
+      bag()->write(topic, message.getTime(), message, message.getConnectionHeader());
+    }
+  }
+}
+
+Transformer::Transformer(FileOperations const& input, FileOperations const& output, Options const& options)
+  : input_(input), output_(output), options_(options)
+{
+  // does nothing
+}
+
+bool Transformer::setupView(rosbag::View& view)
+{
+  vector<pair<FileOperation::Path, FileOperation::BagPtr>> bags;
+  auto& stream = logStream();
+  for (auto& file : input_)
+  {
+    FileOperation::BagPtr bag_ptr;
+    for (auto const& bag : bags)
+    {
+      // Re-use already opened bag file if the same input file
+      // is used several times
+      if (fs::equivalent(bag.first, file.path()))
+      {
+        bag_ptr = bag.second;
+        break;
+      }
+    }
+    if (!bag_ptr)
+    {
+      bag_ptr = make_shared<rosbag::Bag>();
+      stream << "Opening " << file.path().filename().string();
+      stream << " (" << humanReadableSize(file.path()) << ")";
+      stream << ", this may take some time." << endl;
+      bags.emplace_back(file.path(), bag_ptr);
+      try
+      {
+        bag_ptr->open(file.path().string(), rosbag::bagmode::Read);
+      }
+      catch (rosbag::BagException const& e)
+      {
+        cerr << "Cannot open " << file.path().string() << ": " << e.what() << endl;
+        return false;
+      }
+    }
+    file.setBag(bag_ptr);
+
+    if (file.duration() > 0.0 || file.startOffset() > 0.0)
+    {
+      rosbag::View time_range_view(*bag_ptr);
+      auto const begin = time_range_view.getBeginTime() + ros::Duration(file.startOffset());
+      auto const end = begin + ros::Duration(file.duration());
+      view.addQuery(*bag_ptr, bind(&FileOperation::read, file, _1), begin, end);
+    }
+    else
+    {
+      view.addQuery(*bag_ptr, bind(&FileOperation::read, file, _1));
+    }
+  }
+  return true;
+}
+
+std::ostream& Transformer::logStream()
+{
+  return options_.quiet() ? null_ : cout;
+}
+
+bool Transformer::setupOutput()
+{
+  auto& stream = logStream();
+  for (auto& file : output_)
+  {
+    FileOperation::Path path = file.path();
+    string action = "Creating";
+    for (auto const& input : input_)
+    {
+      if (fs::exists(file.path()) && fs::equivalent(file.path(), input.path()))
+      {
+        for (int i = 0; i < 100; ++i)
+        {
+          path = file.path().parent_path() / (file.path().stem().string() + fs::unique_path("_%%%%%%%%.bag").string());
+          if (!fs::exists(path))
+          {
+            in_place_files_[file.path()] = path;
+            action = "Updating";
+            break;
+          }
+        }
+        if (fs::exists(path))
+        {
+          cerr << "Unable to create a temporary file to prevent overwriting " << file.path().string() << endl;
+          return false;
+        }
+      }
+    }
+
+    stream << action << ' ' << file.path().filename().string() << "." << endl;
+    auto bag_ptr = make_shared<rosbag::Bag>();
+    bag_ptr->setCompression(file.compression());
+    try
+    {
+      bag_ptr->open(path.string(), rosbag::bagmode::Write);
+    }
+    catch (rosbag::BagException const& e)
+    {
+      cerr << "Cannot open " << path.string() << " for writing: " << e.what() << endl;
+      return false;
+    }
+    file.setBag(bag_ptr);
+  }
+  return true;
+}
+
+bool Transformer::write(rosbag::View& view)
+{
+  auto const size = view.size();
+  uint32_t current = 0;
+  auto& stream = logStream();
+  for (rosbag::MessageInstance const& m : view)
+  {
+    for (auto& output : output_)
+    {
+      try
+      {
+        output.write(m);
+      }
+      catch (rosbag::BagIOException const& e)
+      {
+        cerr << "Cannot write to " << output.path().string() << ": " << e.what() << endl;
+        return false;
+      }
+    }
+
+    ++current;
+    auto const percent = (100.0 * current) / size;
+    if (percent - progress_percent_ > 0.05)
+    {
+      progress_percent_ = percent;
+      string const bags = output_.size() > 1 ? "bags" : "bag";
+      stream << "\rWriting " << bags << ", " << fixed << setprecision(1) << progress_percent_ << "%";
+      stream.flush();
+    }
+  }
+
+  for (auto& file : output_)
+  {
+    stream << "\r" << file.path().filename().string() << " done (" << humanReadableSize(file.path()) << ")" << endl;
+  }
+  return true;
+}
+
+bool Transformer::rename()
+{
+  for (auto const& target : in_place_files_)
+  {
+    try
+    {
+      fs::rename(target.second, target.first);
+    }
+    catch (fs::filesystem_error const& e)
+    {
+      cerr << "Unable to rename " << target.second << " to " << target.first << ": " << e.what() << endl;
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Transformer::process()
+{
+  bool const reduce_overlap{ true };
+  rosbag::View view(reduce_overlap);
+  return setupView(view) && setupOutput() && write(view) && rename();
+}
+}


### PR DESCRIPTION
Post-processing bag files with `rosbag filter` or the rosbag Python API is very flexible. But when bag files grow large (dozens or hundreds of GB), the processing time becomes significant. This pull request adds a new rosbag tool `transform`, which is written in C++ and performs considerably faster. It provides common filter operations and additional transformations not possible with `rosbag filter` alone (namely bag file merging and topic renaming).

### Examples
```
  # remove the /clock and the /diagnostics topics
  rosbag transform -i input.bag --exclude /clock /diagnostics -o output.bag

  # rename topic from /foo to /bar
  rosbag transform -i input.bag -o output.bag -r /foo:=/bar

  # extract 5.5 seconds from input.bag 10 seconds after the start
  rosbag transform -i input.bag -s 10 -u 5.5 -o output.bag

  # merge everything from input1.bag and input2.bag
  rosbag transform -i input1.bag -i input2.bag -o merge.bag

  # split the /camera/video topic between bag files
  rosbag transform -i input.bag \
                   -o split1.bag --include /camera/video \
                   -o split2.bag --exclude /camera/video
```

### Main commit

> Add a rosbag tool 'transform' to split, merge and transform bag files
> 
> rosbag transform is a bit similar to rosbag filter with two main
> differences:
> * transform can work on multiple input and also output files, and this
>   way it can merge bag files and split bag files in a single invocation
> * transform is much faster since
>   * it does not have to process the whole input files always (for time
>     slice filters)
>   * it is written in C++
>   For example, a 4.5 GB bag file that merely gets copied takes 216s
>   with 'rosbag filter' on my machine and 122s with 'rosbag transform',
>   each with cold caches (echo 1 > /proc/sys/vm/drop_caches). For warm
>   caches, the times are 95s vs. 31s. For time slice extraction, the
>   difference is even larger.
> 
> Possible transformations to apply to input and output bag files are
> topic filtering (via inclusion and exclusion lists), topic renaming,
> time slice extraction (via start and duration) and compression.
> 
> Signed-off-by: Dennis Nienhüser <dennis.nienhueser@de.bosch.com>