### PR TITLE
Fix for #152 add a an optional timeout on service calls

### DIFF
--- a/clients/roscpp/include/ros/master.h
+++ b/clients/roscpp/include/ros/master.h
@@ -43,6 +43,8 @@ namespace master
 
 /** @brief Execute an XMLRPC call on the master
  *
+ * Calls the version with the timeout param with the global timeout defined in XmlRpcClient
+ *
  * @param method The RPC method to invoke
  * @param request The arguments to the RPC call
  * @param response [out] The resonse that was received.
@@ -52,6 +54,19 @@ namespace master
  * @return true if call succeeds, false otherwise.
  */
 ROSCPP_DECL bool execute(const std::string& method, const XmlRpc::XmlRpcValue& request, XmlRpc::XmlRpcValue& response, XmlRpc::XmlRpcValue& payload, bool wait_for_master);
+
+/** @brief Execute an XMLRPC call on the master with a timeout for the socket connection
+ *
+ * @param method The RPC method to invoke
+ * @param request The arguments to the RPC call
+ * @param response [out] The resonse that was received.
+ * @param payload [out] The payload that was received.
+ * @param wait_for_master Whether or not this call should loop until it can contact the master
+ * @param timeout In seconds the time that the socket will try to connect, -1 for infinite wait
+ *
+ * @return true if call succeeds, false otherwise.
+ */
+ROSCPP_DECL bool execute(const std::string& method, const XmlRpc::XmlRpcValue& request, XmlRpc::XmlRpcValue& response, XmlRpc::XmlRpcValue& payload, bool wait_for_master, const double timeout);
 
 /** @brief Get the hostname where the master runs.
  *
@@ -74,10 +89,24 @@ ROSCPP_DECL const std::string& getURI();
  * after ros::init has been called.  The intended usage is to check
  * whether the master is up before trying to make other requests
  * (subscriptions, advertisements, etc.).
+ * This method calls the version with a timeout with the general timeout defined in XmlRpcClient
  *
  * @returns true if the master is available, false otherwise.
  */
 ROSCPP_DECL bool check();
+
+/** @brief Check whether the master is up with a timeout for the socket connection
+ *
+ * This method tries to contact the master.  You can call it any time
+ * after ros::init has been called.  The intended usage is to check
+ * whether the master is up before trying to make other requests
+ * (subscriptions, advertisements, etc.).
+ *
+ * @param timeout In seconds the approximate time the client will try to connect, -1 for infinite wait
+ *
+ * @returns true if the master is available, false otherwise.
+ */
+ROSCPP_DECL bool check(const double timeout);
 
 /**
  * \brief Contains information retrieved from the master about a topic

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcClient.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcClient.h
@@ -50,13 +50,28 @@ namespace XmlRpc {
     //!  @param method The name of the remote procedure to execute
     //!  @param params An array of the arguments for the method
     //!  @param result The result value to be returned to the client
-    //!  @return true if the request was sent and a result received 
+    //!  @return true if the request was sent and a result received
     //!   (although the result might be a fault).
     //!
     //! Currently this is a synchronous (blocking) implementation (execute
     //! does not return until it receives a response or an error). Use isFault()
     //! to determine whether the result is a fault response.
+    //!
+    //! This will call the method using the value of executeTimeout as the timeout parameter value
     bool execute(const char* method, XmlRpcValue const& params, XmlRpcValue& result);
+
+    //! Execute the named procedure on the remote server.
+    //!  @param method The name of the remote procedure to execute
+    //!  @param params An array of the arguments for the method
+    //!  @param result The result value to be returned to the client
+    //!  @param timeout The timeout that the poll implementation will use
+    //!  @return true if the request was sent and a result received
+    //!   (although the result might be a fault).
+    //!
+    //! Currently this is a synchronous (blocking) implementation (execute
+    //! does not return until it receives a response or an error, or the socket connection timed out).
+    //! Use isFault() to determine whether the result is a fault response.
+    bool execute(const char* method, XmlRpcValue const& params, XmlRpcValue& result, const double timeout);
 
     bool executeNonBlock(const char* method, XmlRpcValue const& params);
     bool executeCheckDone(XmlRpcValue& result);
@@ -70,7 +85,7 @@ namespace XmlRpc {
     virtual void close();
 
     //! Handle server responses. Called by the event dispatcher during execute.
-    //!  @param eventType The type of event that occurred. 
+    //!  @param eventType The type of event that occurred.
     //!  @see XmlRpcDispatch::EventType
     virtual unsigned handleEvent(unsigned eventType);
 
@@ -100,7 +115,7 @@ namespace XmlRpc {
     const std::string &getHost() { return _host; }
     const std::string &getUri()  { return _uri; }
     int getPort() const { return _port; }
-    
+
     // The xml-encoded request, http header of response, and response xml
     std::string _request;
     std::string _header;
@@ -129,6 +144,14 @@ namespace XmlRpc {
 
     // Event dispatcher
     XmlRpcDispatch _disp;
+
+  protected:
+    //! general timeout passed to the work method of the dispatcher, to allow avoiding calls blocking forever
+    static double executeTimeout; // s, -1 means infinite wait
+
+  public:
+    static double getExecuteTimeout() { return executeTimeout; }
+    static void setExecuteTimeout(const double timeout) { executeTimeout = timeout; }
 
   };	// class XmlRpcClient
 

--- a/utilities/xmlrpcpp/src/XmlRpcClient.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcClient.cpp
@@ -8,7 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #ifndef _WINDOWS
-	# include <strings.h>
+    # include <strings.h>
 #endif
 #include <string.h>
 #include <climits>
@@ -17,7 +17,7 @@
 using namespace XmlRpc;
 
 // Static data
-const char XmlRpcClient::REQUEST_BEGIN[] = 
+const char XmlRpcClient::REQUEST_BEGIN[] =
   "<?xml version=\"1.0\"?>\r\n"
   "<methodCall><methodName>";
 const char XmlRpcClient::REQUEST_END_METHODNAME[] = "</methodName>\r\n";
@@ -29,6 +29,8 @@ const char XmlRpcClient::REQUEST_END[] = "</methodCall>\r\n";
 const char XmlRpcClient::METHODRESPONSE_TAG[] = "<methodResponse>";
 const char XmlRpcClient::FAULT_TAG[] = "<fault>";
 
+// timeout
+double XmlRpcClient::executeTimeout = -1; // s, -1 means infinite wait
 
 const char * XmlRpcClient::connectionStateStr(ClientConnectionState state) {
   switch(state) {
@@ -103,6 +105,16 @@ struct ClearFlagOnExit {
 bool
 XmlRpcClient::execute(const char* method, XmlRpcValue const& params, XmlRpcValue& result)
 {
+    return execute(method, params, result, XmlRpcClient::getExecuteTimeout());
+}
+
+// Execute the named procedure on the remote server.
+// Params should be an array of the arguments for the method.
+// Returns true if the request was sent and a result received (although the result
+// might be a fault).
+bool
+XmlRpcClient::execute(const char* method, XmlRpcValue const& params, XmlRpcValue& result, const double timeout)
+{
   XmlRpcUtil::log(1, "XmlRpcClient::execute: method %s (_connectionState %s).", method, connectionStateStr(_connectionState));
 
   // This is not a thread-safe operation, if you want to do multithreading, use separate
@@ -124,8 +136,7 @@ XmlRpcClient::execute(const char* method, XmlRpcValue const& params, XmlRpcValue
     return false;
 
   result.clear();
-  double msTime = -1.0;   // Process until exit is called
-  _disp.work(msTime);
+  _disp.work(timeout);
 
   if (_connectionState != IDLE || ! parseResponse(result))
     return false;
@@ -197,10 +208,10 @@ XmlRpcClient::handleEvent(unsigned eventType)
   if (eventType == XmlRpcDispatch::Exception)
   {
     if (_connectionState == WRITE_REQUEST && _bytesWritten == 0)
-      XmlRpcUtil::error("Error in XmlRpcClient::handleEvent: could not connect to server (%s).", 
+      XmlRpcUtil::error("Error in XmlRpcClient::handleEvent: could not connect to server (%s).",
                        XmlRpcSocket::getErrorMsg().c_str());
     else
-      XmlRpcUtil::error("Error in XmlRpcClient::handleEvent (state %s): %s.", 
+      XmlRpcUtil::error("Error in XmlRpcClient::handleEvent (state %s): %s.",
                         connectionStateStr(_connectionState),
                         XmlRpcSocket::getErrorMsg().c_str());
     return 0;
@@ -216,7 +227,7 @@ XmlRpcClient::handleEvent(unsigned eventType)
     if ( ! readResponse()) return 0;
 
   // This should probably always ask for Exception events too
-  return (_connectionState == WRITE_REQUEST) 
+  return (_connectionState == WRITE_REQUEST)
         ? XmlRpcDispatch::WritableEvent : XmlRpcDispatch::ReadableEvent;
 }
 
@@ -231,7 +242,7 @@ XmlRpcClient::setupConnection()
 
   _eof = false;
   if (_connectionState == NO_CONNECTION)
-    if (! doConnect()) 
+    if (! doConnect())
       return false;
 
   // Prepare to write the request
@@ -303,13 +314,13 @@ XmlRpcClient::generateRequest(const char* methodName, XmlRpcValue const& params)
       body += params.toXml();
       body += PARAM_ETAG;
     }
-      
+
     body += PARAMS_ETAG;
   }
   body += REQUEST_END;
 
   std::string header = generateHeader(body.length());
-  XmlRpcUtil::log(4, "XmlRpcClient::generateRequest: header is %d bytes, content-length is %d.", 
+  XmlRpcUtil::log(4, "XmlRpcClient::generateRequest: header is %d bytes, content-length is %d.",
                   header.length(), body.length());
 
   _request = header + body;
@@ -327,7 +338,7 @@ XmlRpcClient::generateRequest(const char* methodName, XmlRpcValue const& params)
 std::string
 XmlRpcClient::generateHeader(size_t length) const
 {
-  std::string header = 
+  std::string header =
     "POST " + _uri + " HTTP/1.1\r\n"
     "User-Agent: ";
   header += XMLRPC_VERSION;
@@ -358,7 +369,7 @@ XmlRpcClient::writeRequest()
     close();
     return false;
   }
-    
+
   XmlRpcUtil::log(3, "XmlRpcClient::writeRequest: wrote %d of %d bytes.", _bytesWritten, _request.length());
 
   // Wait for the result
@@ -427,7 +438,7 @@ XmlRpcClient::readHeader()
       close();
       return false;   // Close the connection
     }
-    
+
     return true;  // Keep reading
   }
 
@@ -449,7 +460,7 @@ XmlRpcClient::readHeader()
     return false;
   }
   _contentLength = int(clength);
-  	
+
   XmlRpcUtil::log(4, "client read content length: %d", _contentLength);
 
   // Otherwise copy non-header data to response buffer and set state to read response.
@@ -459,7 +470,7 @@ XmlRpcClient::readHeader()
   return true;    // Continue monitoring this source
 }
 
-    
+
 bool
 XmlRpcClient::readResponse()
 {
@@ -532,7 +543,7 @@ XmlRpcClient::parseResponse(XmlRpcValue& result)
     _response = "";
     return false;
   }
-      
+
   _response = "";
   return result.valid();
 }


### PR DESCRIPTION
A timeout global is defined for XmlRpc connections.
Overrides are created to allow users to specify a timeout for specific calls.
In particular for ros::master::check a new version is created to allow users to check if the master is up without forever blocking their app.
This fix preserves current functionality but allows user to switch on a global timeout by setting it in the XmlRpcClient class.