### PR TITLE
[xmlrpcpp] Fix build when gtest is not available

### DIFF
--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -104,16 +104,18 @@ if(NOT WIN32)
     ../src/XmlRpcSocket.cpp
     ../src/XmlRpcUtil.cpp
   )
-  if(APPLE)
-    set_target_properties(test_socket PROPERTIES
-      LINK_FLAGS
-      "-Wl,-alias,___wrap_accept,_accept -Wl,-alias,___wrap_bind,_bind -Wl,-alias,___wrap_close,_close -Wl,-alias,___wrap_connect,_connect -Wl,-alias,___wrap_getaddrinfo,_getaddrinfo -Wl,-alias,___wrap_getsockname,_getsockname -Wl,-alias,___wrap_listen,_listen -Wl,-alias,___wrap_read,_read -Wl,-alias,___wrap_setsockopt,_setsockopt -Wl,-alias,___wrap_select,_select -Wl,-alias,___wrap_select,_select$1050 -Wl,-alias,___wrap_socket,_socket -Wl,-alias,___wrap_write,_write -Wl,-alias,___wrap_fcntl,_fcntl -Wl,-alias,___wrap_freeaddrinfo,_freeaddrinfo"
-    )
-  elseif(UNIX)
-    set_target_properties(test_socket PROPERTIES
-      LINK_FLAGS
-      "-Wl,--wrap=accept -Wl,--wrap=bind -Wl,--wrap=close -Wl,--wrap=connect -Wl,--wrap=getaddrinfo -Wl,--wrap=getsockname -Wl,--wrap=listen -Wl,--wrap=read -Wl,--wrap=setsockopt -Wl,--wrap=select -Wl,--wrap=socket -Wl,--wrap=write -Wl,--wrap=fcntl -Wl,--wrap=freeaddrinfo"
-    )
+  if(TARGET test_socket)
+    if(APPLE)
+      set_target_properties(test_socket PROPERTIES
+        LINK_FLAGS
+        "-Wl,-alias,___wrap_accept,_accept -Wl,-alias,___wrap_bind,_bind -Wl,-alias,___wrap_close,_close -Wl,-alias,___wrap_connect,_connect -Wl,-alias,___wrap_getaddrinfo,_getaddrinfo -Wl,-alias,___wrap_getsockname,_getsockname -Wl,-alias,___wrap_listen,_listen -Wl,-alias,___wrap_read,_read -Wl,-alias,___wrap_setsockopt,_setsockopt -Wl,-alias,___wrap_select,_select -Wl,-alias,___wrap_select,_select$1050 -Wl,-alias,___wrap_socket,_socket -Wl,-alias,___wrap_write,_write -Wl,-alias,___wrap_fcntl,_fcntl -Wl,-alias,___wrap_freeaddrinfo,_freeaddrinfo"
+      )
+    elseif(UNIX)
+      set_target_properties(test_socket PROPERTIES
+        LINK_FLAGS
+        "-Wl,--wrap=accept -Wl,--wrap=bind -Wl,--wrap=close -Wl,--wrap=connect -Wl,--wrap=getaddrinfo -Wl,--wrap=getsockname -Wl,--wrap=listen -Wl,--wrap=read -Wl,--wrap=setsockopt -Wl,--wrap=select -Wl,--wrap=socket -Wl,--wrap=write -Wl,--wrap=fcntl -Wl,--wrap=freeaddrinfo"
+      )
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
When gtest is not available, the target test_socket is not created by catkin_add_gtest (it provides a warning that gtest
was not found and does not add the test). Trying to set the target properties then leads to a configuration error. Making this block conditional on the existence of the target fixes the configuration error.