### PR TITLE
Avoid uncatchable exception in bagthread

### DIFF
--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -181,15 +181,55 @@ int Recorder::run() {
     boost::thread record_thread;
     if (options_.snapshot)
     {
-        record_thread = boost::thread(boost::bind(&Recorder::doRecordSnapshotter, this));
+        record_thread = boost::thread([this]() {
+          try
+          {
+            this->doRecordSnapshotter();
+          }
+          catch (const rosbag::BagException& ex)
+          {
+            ROS_ERROR_STREAM(ex.what());
+            exit_code_ = 1;
+          }
+          catch (const std::exception& ex)
+          {
+            ROS_ERROR_STREAM(ex.what());
+            exit_code_ = 2;
+          }
+          catch (...)
+          {
+            ROS_ERROR_STREAM("Unknown exception thrown while recording bag, exiting.");
+            exit_code_ = 3;
+          }
+        });
 
         // Subscribe to the snapshot trigger
         trigger_sub = nh.subscribe<std_msgs::Empty>("snapshot_trigger", 100, boost::bind(&Recorder::snapshotTrigger, this, _1));
     }
     else
-        record_thread = boost::thread(boost::bind(&Recorder::doRecord, this));
-
-
+    {
+        record_thread = boost::thread([this]() {
+          try
+          {
+            this->doRecord();
+          }
+          catch (const rosbag::BagException& ex)
+          {
+            ROS_ERROR_STREAM(ex.what());
+            exit_code_ = 1;
+          }
+          catch (const std::exception& ex)
+          {
+            ROS_ERROR_STREAM(ex.what());
+            exit_code_ = 2;
+          }
+          catch (...)
+          {
+            ROS_ERROR_STREAM("Unknown exception thrown while recording bag, exiting.");
+            exit_code_ = 3;
+          }
+        });
+    }
 
     ros::Timer check_master_timer;
     if (options_.record_all || options_.regex || (options_.node != std::string("")))
@@ -403,16 +443,8 @@ void Recorder::startWriting() {
 
 void Recorder::stopWriting() {
     ROS_INFO("Closing '%s'.", target_filename_.c_str());
-    try
-    {
-        bag_.close();
-        rename(write_filename_.c_str(), target_filename_.c_str());
-    }
-    catch (const rosbag::BagException& ex)
-    {
-        ROS_ERROR_STREAM(ex.what());
-        exit_code_ = 1;
-    }
+    bag_.close();
+    rename(write_filename_.c_str(), target_filename_.c_str());
 }
 
 void Recorder::checkNumSplits()

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -403,8 +403,16 @@ void Recorder::startWriting() {
 
 void Recorder::stopWriting() {
     ROS_INFO("Closing '%s'.", target_filename_.c_str());
-    bag_.close();
-    rename(write_filename_.c_str(), target_filename_.c_str());
+    try
+    {
+        bag_.close();
+        rename(write_filename_.c_str(), target_filename_.c_str());
+    }
+    catch (const rosbag::BagException& ex)
+    {
+        ROS_ERROR_STREAM(ex.what());
+        exit_code_ = 1;
+    }
 }
 
 void Recorder::checkNumSplits()


### PR DESCRIPTION
We saw these exceptions in SubT virtual challenge where a bag file recorder is being stopped by explicitly calling `ros::shutdown()` from the code that started the bag recorder.

This is what shows in console:

```
terminate called after throwing an instance of 'rosbag::BagIOException'
  what():  Error seeking
```

I was looking through the code of rosbag recorder and it seems to me that what this PR fixes is the only place where the `bag_` is accessed with a write operation which is not protected with a try/catch block.