### PR TITLE
handle SIGINT in rosbag play

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -308,6 +308,12 @@ def play_cmd(argv):
         signal.SIGTERM,
         lambda signum, frame: _stop_process(signum, frame, old_handler, process)
     )
+
+    old_handler = signal.signal(
+        signal.SIGINT,
+        lambda signum, frame: _send_process_sigint(signum, frame, old_handler, process)
+    )
+
     # Better way of handling it than os.execv
     # This makes sure stdin handles are passed to the process.
     process = subprocess.Popen(cmd)


### PR DESCRIPTION
This is copy&paste from https://github.com/ros/ros_comm/pull/2038/files#diff-8c5ae1a482044f103bf9b2fa9188ff9639ed617f259a8dd816075bc9e4005ef9R152
where the SIGINT handler was added to rosbag record.

Before the change, if I play a rosbag with

```
rosbag play mybag.bag
```

and then send `INT` to the python process

```
ps aux | grep play
...
pseyfert  8972  2.6  0.0 144336 54240 pts/3    S+   09:26   0:00 /usr/bin/python2 /opt/ros/melodic/bin/rosbag play mybag.bag
pseyfert  8991  3.4  0.0 492380 44296 pts/3    Sl+  09:26   0:00 /opt/ros/melodic/lib/rosbag/play --queue 100 --rate 1.0 --delay 0.2 --start 0.0 mybag.bag --rate-control-max-delay 1.0
...
kill -INT 8972
```
I would observe that the `play` process was still running (and printing to the terminal).

With the change in this MR, I observe that the `play` process also gets interrupted.