### PR TITLE
Fix $(dirname) resolution in include tags

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -613,6 +613,7 @@ class XmlLoader(loader.Loader):
             # error on) attempts to set the same arg twice.
             child_ns.pass_all_args = True
 
+        child_ns.filename = context.filename  # evaluate substitutions w.r.t. parent filename
         for t in [c for c in tag.childNodes if c.nodeType == DomNode.ELEMENT_NODE]:
             tag_name = t.tagName.lower()
             if tag_name == 'env':
@@ -621,6 +622,7 @@ class XmlLoader(loader.Loader):
                 self._arg_tag(t, child_ns, ros_config, verbose=verbose)
             else:
                 print("WARN: unrecognized '%s' tag in <%s> tag"%(t.tagName, tag.tagName), file=sys.stderr)
+        child_ns.filename = inc_filename  # restore filename
 
         # setup arg passing
         loader.process_include_args(child_ns)

--- a/tools/roslaunch/test/unit/test_xmlloader.py
+++ b/tools/roslaunch/test/unit/test_xmlloader.py
@@ -1080,5 +1080,7 @@ class TestXmlLoader(unittest.TestCase):
         for p in mock.params:
             param_d[p.key] = p.value
 
-        self.assertEquals(param_d['/foo'], self.xml_dir + '/bar')
-        self.assertEquals(param_d['/bar'], self.xml_dir + '/test-dirname/baz')
+        self.assertEqual(param_d['/base'], self.xml_dir)
+        self.assertEqual(param_d['/foo'], self.xml_dir + '/bar')
+        self.assertEqual(param_d['/baz'], self.xml_dir + '/baz')
+        self.assertEqual(param_d['/bar'], self.xml_dir + '/test-dirname/baz')

--- a/tools/roslaunch/test/xml/test-dirname.xml
+++ b/tools/roslaunch/test/xml/test-dirname.xml
@@ -1,4 +1,7 @@
 <launch>
+  <arg name="base" value="$(dirname)" />
   <param name="foo" value="$(dirname)/bar" />
-  <include file="$(dirname)/test-dirname/included.xml" />
+  <include file="$(dirname)/test-dirname/included.xml" pass_all_args="True">
+    <arg name="baz" value="$(dirname)/baz" />
+  </include>
 </launch>

--- a/tools/roslaunch/test/xml/test-dirname/included.xml
+++ b/tools/roslaunch/test/xml/test-dirname/included.xml
@@ -1,3 +1,6 @@
 <launch>
+  <arg name="baz" />
+  <param name="base" value="$(arg base)" />
   <param name="bar" value="$(dirname)/baz" />
+  <param name="baz" value="$(arg baz)" />
 </launch>


### PR DESCRIPTION
Fixes #1487. The problem was that arg values were evaluated (non-lazily) in the context of the newly included file already.
This PR first augments the unit test and then fixes it.