### PR TITLE
Fix memory leak in rosgraph for kernel < 4.16 and Python 3

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -114,8 +114,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     requests via threading. Also makes logging toggleable.
     """
 
-    if _support_http_1_1():
-        daemon_threads = True
+    daemon_threads = True
 
     def __init__(self, addr, log_requests=1):
         """


### PR DESCRIPTION
Following #2132 and the discussion from https://github.com/ros/ros_comm/pull/2132#issuecomment-866097368, here is a fix for the memory leak detected in Python 3 with kernel < 4.16.
> I see no reason why daemon_threads should depend on the HTTP version. The only reason the changes were grouped together was to "switch off" the change in https://github.com/ros/ros_comm/pull/1287/files, which we observed introduced the problem.


I have tested it with kernel 4.15 (with the bug) and 4.18 (without the bug), works for both in Python3.

The memory leak is due to the ThreadingMixin referencing all threads, with `daemon_threads = False` and `block_on_close = True` by default:
https://github.com/python/cpython/blob/3.8/Lib/socketserver.py#L696
It only releases the memory when the server is closed. That's not a real memory leak as the memory is released at the end but roscore is designed to run for a long time. In my project it represents 3GB/hour of unreleased RAM in `rosmaster`.

Even the native `ThreadingHTTPServer` has the option enabled by default: https://github.com/python/cpython/blob/3.8/Lib/http/server.py#L144

For Python2 the problem does not exist, since there is no `block_on_close` option.
https://github.com/python/cpython/blob/v2.7.15/Lib/SocketServer.py#L582

I don't know if I have to put comments in the code explaining the changes or not.