### PR TITLE
check if ignore_unset_args is set in xmlloader

### DIFF
--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -638,7 +638,7 @@ class XmlLoader(loader.Loader):
                 loader.post_process_include_args(child_ns)
 
         except ArgException as e:
-            if not self.ignore_unset_args:
+            if not (hasattr(self, 'ignore_unset_args') and self.ignore_unset_args):
                 raise XmlParseException("included file [%s] requires the '%s' arg to be set"%(inc_filename, str(e)))
         except XmlParseException as e:
             raise XmlParseException("while processing %s:\n%s"%(inc_filename, str(e)))
@@ -760,7 +760,7 @@ class XmlLoader(loader.Loader):
             ros_config.add_roslaunch_file(filename)            
             self._load_launch(launch, ros_config, is_core=core, filename=filename, argv=argv, verbose=verbose)
         except ArgException as e:
-            if not self.ignore_unset_args:
+            if not (hasattr(self, 'ignore_unset_args') and self.ignore_unset_args):
                 raise XmlParseException("[%s] requires the '%s' arg to be set"%(filename, str(e)))
         except SubstitutionException as e:
             raise XmlParseException(str(e))


### PR DESCRIPTION
`ignore_unset_args` is introduced in #1788, but it is set from outside of the class instance.
https://github.com/ros/ros_comm/commit/3fc9b9ba909f9c691897d41401c3eaf47ad6ef02#diff-3157de68f88b12267c21f7208ae4c58c5c9bd4ab1ca2685c2167bc46e96daeb8R445

This PR change to check `ignore_unset_args` attribute is set before calling it.

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/knorth55/.cache/dein/.cache/.vimrc/.dein/plugin/rosvim/filetypes/launch.py", line 150, in syntastic_checker
    loader.load(vimp.buf.name, conf, verbose=False)
  File "/opt/ros/melodic/lib/python2.7/dist-packages/roslaunch/xmlloader.py", line 763, in load
    if not self.ignore_unset_args:
AttributeError: 'XmlLoader' object has no attribute 'ignore_unset_args'
```

my environment:
ROS: melodic
Ubuntu 18.04
roslaunch: `1.14.12-1bionic.20210921.202835`