### PR TITLE
fix typo t_start -> self.t_start

### DIFF
--- a/tools/rostest/nodes/advertisetest
+++ b/tools/rostest/nodes/advertisetest
@@ -110,7 +110,7 @@ class AdvertiseTest(unittest.TestCase):
                 use_sim_time and (rospy.Time.now() == rospy.Time(0)):
             rospy.logwarn_throttle(
                 1, '/use_sim_time is specified and rostime is 0, /clock is published?')
-            if time.time() - t_start > 10:
+            if time.time() - self.t_start > 10:
                 self.fail('Timed out (10s) of /clock publication.')
             # must use time.sleep because /clock isn't yet published, so rospy.sleep hangs.
             time.sleep(0.1)


### PR DESCRIPTION
fix typo local t_start is not defined here, need to use self.t_start

Cc: @furushchev 