### PR TITLE
github action for noetic

### DIFF
--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -2,6 +2,7 @@ name: Ubuntu 20.04 Noetic ros_comm
 
 on:
   push:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ubuntu_20_04.yml
+++ b/.github/workflows/ubuntu_20_04.yml
@@ -1,0 +1,79 @@
+name: Ubuntu 20.04 Noetic ros_comm
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      ROS_CI_DESKTOP: "`lsb_release -cs`"  # e.g. [trusty|xenial|...]
+      ROS_DISTRO: noetic
+    steps:
+      - name: ros_comm
+        uses: actions/checkout@v2
+        with:
+          path: catkin_ws/src/ros_comm
+      - name: Configure ROS for install
+        run: |
+          sudo sh -c "echo \"deb http://packages.ros.org/ros/ubuntu $ROS_CI_DESKTOP main\" > /etc/apt/sources.list.d/ros-latest.list"
+          sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+          sudo apt-get update -qq
+          # sudo apt-get install dpkg
+          # sudo apt-get install -y gfortran
+          # sudo apt-get install -y libatlas-base-dev
+          # sudo apt-get install -y libblas-dev
+          # sudo apt-get install -y libboost-dev
+          # sudo apt-get install -y libboost-signals-dev
+          # sudo apt-get install -y libbullet-dev
+          # sudo apt-get install -y libceres-dev
+          # sudo apt-get install -y libeigen3-dev
+          # sudo apt-get install -y liblapack-dev
+          # sudo apt-get install -y libpng++-dev
+          # sudo apt-get install -y libsdl2-dev
+          # sudo apt-get install -y libv4l-dev
+          # sudo apt-get install -y libyaml-cpp-dev
+          # sudo apt-get install -y qt5-default
+      - name: Install ROS base packages
+        run: |
+          sudo apt-get install -y python3-catkin-pkg
+          sudo apt-get install -y python3-catkin-tools
+          sudo apt-get install -y python3-rosdep
+          sudo apt-get install -y python3-wstool
+          sudo apt-get install -y python3-osrf-pycommon
+          sudo apt-get install -y ros-cmake-modules
+          sudo apt-get install -y ros-$ROS_DISTRO-catkin  # provides setup.bash
+      - name: Install ROS packages with rosdep
+        run: |
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          sudo rosdep init
+          rosdep update
+          mkdir -p ~/catkin_ws/src
+          cd ~/catkin_ws/src
+          ln -s ~/work  # $CI_SOURCE_PATH
+          cd ..
+          rosdep install --from-paths src --ignore-src -r -s  # do a dry-run first
+          rosdep install --from-paths src --ignore-src -r -y
+      - name: Build Release
+        run: |
+          source /opt/ros/$ROS_DISTRO/setup.bash
+          cd ~/catkin_ws
+          # echo "::warning $CI_SOURCE_PATH"
+          # echo "::warning `ls -l`"
+          catkin config --install --cmake-args -DCMAKE_BUILD_TYPE=Release
+          catkin build --no-status
+          source devel/setup.bash
+      - name: lint
+        run: |
+          cd ~/catkin_ws
+          # nothing uses linting here so this fails:
+          # "Error: With --no-deps, you must specify packages to build."
+          # catkin build $(catkin list --depends-on roslint -u) --no-deps --catkin-make-args roslint
+          #
+      - name: Tests
+        run: |
+          cd ~/catkin_ws
+          # nothing uses linting here so this fails:
+          # "Error: With --no-deps, you must specify packages to build."
+          catkin run_tests


### PR DESCRIPTION
Maybe there are other steps to do here to match more of what is happening in jenkins?  I can view raw console output in jenkins (e.g. https://build.ros.org/job/Npr__ros_comm__ubuntu_focal_amd64/455/console)  but I'm not sure where I can view the ros_comm jenkins script/s that made that happen- it's in another repo (buildfarm?)?

If there are other core/base ros packages that use github actions I can look at those and following yml naming schemes or copy in boilerplate.

Run tests, but don't run linting because no packages here use roslint and that results in an error (but some extra bash scripting could handle that), but leave it here in case one does in the future.

I notice the action is running in my fork, but not here in the PR, maybe that's a repo setting (or a consequence of the repo type or the `ros` github organization type- the action minutes would get billed?) or I need to add something to the action.  Even if the action doesn't run here it would still be useful to run in a fork prior to making a PR here, since the jenkins builds don't and shouldn't run in forks.