### PR TITLE
Fix determining supported kernel version for HTTP 1.1 in kernels with patch version 0

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -45,6 +45,7 @@ The common entry point for most libraries is the L{XmlRpcNode} class.
 import errno
 import logging
 import platform
+import re
 import select
 import socket
 
@@ -91,9 +92,11 @@ def _support_http_1_1():
     minimum_supported_major, minimum_supported_minor = (4, 16)
     release = platform.release().split('.')
     platform_major = int(release[0])
-    platform_minor = int(release[1])
+    platform_minor = int(re.sub('[^0-9].*$', '', release[1]))
     if platform_major < minimum_supported_major:
         return False
+    if platform_major > minimum_supported_major:
+        return True
     if (platform_major == minimum_supported_major and
         platform_minor < minimum_supported_minor):
         return False


### PR DESCRIPTION
I use ROS on a system with mainline kernels, and every time a new minor version is installed, ROS stops working.

That's because the uname of the kernel with patch version 0 looks like this: `5.15-051500-generic`. It does not correspond to the standard `x.y.z-whatever` pattern, which breaks rosgraph. The error I'm getting from rosgraph is:

    ValueError: invalid literal for int() with base 10: '15-051501-generic'

This patch removes all characters starting from the first non-numeric character in the minor version part. This should make the `int()` call pass.

I also added another workaround that returns True as early as kernel 5.x or newer is detected, not looking at the minor version at all. This should further limit the surface for more bugs like this.

I'm not sure how other kernel strings in other distros than Ubuntu can look like, but taking into account I'm the first one reporting such issue, I believe the kernel strings look more or less the same, thus this fix should be the "final" ™ one in this regard.