### PR TITLE
fix bug #2126:Duplicate messages when reindexing a rosbag with Python API

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -2302,7 +2302,7 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
                 _skip_record(f)
 
             offset = f.tell()
-            
+
         self.bag._connection_indexes_read = True
 
     def start_reading(self):
@@ -2428,6 +2428,7 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
             return BagMessageWithConnectionHeader(topic, msg, t, header)
         else:
             return BagMessage(topic, msg, t)
+
 
 class _BagReader200(_BagReader):
     """

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -2138,6 +2138,8 @@ class _BagReader102_Unindexed(_BagReader):
             
             offset = f.tell()
 
+        self.bag._connection_indexes_read = True
+
     def read_messages(self, topics, start_time, end_time, topic_filter, raw, return_connection_header=False):
         f = self.bag._file
 
@@ -2300,6 +2302,8 @@ class _BagReader102_Indexed(_BagReader102_Unindexed):
                 _skip_record(f)
 
             offset = f.tell()
+            
+        self.bag._connection_indexes_read = True
 
     def start_reading(self):
         try:

--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -2566,6 +2566,7 @@ class _BagReader200(_BagReader):
 
             offset = chunk_file.tell()
 
+        self.bag._connection_indexes_read = True
         # Skip over index records, connection records and chunk info records
         next_op = _peek_next_header_op(f)
         


### PR DESCRIPTION
fix bug #2126 

when `_reindex_read_chunk()` is called, `_connection_indexes` is assigned, but `_connection_indexes_read`   is not set to True.
