### PR TITLE
some fixes for the --repeat_latched option

### DIFF
--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -457,7 +457,7 @@ void Recorder::startWriting() {
         {
             // Overwrite the original receipt time, otherwise the new bag will
             // have a gap before the new messages start.
-            bag_.write(out.second.topic, now, *out.second.msg);
+            bag_.write(out.second.topic, now, *out.second.msg, out.second.connection_header);
         }
     }
 


### PR DESCRIPTION
This should fix some problems with #1850 : 
**1**
The `repeat_latched` member variable bool was left in an uninitialized/random state.
On my machine, even without specifying "--repeat_latched", it was sometimes activated.

**2**
When repeating the latched messages in splitted bags, these should still be published as latched.

_Steps to reproduce :_ 
Start the following in several terminals :

-  `roscore`
- publish a latched topic : `rostopic pub -l /chatter_latched std_msgs/String "data: 'blabla'"`
- publish a periodic topic : `rostopic pub -r 2 /periodic std_msgs/Empty`
- launch a rosbag record : `rosrun rosbag record -a --repeat-latched --duration 5 --split`

after ~15 seconds stop all the nodes and the `rosbag record`

without the fix : when playing a splitted bag `rosrun rosbag play [...]_1.bag -s 2` : running `rostopic echo /chatter_latched` will show nothing

with this fix : when playing a splitted bag `rosrun rosbag play [...]_1.bag -s 2` : running `rostopic echo /chatter_latched` will show the message, because it is latched
