### PR TITLE
Fix warning related to Boost bind placeholders declared in global namespace.

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -47,7 +47,7 @@
 #include "ros/init.h"
 #include "common.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <xmlrpcpp/XmlRpcValue.h>
 

--- a/clients/roscpp/include/ros/publisher.h
+++ b/clients/roscpp/include/ros/publisher.h
@@ -32,7 +32,7 @@
 #include "ros/common.h"
 #include "ros/message.h"
 #include "ros/serialization.h"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 
 namespace ros


### PR DESCRIPTION
This pull request fixes the following warning in `clients/roscpp/include/ros/publisher.h` and `clients/roscpp/include/ros/node_handle.h`:

Warning: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define  BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.