### PR TITLE
Revert "Fix warning related to Boost bind placeholders declared in global namespace. (#2169)"

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -47,7 +47,7 @@
 #include "ros/init.h"
 #include "common.h"
 
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 
 #include <xmlrpcpp/XmlRpcValue.h>
 

--- a/clients/roscpp/include/ros/publisher.h
+++ b/clients/roscpp/include/ros/publisher.h
@@ -32,7 +32,7 @@
 #include "ros/common.h"
 #include "ros/message.h"
 #include "ros/serialization.h"
-#include <boost/bind/bind.hpp>
+#include <boost/bind.hpp>
 #include <boost/thread/mutex.hpp>
 
 namespace ros


### PR DESCRIPTION
This reverts commit 32942993e3f9afc8248be7b1f5944344fa2b4e30.

To unblock the buildfarm that's failing to build downstream packages transitively depending on this header being included.