### PR TITLE
Add exception hook and log them on logerr

### DIFF
--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -202,13 +202,15 @@ logout = loginfo # alias deprecated name
 
 logerror = logerr # alias logerr
 
-# add exception hook for threads and properly log them on rospyerr
-# docs: https://docs.python.org/3.8/library/threading.html#threading.excepthook
+# add exception hooks and properly log them on rospyerr
+# sys docs: https://docs.python.org/3/library/sys.html#sys.excepthook
+# threading docs: https://docs.python.org/3.8/library/threading.html#threading.excepthook
 
-def threadinghook(*args):
+def exceptionhook(*args):
     logerr(traceback.format_exc())
 
-threading.excepthook = threadinghook
+sys.excepthook = exceptionhook
+threading.excepthook = exceptionhook
 
 
 class LoggingThrottle(object):

--- a/clients/rospy/src/rospy/core.py
+++ b/clients/rospy/src/rospy/core.py
@@ -202,6 +202,14 @@ logout = loginfo # alias deprecated name
 
 logerror = logerr # alias logerr
 
+# add exception hook for threads and properly log them on rospyerr
+# docs: https://docs.python.org/3.8/library/threading.html#threading.excepthook
+
+def threadinghook(*args):
+    logerr(traceback.format_exc())
+
+threading.excepthook = threadinghook
+
 
 class LoggingThrottle(object):
 


### PR DESCRIPTION
properly log exception within threads on logerr

behavior before change:
```
process[test_node-1]: started with pid [21234]
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/sahin/catkin_ws/install/lib/test_package/test.py", line 14, in run
    raise Exception('in thread')
Exception: in thread
[test_node-1] process has finished cleanly
```

behavior after change:
```
process[test_node-1]: started with pid [21059]
[/test_node ERROR 1642419799.922205]: Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/sahin/catkin_ws/install/lib/test_package/test.py", line 14, in run
    raise Exception('in thread')
Exception: in thread

[test_node-1] process has finished cleanly
```

This change makes it easier for log analytics to group together tracebacks for prioritizing bugfixes