### PR TITLE
Changes between 1.15.11 and 1.15.14 for backporting to Melodic

### DIFF
--- a/clients/roscpp/src/libros/param.cpp
+++ b/clients/roscpp/src/libros/param.cpp
@@ -33,7 +33,7 @@
 
 #include <ros/console.h>
 
-#include <boost/thread/mutex.hpp>
+#include <boost/thread/recursive_mutex.hpp>
 #include <boost/lexical_cast.hpp>
 
 #include <vector>
@@ -47,7 +47,7 @@ namespace param
 
 typedef std::map<std::string, XmlRpc::XmlRpcValue> M_Param;
 M_Param g_params;
-boost::mutex g_params_mutex;
+boost::recursive_mutex g_params_mutex;
 S_string g_subscribed_params;
 
 void invalidateParentParams(const std::string& key)
@@ -76,7 +76,7 @@ void set(const std::string& key, const XmlRpc::XmlRpcValue& v)
   {
     // Lock around the execute to the master in case we get a parameter update on this value between
     // executing on the master and setting the parameter in the g_params list.
-    boost::mutex::scoped_lock lock(g_params_mutex);
+    boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
     if (master::execute("setParam", params, result, payload, true))
     {
@@ -230,7 +230,7 @@ bool del(const std::string& key)
   std::string mapped_key = ros::names::resolve(key);
 
   {
-    boost::mutex::scoped_lock lock(g_params_mutex);
+    boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
     if (g_subscribed_params.find(mapped_key) != g_subscribed_params.end())
     {
@@ -261,7 +261,7 @@ bool getImpl(const std::string& key, XmlRpc::XmlRpcValue& v, bool use_cache)
 
   if (use_cache)
   {
-    boost::mutex::scoped_lock lock(g_params_mutex);
+    boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
     if (g_subscribed_params.find(mapped_key) != g_subscribed_params.end())
     {
@@ -309,7 +309,7 @@ bool getImpl(const std::string& key, XmlRpc::XmlRpcValue& v, bool use_cache)
 
   if (use_cache)
   {
-    boost::mutex::scoped_lock lock(g_params_mutex);
+    boost::recursive_mutex::scoped_lock lock(g_params_mutex);
     g_params[mapped_key] = v;
   }
 
@@ -783,7 +783,7 @@ void update(const std::string& key, const XmlRpc::XmlRpcValue& v)
   std::string clean_key = names::clean(key);
   ROS_DEBUG_NAMED("cached_parameters", "Received parameter update for key [%s]", clean_key.c_str());
 
-  boost::mutex::scoped_lock lock(g_params_mutex);
+  boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
   if (g_subscribed_params.find(clean_key) != g_subscribed_params.end())
   {
@@ -813,7 +813,7 @@ void unsubscribeCachedParam(const std::string& key)
 void unsubscribeCachedParam(void)
 {
   // lock required, all of the cached parameter will be unsubscribed.
-  boost::mutex::scoped_lock lock(g_params_mutex);
+  boost::recursive_mutex::scoped_lock lock(g_params_mutex);
 
   for(S_string::iterator itr = g_subscribed_params.begin();
     itr != g_subscribed_params.end(); ++itr)

--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -63,6 +63,7 @@ from rospy.msg import deserialize_messages, serialize_message
 from rospy.service import ServiceException
 
 from rospy.impl.transport import Transport, BIDIRECTIONAL
+from errno import EAGAIN, EWOULDBLOCK
 
 logger = logging.getLogger('rospy.tcpros')
 
@@ -101,12 +102,18 @@ def recv_buff(sock, b, buff_size):
     @return: number of bytes read
     @rtype: int
     """
-    d = sock.recv(buff_size)
-    if d:
-        b.write(d)
-        return len(d)
-    else: #bomb out
-        raise TransportTerminated("unable to receive data from sender, check sender's logs for details")
+    try:
+        d = sock.recv(buff_size)
+        if d:
+            b.write(d)
+            return len(d)
+        else: #bomb out
+            raise TransportTerminated("unable to receive data from sender, check sender's logs for details")
+    except socket.error as ex:
+        if ex.errno not in (EAGAIN, EWOULDBLOCK):
+            raise TransportTerminated("unable to receive data from sender, check sender's logs for details")
+        else:
+            return 0
 
 class TCPServer(object):
     """
@@ -799,6 +806,11 @@ class TCPROSTransport(Transport):
                             msgs_callback(msgs, self)
                     else:
                         self._reconnect()
+
+                except TransportTerminated as e:
+                    logdebug("[%s] failed to receive incoming message : %s" % (self.name, str(e)))
+                    rospydebug("[%s] failed to receive incoming message: %s" % (self.name, traceback.format_exc()))
+                    break
 
                 except TransportException as e:
                     # set socket to None so we reconnect

--- a/clients/rospy/src/rospy/impl/tcpros_service.py
+++ b/clients/rospy/src/rospy/impl/tcpros_service.py
@@ -510,7 +510,8 @@ class ServiceProxy(_Service):
             except TransportInitError as e:
                 # can be a connection or md5sum mismatch
                 raise ServiceException("unable to connect to service: %s"%e)
-            self.transport = transport
+            if self.persistent:
+                self.transport = transport
         else:
             transport = self.transport
 

--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -173,6 +173,9 @@ class TimerEvent(object):
     @type  last_real: rospy.Time
     @param current_expected: in a perfect world, this is when the current callback should have been called
     @type  current_expected: rospy.Time
+    @param current_real: when the current callback is actually being called
+                         (rospy.Time.now() as of immediately before calling the callback)
+    @type  current_real: rospy.Time
     @param last_duration: contains the duration of the last callback (end time minus start time) in seconds.
                           Note that this is always in wall-clock time.
     @type  last_duration: float

--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -114,8 +114,7 @@ class ThreadingXMLRPCServer(socketserver.ThreadingMixIn, SimpleXMLRPCServer):
     requests via threading. Also makes logging toggleable.
     """
 
-    if _support_http_1_1():
-        daemon_threads = True
+    daemon_threads = True
 
     def __init__(self, addr, log_requests=1):
         """

--- a/tools/roslaunch/resources/timeouts.launch
+++ b/tools/roslaunch/resources/timeouts.launch
@@ -1,0 +1,5 @@
+<launch>
+
+  <node name="signals" pkg="roslaunch" type="signal_logger.py" />
+
+</launch>

--- a/tools/roslaunch/scripts/roscore
+++ b/tools/roslaunch/scripts/roscore
@@ -34,6 +34,7 @@
 import sys
 from optparse import OptionParser
 from rosmaster.master_api import NUM_WORKERS
+from roslaunch.nodeprocess import DEFAULT_TIMEOUT_SIGINT, DEFAULT_TIMEOUT_SIGTERM
 
 NAME = 'roscore'
 
@@ -59,6 +60,16 @@ def _get_optparse():
     parser.add_option("--master-logger-level",
                       dest="master_logger_level", default=False, type=str,
                       help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
+    parser.add_option("--sigint-timeout",
+                      dest="sigint_timeout",
+                      default=DEFAULT_TIMEOUT_SIGINT, type=float,
+                      help="the SIGINT timeout used when killing the core (in seconds).",
+                      metavar="SIGINT_TIMEOUT")
+    parser.add_option("--sigterm-timeout",
+                      dest="sigterm_timeout",
+                      default=DEFAULT_TIMEOUT_SIGTERM, type=float,
+                      help="the SIGTERM timeout used when killing core if SIGINT does not stop the core (in seconds).",
+                      metavar="SIGTERM_TIMEOUT")
     return parser
 
 

--- a/tools/roslaunch/src/roslaunch/__init__.py
+++ b/tools/roslaunch/src/roslaunch/__init__.py
@@ -68,6 +68,7 @@ except:
     DEFAULT_MASTER_PORT = 11311
 
 from rosmaster.master_api import NUM_WORKERS
+from roslaunch.nodeprocess import DEFAULT_TIMEOUT_SIGINT, DEFAULT_TIMEOUT_SIGTERM
 
 NAME = 'roslaunch'
 
@@ -193,6 +194,16 @@ def _get_optparse():
     parser.add_option("--master-logger-level",
                       dest="master_logger_level", default=False, type=str,
                       help="set rosmaster.master logger level ('debug', 'info', 'warn', 'error', 'fatal')")
+    parser.add_option("--sigint-timeout",
+                      dest="sigint_timeout",
+                      default=DEFAULT_TIMEOUT_SIGINT, type=float,
+                      help="the SIGINT timeout used when killing nodes (in seconds).",
+                      metavar="SIGINT_TIMEOUT")
+    parser.add_option("--sigterm-timeout",
+                      dest="sigterm_timeout",
+                      default=DEFAULT_TIMEOUT_SIGTERM, type=float,
+                      help="the SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).",
+                      metavar="SIGTERM_TIMEOUT")
 
     return parser
     
@@ -298,7 +309,9 @@ def main(argv=sys.argv):
             # client spins up an XML-RPC server that waits for
             # commands and configuration from the server.
             from . import child as roslaunch_child
-            c = roslaunch_child.ROSLaunchChild(uuid, options.child_name, options.server_uri)
+            c = roslaunch_child.ROSLaunchChild(uuid, options.child_name, options.server_uri,
+                                               sigint_timeout=options.sigint_timeout,
+                                               sigterm_timeout=options.sigterm_timeout)
             c.run()
         else:
             logger.info('starting in server mode')
@@ -328,7 +341,9 @@ def main(argv=sys.argv):
                     num_workers=options.num_workers, timeout=options.timeout,
                     master_logger_level=options.master_logger_level,
                     show_summary=not options.no_summary,
-                    force_required=options.force_required)
+                    force_required=options.force_required,
+                    sigint_timeout=options.sigint_timeout,
+                    sigterm_timeout=options.sigterm_timeout)
             p.start()
             p.spin()
 

--- a/tools/roslaunch/src/roslaunch/child.py
+++ b/tools/roslaunch/src/roslaunch/child.py
@@ -49,6 +49,7 @@ import traceback
 import roslaunch.core
 import roslaunch.pmon
 import roslaunch.server
+from roslaunch.nodeprocess import DEFAULT_TIMEOUT_SIGINT, DEFAULT_TIMEOUT_SIGTERM
 
 class ROSLaunchChild(object):
     """
@@ -57,7 +58,7 @@ class ROSLaunchChild(object):
     This must be called from the Python Main thread due to signal registration.
     """
 
-    def __init__(self, run_id, name, server_uri):
+    def __init__(self, run_id, name, server_uri, sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
         """
         Startup roslaunch remote client XML-RPC services. Blocks until shutdown
         @param run_id: UUID of roslaunch session
@@ -66,6 +67,11 @@ class ROSLaunchChild(object):
         @type  name: str
         @param server_uri: XML-RPC URI of roslaunch server
         @type  server_uri: str
+        @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        @type  sigint_timeout: float
+        @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (
+                                in seconds).
+        @type  sigterm_timeout: float
         @return: XML-RPC URI
         @rtype:  str
         """
@@ -77,6 +83,8 @@ class ROSLaunchChild(object):
         self.server_uri = server_uri
         self.child_server = None
         self.pm = None
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
 
         roslaunch.pmon._init_signal_handlers()
 
@@ -102,7 +110,9 @@ class ROSLaunchChild(object):
             try:
                 self.logger.info("starting roslaunch child process [%s], server URI is [%s]", self.name, self.server_uri)
                 self._start_pm()
-                self.child_server = roslaunch.server.ROSLaunchChildNode(self.run_id, self.name, self.server_uri, self.pm)
+                self.child_server = roslaunch.server.ROSLaunchChildNode(self.run_id, self.name, self.server_uri,
+                                                                        self.pm, sigint_timeout=self.sigint_timeout,
+                                                                        sigterm_timeout=self.sigterm_timeout)
                 self.logger.info("... creating XMLRPC server for child")
                 self.child_server.start()
                 self.logger.info("... started XMLRPC server for child")

--- a/tools/roslaunch/src/roslaunch/launch.py
+++ b/tools/roslaunch/src/roslaunch/launch.py
@@ -52,7 +52,7 @@ import rosgraph.network
 
 from roslaunch.core import *
 #from roslaunch.core import setup_env
-from roslaunch.nodeprocess import create_master_process, create_node_process
+from roslaunch.nodeprocess import create_master_process, create_node_process, DEFAULT_TIMEOUT_SIGINT, DEFAULT_TIMEOUT_SIGTERM
 from roslaunch.pmon import start_process_monitor, ProcessListener
 
 from roslaunch.rlutil import update_terminal_name
@@ -235,7 +235,8 @@ class ROSLaunchRunner(object):
     monitored.
     """
     
-    def __init__(self, run_id, config, server_uri=None, pmon=None, is_core=False, remote_runner=None, is_child=False, is_rostest=False, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
+    def __init__(self, run_id, config, server_uri=None, pmon=None, is_core=False, remote_runner=None, is_child=False, is_rostest=False, num_workers=NUM_WORKERS, timeout=None,
+                 master_logger_level=False, sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
         """
         @param run_id: /run_id for this launch. If the core is not
             running, this value will be used to initialize /run_id. If
@@ -266,9 +267,19 @@ class ROSLaunchRunner(object):
         @type timeout: Float or None
         @param master_logger_level: Specify roscore's rosmaster.master logger level, use default if it is False.
         @type master_logger_level: str or False
+        @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        @type sigint_timeout: float
+        @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+        @type sigterm_timeout: float
+        @raise RLException: If sigint_timeout or sigterm_timeout are nonpositive.
         """
         if run_id is None:
             raise RLException("run_id is None")
+        if sigint_timeout <= 0:
+            raise RLException("sigint_timeout must be a positive number, received %f" % sigint_timeout)
+        if sigterm_timeout <= 0:
+            raise RLException("sigterm_timeout must be a positive number, received %f" % sigterm_timeout)
+
         self.run_id = run_id
 
         # In the future we should can separate the notion of a core
@@ -286,6 +297,8 @@ class ROSLaunchRunner(object):
         self.master_logger_level = master_logger_level
         self.logger = logging.getLogger('roslaunch')
         self.pm = pmon or start_process_monitor()
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
 
         # wire in ProcessMonitor events to our listeners
         # aggregator. We similarly wire in the remote events when we
@@ -402,7 +415,8 @@ class ROSLaunchRunner(object):
             printlog("auto-starting new master")
             p = create_master_process(
                 self.run_id, m.type, get_ros_root(), m.get_port(), self.num_workers,
-                self.timeout, master_logger_level=self.master_logger_level)
+                self.timeout, master_logger_level=self.master_logger_level,
+                sigint_timeout=self.sigint_timeout, sigterm_timeout=self.sigterm_timeout)
             self.pm.register_core_proc(p)
             success = p.start()
             if not success:
@@ -541,7 +555,7 @@ class ROSLaunchRunner(object):
         master = self.config.master
         import roslaunch.node_args
         try:
-            process = create_node_process(self.run_id, node, master.uri)
+            process = create_node_process(self.run_id, node, master.uri, sigint_timeout=self.sigint_timeout, sigterm_timeout=self.sigterm_timeout)
         except roslaunch.node_args.NodeParamsException as e:
             self.logger.error(e)
             printerrlog("ERROR: cannot launch node of type [%s/%s]: %s"%(node.package, node.type, str(e)))

--- a/tools/roslaunch/src/roslaunch/nodeprocess.py
+++ b/tools/roslaunch/src/roslaunch/nodeprocess.py
@@ -55,8 +55,8 @@ from rosmaster.master_api import NUM_WORKERS
 import logging
 _logger = logging.getLogger("roslaunch")
 
-_TIMEOUT_SIGINT  = 15.0 #seconds
-_TIMEOUT_SIGTERM = 2.0 #seconds
+DEFAULT_TIMEOUT_SIGINT  = 15.0 #seconds
+DEFAULT_TIMEOUT_SIGTERM = 2.0 #seconds
 
 _counter = 0
 def _next_counter():
@@ -64,7 +64,7 @@ def _next_counter():
     _counter += 1
     return _counter
 
-def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False):
+def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS, timeout=None, master_logger_level=False, sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
     """
     Launch a master
     @param type_: name of master executable (currently just Master.ZENMASTER)
@@ -77,10 +77,14 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
     @type  num_workers: int
     @param timeout: socket timeout for connections.
     @type  timeout: float
-    @raise RLException: if type_ or port is invalid
     @param master_logger_level: rosmaster.master logger debug level
     @type  master_logger_level=: str or False
-    """    
+    @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+    @type sigint_timeout: float
+    @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+    @type sigterm_timeout: float
+    @raise RLException: if type_ or port is invalid or sigint_timeout or sigterm_timeout are nonpositive.
+    """
     if port < 1 or port > 65535:
         raise RLException("invalid port assignment: %s"%port)
 
@@ -100,9 +104,10 @@ def create_master_process(run_id, type_, ros_root, port, num_workers=NUM_WORKERS
 
     _logger.info("process[master]: launching with args [%s]"%args)
     log_output = False
-    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, None, required=True)
+    return LocalProcess(run_id, package, 'master', args, os.environ, log_output, None, required=True,
+                        sigint_timeout=sigint_timeout, sigterm_timeout=sigterm_timeout)
 
-def create_node_process(run_id, node, master_uri):
+def create_node_process(run_id, node, master_uri, sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
     """
     Factory for generating processes for launching local ROS
     nodes. Also registers the process with the L{ProcessMonitor} so that
@@ -114,9 +119,14 @@ def create_node_process(run_id, node, master_uri):
     @type  node: L{Node}
     @param master_uri: API URI for master node
     @type  master_uri: str
+    @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+    @type sigint_timeout: float
+    @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+    @type sigterm_timeout: float
     @return: local process instance
     @rtype: L{LocalProcess}
     @raise NodeParamsException: If the node's parameters are improperly specific
+    @raise RLException: If sigint_timeout or sigterm_timeout are nonpositive.
     """    
     _logger.info("create_node_process: package[%s] type[%s] machine[%s] master_uri[%s]", node.package, node.type, node.machine, master_uri)
     # check input args
@@ -150,7 +160,8 @@ def create_node_process(run_id, node, master_uri):
     _logger.debug('process[%s]: returning LocalProcess wrapper')
     return LocalProcess(run_id, node.package, name, args, env, log_output, \
             respawn=node.respawn, respawn_delay=node.respawn_delay, \
-            required=node.required, cwd=node.cwd)
+            required=node.required, cwd=node.cwd, \
+            sigint_timeout=sigint_timeout, sigterm_timeout=sigterm_timeout)
 
 
 class LocalProcess(Process):
@@ -160,7 +171,7 @@ class LocalProcess(Process):
     
     def __init__(self, run_id, package, name, args, env, log_output,
             respawn=False, respawn_delay=0.0, required=False, cwd=None,
-            is_node=True):
+            is_node=True, sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
         """
         @param run_id: unique run ID for this roslaunch. Used to
           generate log directory location. run_id may be None if this
@@ -184,9 +195,20 @@ class LocalProcess(Process):
         @type  cwd: str
         @param is_node: (optional) if True, process is ROS node and accepts ROS node command-line arguments. Default: True
         @type  is_node: False
+        @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        @type sigint_timeout: float
+        @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+        @type sigterm_timeout: float
+        @raise RLException: If sigint_timeout or sigterm_timeout are nonpositive.
         """    
         super(LocalProcess, self).__init__(package, name, args, env,
                 respawn, respawn_delay, required)
+
+        if sigint_timeout <= 0:
+            raise RLException("sigint_timeout must be a positive number, received %f" % sigint_timeout)
+        if sigterm_timeout <= 0:
+            raise RLException("sigterm_timeout must be a positive number, received %f" % sigterm_timeout)
+
         self.run_id = run_id
         self.popen = None
         self.log_output = log_output
@@ -196,6 +218,8 @@ class LocalProcess(Process):
         self.log_dir = None
         self.pid = -1
         self.is_node = is_node
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
 
     # NOTE: in the future, info() is going to have to be sufficient for relaunching a process
     def get_info(self):
@@ -406,7 +430,7 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
             _logger.info("[%s] sending SIGINT to pgid [%s]", self.name, pgid)                                    
             os.killpg(pgid, signal.SIGINT)
             _logger.info("[%s] sent SIGINT to pgid [%s]", self.name, pgid)
-            timeout_t = time.time() + _TIMEOUT_SIGINT
+            timeout_t = time.time() + self.sigint_timeout
             retcode = self.popen.poll()                
             while time.time() < timeout_t and retcode is None:
                 time.sleep(0.1)
@@ -414,7 +438,7 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
             # Escalate non-responsive process
             if retcode is None:
                 printerrlog("[%s] escalating to SIGTERM"%self.name)
-                timeout_t = time.time() + _TIMEOUT_SIGTERM
+                timeout_t = time.time() + self.sigterm_timeout
                 os.killpg(pgid, signal.SIGTERM)                
                 _logger.info("[%s] sent SIGTERM to pgid [%s]"%(self.name, pgid))
                 retcode = self.popen.poll()
@@ -474,7 +498,7 @@ executable permission. This is often caused by a bad launch-prefix."""%(e.strerr
             _logger.info("[%s] running taskkill pid tree [%s]", self.name, pid)
             subprocess.call(['taskkill', '/F', '/T', '/PID', str(pid)])
             _logger.info("[%s] run taskkill pid tree [%s]", self.name, pid)
-            timeout_t = time.time() + _TIMEOUT_SIGINT
+            timeout_t = time.time() + self.sigint_timeout
             retcode = self.popen.poll()
             while time.time() < timeout_t and retcode is None:
                 time.sleep(0.1)

--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -48,6 +48,7 @@ import rosgraph
 from roslaunch.core import printlog, printerrlog
 import roslaunch.pmon
 import roslaunch.server
+from roslaunch.nodeprocess import DEFAULT_TIMEOUT_SIGINT, DEFAULT_TIMEOUT_SIGTERM
 
 import logging
 _logger = logging.getLogger("roslaunch.remoteprocess")
@@ -126,18 +127,25 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
     """
     Process wrapper for launching and monitoring a child roslaunch process over SSH
     """
-    def __init__(self, run_id, name, server_uri, machine, master_uri=None):
+    def __init__(self, run_id, name, server_uri, machine, master_uri=None, sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
         """
         :param machine: Machine instance. Must be fully configured.
             machine.env_loader is required to be set.
+        :param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        :type sigint_timeout: float
+        :param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (in seconds).
+        :type sigterm_timeout: float
         """
         if not machine.env_loader:
             raise ValueError("machine.env_loader must have been assigned before creating ssh child instance")
-        args = [machine.env_loader, 'roslaunch', '-c', name, '-u', server_uri, '--run_id', run_id]
+        args = [machine.env_loader, 'roslaunch', '-c', name, '-u', server_uri, '--run_id', run_id,
+                '--sigint-timeout', str(sigint_timeout), '--sigterm-timeout', str(sigterm_timeout)]
         # env is always empty dict because we only use env_loader
         super(SSHChildROSLaunchProcess, self).__init__(name, args, {})
         self.machine = machine
         self.master_uri = master_uri
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
         self.ssh = self.sshin = self.sshout = self.ssherr = None
         self.started = False
         self.uri = None

--- a/tools/roslaunch/src/roslaunch/server.py
+++ b/tools/roslaunch/src/roslaunch/server.py
@@ -70,6 +70,7 @@ import rosgraph.xmlrpc as xmlrpc
 import roslaunch.config 
 from roslaunch.pmon import ProcessListener, Process
 import roslaunch.xmlloader
+from roslaunch.nodeprocess import DEFAULT_TIMEOUT_SIGINT, DEFAULT_TIMEOUT_SIGTERM
 
 from roslaunch.launch import ROSLaunchRunner
 from roslaunch.core import RLException, \
@@ -243,12 +244,17 @@ class ROSLaunchChildHandler(ROSLaunchBaseHandler):
     it can track processes across requests
     """    
     
-    def __init__(self, run_id, name, server_uri, pm):
+    def __init__(self, run_id, name, server_uri, pm, sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
         """
         @param server_uri: XML-RPC URI of server
         @type  server_uri: str
         @param pm: process monitor to use
         @type  pm: L{ProcessMonitor}
+        @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+        @type  sigint_timeout: float
+        @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (
+                                in seconds).
+        @type  sigterm_timeout: float
         @raise RLException: If parameters are invalid
         """            
         super(ROSLaunchChildHandler, self).__init__(pm)        
@@ -264,6 +270,8 @@ class ROSLaunchChildHandler(ROSLaunchBaseHandler):
         self.name = name
         self.pm = pm
         self.server_uri = server_uri
+        self.sigint_timeout = sigint_timeout
+        self.sigterm_timeout = sigterm_timeout
         self.server = ServerProxy(server_uri)
 
     def _shutdown(self, reason):
@@ -328,7 +336,8 @@ class ROSLaunchChildHandler(ROSLaunchBaseHandler):
             # mainly the responsibility of the roslaunch server to not give us any XML that might
             # cause conflict (e.g. master tags, param tags, etc...).
             self._log(Log.INFO, "launching nodes...")
-            runner = ROSLaunchRunner(self.run_id, rosconfig, server_uri=self.server_uri, pmon=self.pm)
+            runner = ROSLaunchRunner(self.run_id, rosconfig, server_uri=self.server_uri, pmon=self.pm,
+                                     sigint_timeout=self.sigint_timeout, sigterm_timeout=self.sigterm_timeout)
             succeeded, failed = runner.launch()
             self._log(Log.INFO, "... done launching nodes")
             # enable the process monitor to exit of all processes die
@@ -475,13 +484,18 @@ class ROSLaunchChildNode(ROSLaunchNode):
     XML-RPC server for roslaunch child processes
     """    
 
-    def __init__(self, run_id, name, server_uri, pm):
+    def __init__(self, run_id, name, server_uri, pm, sigint_timeout=DEFAULT_TIMEOUT_SIGINT, sigterm_timeout=DEFAULT_TIMEOUT_SIGTERM):
         """
     ## Startup roslaunch remote client XML-RPC services. Blocks until shutdown
     ## @param name: name of remote client
     ## @type  name: str
     ## @param server_uri: XML-RPC URI of roslaunch server
     ## @type  server_uri: str
+    ## @param sigint_timeout: The SIGINT timeout used when killing nodes (in seconds).
+    ## @type  sigint_timeout: float
+    ## @param sigterm_timeout: The SIGTERM timeout used when killing nodes if SIGINT does not stop the node (
+    ##                         in seconds).
+    ## @type  sigterm_timeout: float
     ## @return: XML-RPC URI
     ## @rtype: str
         """        
@@ -493,7 +507,8 @@ class ROSLaunchChildNode(ROSLaunchNode):
         
         if self.pm is None:
             raise RLException("cannot create child node: pm is not initialized")
-        handler = ROSLaunchChildHandler(self.run_id, self.name, self.server_uri, self.pm)
+        handler = ROSLaunchChildHandler(self.run_id, self.name, self.server_uri, self.pm,
+                                        sigint_timeout=sigint_timeout, sigterm_timeout=sigterm_timeout)
         super(ROSLaunchChildNode, self).__init__(handler)
 
     def _register_with_server(self):

--- a/tools/roslaunch/test/manual-test-remote-timeouts.sh
+++ b/tools/roslaunch/test/manual-test-remote-timeouts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+if [ $# -lt 5 ] || [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
+    echo "Usage: manual-test-remote-timeouts.sh sigint_timeout sigterm_timeout address env_loader user [roslaunch_timeout]"
+    echo "Run this script set up to connect to a remote machine (or your own one, if you have self-ssh enabled), and after a while, break the program with Ctrl-C."
+    echo "Observe, if SIGINT and SIGTERM are issued approximately after the time you have given in sigint_timeout and sigterm_timeout"
+    echo "Make sure the remote machine also has the same version of ros_comm as this one!"
+    exit 1
+fi
+
+sigint=$1
+sigterm=$2
+address=$3
+env_loader=$4
+user=$5
+if [ $# -gt 6 ]; then
+    timeout=$6
+else
+    timeout=10.0
+fi
+
+bold="\033[1m"
+normal="\033[0m"
+echo -e "${bold}A while after you see '... done launching nodes', break the program with Ctrl-C."
+echo -e "Observe, if SIGINT and SIGTERM are issued approximately after ${sigint} and ${sigterm} seconds"
+echo -e "Make sure the remote machine also has the same version of ros_comm as this one!${normal}"
+
+sleep 5
+
+"${THIS_DIR}/../scripts/roslaunch" --sigint-timeout ${sigint} --sigterm-timeout ${sigterm} \
+    "${THIS_DIR}/xml/manual-test-remote-timeouts.launch" \
+    address:=${address} env_loader:=${env_loader} user:=${user} timeout:=${timeout}

--- a/tools/roslaunch/test/signal_logger.py
+++ b/tools/roslaunch/test/signal_logger.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+import os
+import signal
+import tempfile
+import time
+
+if __name__ == '__main__':
+    LOG_FILE = os.path.join(tempfile.gettempdir(), "signal.log")
+    log_stream = open(LOG_FILE, 'w')
+
+
+    def handler(signum, _):
+        log_stream.write("%i %s\n" % (signum, str(time.time())))
+        log_stream.flush()
+
+        if signum == signal.SIGTERM:
+            log_stream.close()
+
+
+    signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
+
+    while True:
+        time.sleep(10)

--- a/tools/roslaunch/test/unit/test_nodeprocess.py
+++ b/tools/roslaunch/test/unit/test_nodeprocess.py
@@ -78,6 +78,14 @@ class TestNodeprocess(unittest.TestCase):
         self.assertEquals(p.package, 'rosmaster')
         p = create_master_process(run_id, type, ros_root, port)
         
+        self.assertEquals(create_master_process(run_id, type, ros_root, port, sigint_timeout=3).sigint_timeout, 3)
+        self.assertEquals(create_master_process(run_id, type, ros_root, port, sigint_timeout=1).sigint_timeout, 1)
+        self.assertRaises(RLException, create_master_process, run_id, type, ros_root, port, sigint_timeout=0)
+
+        self.assertEquals(create_master_process(run_id, type, ros_root, port, sigterm_timeout=3).sigterm_timeout, 3)
+        self.assertEquals(create_master_process(run_id, type, ros_root, port, sigterm_timeout=1).sigterm_timeout, 1)
+        self.assertRaises(RLException, create_master_process, run_id, type, ros_root, port, sigterm_timeout=0)
+        
         # TODO: have to think more as to the correct environment for the master process
         
         
@@ -164,6 +172,16 @@ class TestNodeprocess(unittest.TestCase):
         n.cwd = 'node'                
         self.assertEquals(create_node_process(run_id, n, master_uri).cwd, 'node')
 
+        # sigint timeout
+        self.assertEquals(create_node_process(run_id, n, master_uri).sigint_timeout, 15)
+        self.assertEquals(create_node_process(run_id, n, master_uri, sigint_timeout=1).sigint_timeout, 1)
+        self.assertRaises(RLException, create_node_process, run_id, n, master_uri, sigint_timeout=0)
+
+        # sigterm timeout
+        self.assertEquals(create_node_process(run_id, n, master_uri).sigterm_timeout, 2)
+        self.assertEquals(create_node_process(run_id, n, master_uri, sigterm_timeout=1).sigterm_timeout, 1)
+        self.assertRaises(RLException, create_node_process, run_id, n, master_uri, sigterm_timeout=0)
+
         # test args
 
         # - simplest test (no args)
@@ -201,7 +219,69 @@ class TestNodeprocess(unittest.TestCase):
         self.failIf('SUB_TEST' in p.args)
         self.assert_('foo' in p.args)
         self.assert_('subtest' in p.args)
-        self.assert_('subtest2' in p.args)        
+        self.assert_('subtest2' in p.args)
+
+    def test_local_process_stop_timeouts(self):
+        from roslaunch.core import Node, Machine
+
+        # have to use real ROS configuration for these tests
+        ros_root = os.environ['ROS_ROOT']
+        rpp = os.environ.get('ROS_PACKAGE_PATH', None)
+        master_uri = 'http://masteruri:1234'
+        m = Machine('name1', ros_root, rpp, '1.2.3.4')
+
+        run_id = 'id'
+
+        n = Node('roslaunch', 'signal_logger.py')
+        n.name = 'logger'
+        n.machine = m
+        self.check_stop_timeouts(master_uri, n, run_id, 1.0, 1.0)
+        self.check_stop_timeouts(master_uri, n, run_id, 0.00001, 1.0)
+        # shorter sigterm times are risky in the test - the signal file might not get written; but in the wild, it's ok
+        self.check_stop_timeouts(master_uri, n, run_id, 1.0, 0.001)
+        self.check_stop_timeouts(master_uri, n, run_id, 2.0, 3.0)
+
+    def check_stop_timeouts(self, master_uri, n, run_id, sigint_timeout, sigterm_timeout):
+        from roslaunch.nodeprocess import create_node_process, LocalProcess
+
+        import time
+        import tempfile
+        import signal
+
+        signal_log_file = os.path.join(tempfile.gettempdir(), "signal.log")
+
+        try:
+            os.remove(signal_log_file)
+        except OSError:
+            pass
+
+        p = create_node_process(run_id, n, master_uri, sigint_timeout=sigint_timeout, sigterm_timeout=sigterm_timeout)
+        self.assert_(isinstance(p, LocalProcess))
+
+        p.start()
+        time.sleep(3)  # give it time to start
+
+        before_stop_call_time = time.time()
+        p.stop()
+        after_stop_call_time = time.time()
+
+        signals = dict()
+        
+        try:
+            with open(signal_log_file, 'r') as f:
+                lines = f.readlines()
+                for line in lines:
+                    sig, timestamp = line.split(" ")
+                    sig = int(sig)
+                    timestamp = float(timestamp)
+                    signals[sig] = timestamp
+        except IOError:
+            self.fail("Could not open %s" % signal_log_file)
+
+        self.assertSetEqual({signal.SIGINT, signal.SIGTERM}, set(signals.keys()))
+        self.assertAlmostEqual(before_stop_call_time, signals[signal.SIGINT], delta=1)
+        self.assertAlmostEqual(before_stop_call_time, signals[signal.SIGTERM] - sigint_timeout, delta=1)
+        self.assertAlmostEqual(before_stop_call_time, after_stop_call_time - sigint_timeout - sigterm_timeout, delta=1)
 
     def test__cleanup_args(self):
         # #1595

--- a/tools/roslaunch/test/unit/test_roslaunch_parent.py
+++ b/tools/roslaunch/test/unit/test_roslaunch_parent.py
@@ -236,6 +236,89 @@ class TestRoslaunchParent(unittest.TestCase):
         p.shutdown()
         self.assert_(pmon.is_shutdown)        
 
+
+## Test sigint_timeout and sigterm_timeout
+# We need real ProcessMonitor here, and we need to spawn real threads
+class TestRoslaunchTimeouts(unittest.TestCase):
+    def setUp(self):
+        from roslaunch.pmon import ProcessMonitor
+        self.pmon = ProcessMonitor()
+
+    def test_roslaunchTimeouts(self):
+        try:
+            self._subtestTimeouts()
+        finally:
+            self.pmon.shutdown()
+
+    def _subtestTimeouts(self):
+        from roslaunch.parent import ROSLaunchParent
+        from roslaunch.server import ROSLaunchParentNode
+        import signal
+        import tempfile
+        from threading import Thread
+
+        pmon = self.pmon
+        pmon.start()
+        try:
+            # if there is a core up, we have to use its run id
+            run_id = get_param('/run_id')
+        except:
+            run_id = 'test-rl-parent-timeout-%s' % time.time()
+
+        rl_dir = rospkg.RosPack().get_path('roslaunch')
+        rl_file = os.path.join(rl_dir, 'resources', 'timeouts.launch')
+
+        sigint_timeout = 2
+        sigterm_timeout = 3
+
+        p = ROSLaunchParent(run_id, [rl_file], is_core=False, port=11312, local_only=True,
+                            sigint_timeout=sigint_timeout, sigterm_timeout=sigterm_timeout)
+        p._load_config()
+        p.pm = pmon
+        p.server = ROSLaunchParentNode(p.config, pmon)
+
+        signal_log_file = os.path.join(tempfile.gettempdir(), "signal.log")
+        try:
+            os.remove(signal_log_file)
+        except OSError:
+            pass
+
+        def kill_launch(times):
+            time.sleep(3)  # give it time to start
+
+            times.append(time.time())
+            p.shutdown()
+            times.append(time.time())
+
+        p.start()
+
+        times = []
+        t = Thread(target=kill_launch, args=(times,))
+        t.start()
+
+        p.spin()
+        t.join()
+
+        before_stop_call_time, after_stop_call_time = times
+
+        signals = dict()
+        try:
+            with open(signal_log_file, 'r') as f:
+                lines = f.readlines()
+                for line in lines:
+                    sig, timestamp = line.split(" ")
+                    sig = int(sig)
+                    timestamp = float(timestamp)
+                    signals[sig] = timestamp
+        except IOError:
+            self.fail("Could not open %s" % signal_log_file)
+
+        self.assertSetEqual({signal.SIGINT, signal.SIGTERM}, set(signals.keys()))
+        self.assertAlmostEqual(before_stop_call_time, signals[signal.SIGINT], delta=1.0)
+        self.assertAlmostEqual(before_stop_call_time, signals[signal.SIGTERM] - sigint_timeout, delta=1)
+        self.assertAlmostEqual(before_stop_call_time, after_stop_call_time - sigint_timeout - sigterm_timeout, delta=1)
+
+
 def kill_parent(p, delay=1.0):
     # delay execution so that whatever pmon method we're calling has time to enter
     time.sleep(delay)

--- a/tools/roslaunch/test/xml/manual-test-remote-timeouts.launch
+++ b/tools/roslaunch/test/xml/manual-test-remote-timeouts.launch
@@ -1,0 +1,14 @@
+<launch>
+
+    <!-- To be used with roslaunch/test/manual-test-remote-timeouts.sh -->
+
+    <arg name="address" />
+    <arg name="env_loader" />
+    <arg name="user" />
+    <arg name="timeout" default="10.0" />
+
+    <machine name="remote" address="$(arg address)" user="$(arg user)" env-loader="$(arg env_loader)" timeout="$(arg timeout)" />
+
+    <node name="signal_logger" pkg="roslaunch" type="signal_logger.py" machine="remote" output="screen" />
+
+</launch>

--- a/utilities/xmlrpcpp/test/CMakeLists.txt
+++ b/utilities/xmlrpcpp/test/CMakeLists.txt
@@ -104,16 +104,18 @@ if(NOT WIN32)
     ../src/XmlRpcSocket.cpp
     ../src/XmlRpcUtil.cpp
   )
-  if(APPLE)
-    set_target_properties(test_socket PROPERTIES
-      LINK_FLAGS
-      "-Wl,-alias,___wrap_accept,_accept -Wl,-alias,___wrap_bind,_bind -Wl,-alias,___wrap_close,_close -Wl,-alias,___wrap_connect,_connect -Wl,-alias,___wrap_getaddrinfo,_getaddrinfo -Wl,-alias,___wrap_getsockname,_getsockname -Wl,-alias,___wrap_listen,_listen -Wl,-alias,___wrap_read,_read -Wl,-alias,___wrap_setsockopt,_setsockopt -Wl,-alias,___wrap_select,_select -Wl,-alias,___wrap_select,_select$1050 -Wl,-alias,___wrap_socket,_socket -Wl,-alias,___wrap_write,_write -Wl,-alias,___wrap_fcntl,_fcntl -Wl,-alias,___wrap_freeaddrinfo,_freeaddrinfo"
-    )
-  elseif(UNIX)
-    set_target_properties(test_socket PROPERTIES
-      LINK_FLAGS
-      "-Wl,--wrap=accept -Wl,--wrap=bind -Wl,--wrap=close -Wl,--wrap=connect -Wl,--wrap=getaddrinfo -Wl,--wrap=getsockname -Wl,--wrap=listen -Wl,--wrap=read -Wl,--wrap=setsockopt -Wl,--wrap=select -Wl,--wrap=socket -Wl,--wrap=write -Wl,--wrap=fcntl -Wl,--wrap=freeaddrinfo"
-    )
+  if(TARGET test_socket)
+    if(APPLE)
+      set_target_properties(test_socket PROPERTIES
+        LINK_FLAGS
+        "-Wl,-alias,___wrap_accept,_accept -Wl,-alias,___wrap_bind,_bind -Wl,-alias,___wrap_close,_close -Wl,-alias,___wrap_connect,_connect -Wl,-alias,___wrap_getaddrinfo,_getaddrinfo -Wl,-alias,___wrap_getsockname,_getsockname -Wl,-alias,___wrap_listen,_listen -Wl,-alias,___wrap_read,_read -Wl,-alias,___wrap_setsockopt,_setsockopt -Wl,-alias,___wrap_select,_select -Wl,-alias,___wrap_select,_select$1050 -Wl,-alias,___wrap_socket,_socket -Wl,-alias,___wrap_write,_write -Wl,-alias,___wrap_fcntl,_fcntl -Wl,-alias,___wrap_freeaddrinfo,_freeaddrinfo"
+      )
+    elseif(UNIX)
+      set_target_properties(test_socket PROPERTIES
+        LINK_FLAGS
+        "-Wl,--wrap=accept -Wl,--wrap=bind -Wl,--wrap=close -Wl,--wrap=connect -Wl,--wrap=getaddrinfo -Wl,--wrap=getsockname -Wl,--wrap=listen -Wl,--wrap=read -Wl,--wrap=setsockopt -Wl,--wrap=select -Wl,--wrap=socket -Wl,--wrap=write -Wl,--wrap=fcntl -Wl,--wrap=freeaddrinfo"
+      )
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
The following list of changes has been integrated into ros_comm 1.15.13 (Noetic) since the last Melodic release (1.14.11)

**Backported** (in this PR):

* #2165
  * Bug fix

* #2131
  * Bug fix

* #2177
  * Bug fix

* #2171
  * Bug fix

* #2178
  * Documentation fix

* #1937
  * New feature, requested to backport by community (https://github.com/ros/ros_comm/pull/2179)

* #2209 
  * Bug fix

* #2208 
  * Bug fix
 
**Not backported:**

* #2185
  * Already applied in #2186

* #2169
  * Introduced a regression

* #2187