### PR TITLE
Add option to not immediately start message_filters subscriber

### DIFF
--- a/utilities/message_filters/src/message_filters/__init__.py
+++ b/utilities/message_filters/src/message_filters/__init__.py
@@ -65,12 +65,22 @@ class Subscriber(SimpleFilter):
     This class acts as a highest-level filter, simply passing messages
     from a ROS subscription through to the filters which have connected
     to it.
+
+    Passing auto_start=False will not immediately start the subscriber,
+    you should use the start function to do so.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, auto_start=True, **kwargs):
         SimpleFilter.__init__(self)
         self.topic = args[0]
         kwargs['callback'] = self.callback
-        self.sub = rospy.Subscriber(*args, **kwargs)
+        self._create_sub = lambda: rospy.Subscriber(*args, **kwargs)
+        self.sub = None
+        if auto_start:
+            self.sub = self._create_sub()
+
+    def start(self):
+        if not self.sub:
+            self.sub = self._create_sub()
 
     def callback(self, msg):
         self.signalMessage(msg)


### PR DESCRIPTION
Solution for #2189.

This fixes an issue where sometimes caches do not receive the first message on the subscribed topic, if the message arrives immediately after initialising the subscriber. This can happen when the topic is latched, and is problematic if the latched topic never updates as the cache will never receive a message.

Example of starting a cache with delayed initialisation:

```python
sub = message_filters.Subscriber(test_topic, PoseStamped, auto_start=False)
cache = message_filters.Cache(sub)
cache.registerCallback(callback)
# Both the internal cache callback and our custom callback are now in place, so we can start
# the subscriber and guarantee that even if a message arrives instantly both callbacks are called
sub.start()  
```