### PR TITLE
[rostest] Partial fix of _stop_coverage()

### DIFF
--- a/tools/rostest/src/rostest/__init__.py
+++ b/tools/rostest/src/rostest/__init__.py
@@ -252,7 +252,7 @@ def _stop_coverage(packages, html=None):
             # iterate over packages to generate per-package console reports
             for package in packages:
                 pkg = __import__(package)
-                m = [v for v in sys.modules.values() if v and v.__name__.startswith(package)]
+                m = [v for v in sys.modules.values() if v and not isinstance(v, tuple) and v.__name__.startswith(package)]
                 all_mods.extend(m)
 
                 # generate overall report and per module analysis


### PR DESCRIPTION
coverage [stores a tuple](https://github.com/nedbat/coveragepy/blob/ff59658edcc0fbc3dd7f247cd63ec6a44c019410/coverage/debug.py#L303) in `sys.modules` (which does not have `__name__`)