### PR TITLE
Improve performance of ShapeShifter::read()

### DIFF
--- a/tools/topic_tools/include/topic_tools/shape_shifter.h
+++ b/tools/topic_tools/include/topic_tools/shape_shifter.h
@@ -222,12 +222,8 @@ void ShapeShifter::write(Stream& stream) const {
 template<typename Stream>
 void ShapeShifter::read(Stream& stream)
 {
-  stream.getLength();
-  stream.getData();
-
   // stash this message in our buffer
-  msgBuf.resize(stream.getLength());
-  memcpy(msgBuf.data(), stream.getData(), stream.getLength());
+  msgBuf.insert(msgBuf.end(), stream.getData(), stream.getData() + stream.getLength());
 }
 
 } // namespace topic_tools


### PR DESCRIPTION
using `resize` causes an unnecessary call to `memset`. Replacing it with `insert` mitigates that. 
Especially when handling lots of large messages (e.g. images) the overhead caused by  `memset`  is substantial. 
This results in ~30% improved performance in my use-case.