### PR TITLE
Fix printing XmlRpcValue with GTest

### DIFF
--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
@@ -201,6 +201,15 @@ namespace XmlRpc {
     } _value;
     
   };
+  
+  // This prevents GTest to understand all XmlRpcValues as structs and trying to print them as such.
+  // That results in assertStruct() being called an exception being thrown in GTest EXPECT* methods.
+  void PrintTo(const XmlRpcValue& value, ::std::ostream* os)
+  {
+    if (os)
+      *os << value.toXml();
+  }
+
 } // namespace XmlRpc
 
 

--- a/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
+++ b/utilities/xmlrpcpp/include/xmlrpcpp/XmlRpcValue.h
@@ -204,7 +204,7 @@ namespace XmlRpc {
   
   // This prevents GTest to understand all XmlRpcValues as structs and trying to print them as such.
   // That results in assertStruct() being called an exception being thrown in GTest EXPECT* methods.
-  void PrintTo(const XmlRpcValue& value, ::std::ostream* os)
+  inline void PrintTo(const XmlRpcValue& value, ::std::ostream* os)
   {
     if (os)
       *os << value.toXml();

--- a/utilities/xmlrpcpp/test/TestValues.cpp
+++ b/utilities/xmlrpcpp/test/TestValues.cpp
@@ -73,6 +73,9 @@ TEST(XmlRpc, testBoolean) {
   std::stringstream ss2;
   ss2 << booleanTrue;
   EXPECT_EQ("1", ss2.str());
+  
+  // Test that printing the value with GTest printer works
+  EXPECT_EQ(booleanFalse.toXml(), ::testing::PrintToString(booleanFalse));
 }
 
 // Int
@@ -108,6 +111,9 @@ TEST(XmlRpc, testInt) {
   std::stringstream ss;
   ss << int9Xml;
   EXPECT_EQ("9", ss.str());
+  
+  // Test that printing the value with GTest printer works
+  EXPECT_EQ(int0.toXml(), ::testing::PrintToString(int0));
 }
 
 TEST(XmlRpc, testDouble) {
@@ -162,6 +168,9 @@ TEST(XmlRpc, testDouble) {
   ss.str("");
 
   XmlRpc::XmlRpcValue::setDoubleFormat(save_format.c_str());
+  
+  // Test that printing the value with GTest printer works
+  EXPECT_EQ(d.toXml(), ::testing::PrintToString(d));
 }
 
 TEST(XmlRpc, testString) {
@@ -208,6 +217,9 @@ TEST(XmlRpc, testString) {
   std::stringstream ss;
   ss << s;
   EXPECT_EQ("Now is the time <&", ss.str());
+  
+  // Test that printing the value with GTest printer works
+  EXPECT_EQ(s.toXml(), ::testing::PrintToString(s));
 }
 
 //Test decoding of a well-formed but overly large XML input
@@ -542,6 +554,9 @@ TEST(XmlRpc, testArray) {
   std::stringstream ss;
   ss << a;
   EXPECT_EQ("{1,two,43.7,four}", ss.str());
+  
+  // Test that printing the value with GTest printer works
+  EXPECT_EQ(a.toXml(), ::testing::PrintToString(a));
 }
 
 TEST(XmlRpc, testStruct) {
@@ -635,6 +650,8 @@ TEST(XmlRpc, testStruct) {
         EXPECT_EQ(Event[std::string(buf)].size(), NELMTS);
     }
   }
+  // Test that printing the value with GTest printer works
+  EXPECT_EQ(struct1.toXml(), ::testing::PrintToString(struct1));
 }
 
 TEST(XmlRpc, base64) {
@@ -684,6 +701,9 @@ TEST(XmlRpc, base64) {
   d = bin4;
   EXPECT_EQ(d[0], 1);
   EXPECT_EQ(d[1], 2);
+  
+  // Test that printing the value with GTest printer works
+  EXPECT_EQ(bin.toXml(), ::testing::PrintToString(bin));
 }
 
 TEST(XmpRpc, errors) {


### PR DESCRIPTION
The following GTest call currently ends in `XmlRpcException("type error: expected a struct")` being thrown:

    EXPECT_EQ(XmlRpc::XmlRpcValue(false), XmlRpc::XmlRpcValue(0));

That is because GTest tries to print all XmlRpcValues as "containers". Here is the code how GTest determines whether a value is a container:

```c++
typedef int IsContainer;
template <class C>
IsContainer IsContainerTest(int /* dummy */,
                            typename C::iterator* /* it */ = NULL,
                            typename C::const_iterator* /* const_it */ = NULL) {
  return 0;
}
```

XmlRpcValue contains the `iterator` and `const_iterator` typedefs, so it satisifies the GTest condition to be treated as a container.

Further in GTest code:

```c++
template <typename C>
void DefaultPrintTo(IsContainer /* dummy */,
                    false_type /* is not a pointer */,
                    const C& container, ::std::ostream* os) {
  const size_t kMaxCount = 32;  // The maximum number of elements to print.
  *os << '{';
  size_t count = 0;
  for (typename C::const_iterator it = container.begin();
       it != container.end(); ++it, ++count) {
    if (count > 0) {
      *os << ',';
      if (count == kMaxCount) {  // Enough has been printed.
        *os << " ...";
        break;
      }
    }
    *os << ' ';
    // We cannot call PrintTo(*it, os) here as PrintTo() doesn't
    // handle *it being a native array.
    internal::UniversalPrint(*it, os);
  }

  if (count > 0) {
    *os << ' ';
  }
  *os << '}';
}
```

This function calls `container.begin()`, which in case of XmlRpcValue results in `assertStruct()` being called. And that throws the exception for non-struct values.

---

The fix is simple - GTest looks for a `PrintTo()` method and if it finds it, it uses this method to print values and skips the default printer which is problematic.

I chose to print the `toXml()` value instead of calling `write()` so that the GTest output is more explicit about what kind of values failed to compare.

I get this output with this PR:

```
Failure
      Expected: XmlRpc::XmlRpcValue(false)
      Which is: <value><boolean>0</boolean></value>
To be equal to: XmlRpc::XmlRpcValue(0)
      Which is: <value><i4>0</i4></value>
```