### PR TITLE
fix error in base64EncodedSize()

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -466,6 +466,8 @@ namespace XmlRpc {
       encoded += (encoded + 71) / 72;
       // for some input, the encoder puts two newlines at the end
       encoded += 1;
+      // add a buffer safety margin
+      encoded += 16;
       return encoded;
     }
 

--- a/utilities/xmlrpcpp/src/XmlRpcValue.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcValue.cpp
@@ -464,6 +464,8 @@ namespace XmlRpc {
       // plus a newline character per 72 output characters, rounded up.
       std::size_t encoded = (raw_size + 2) / 3 * 4;
       encoded += (encoded + 71) / 72;
+      // for some input, the encoder puts two newlines at the end
+      encoded += 1;
       return encoded;
     }
 


### PR DESCRIPTION
I have been debugging an issue where no messages are delivered over UDP Transport. I'm on melodic, ubuntu 18.04, x86_64 cpu. Here is what I found.

The base64 encoder called by XmlRpcValue.cpp may write two newlines to the end of the encoded string, but this is not accounted for in base64EncodedSize(). This results in a buffer overflow, which then causes ROS UDP Transport connection setup to fail.
    
One case which results in the double newline is when the total length of "node_name + topic_name + msg_type" is 33 bytes.
