### PR TITLE
rosbag::Recorder: allow pausing of message recording

### DIFF
--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -54,6 +54,7 @@
 #include <ros/ros.h>
 #include <ros/time.h>
 
+#include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
 #include <std_msgs/String.h>
 #include <topic_tools/shape_shifter.h>
@@ -102,6 +103,7 @@ struct ROSBAG_DECL RecorderOptions
     // continuous: Messages are continously written to file. A new bag file is opened
     //             when needed, i.e. when max_size or max_duration is exceeded
     bool            snapshot;
+    bool            pause;  //< Allow pausing of message recording, switch via message on topic '~pause'
     bool            verbose;
     bool            publish;  //< publish the current bagfile name on topic 'begin_write'
     bool            repeat_latched;
@@ -137,6 +139,9 @@ public:
 
     int run();
 
+    void pauseTrigger(std_msgs::Bool::ConstPtr trigger);
+    void snapshotTrigger(std_msgs::Empty::ConstPtr trigger);
+
 private:
     void printUsage();
 
@@ -148,7 +153,6 @@ private:
     bool scheduledCheckDisk();
     bool checkDisk();
 
-    void snapshotTrigger(std_msgs::Empty::ConstPtr trigger);
     void doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doRecord();
     void checkNumSplits();

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -95,9 +95,15 @@ struct ROSBAG_DECL RecorderOptions
     bool            do_exclude;
     bool            quiet;
     bool            append_date;
+    // We distinguish two writing modes: snapshot-triggered and continuous
+    // snapshot: Messages are buffered in memory (queue_) and only written to file
+    //           when a message was received on the topic 'snapshot_trigger'.
+    //           Message buffering will continue on a new queue_ meanwhile.
+    // continuous: Messages are continously written to file. A new bag file is opened
+    //             when needed, i.e. when max_size or max_duration is exceeded
     bool            snapshot;
     bool            verbose;
-    bool            publish;
+    bool            publish;  //< publish the current bagfile name on topic 'begin_write'
     bool            repeat_latched;
     CompressionType compression;
     std::string     prefix;
@@ -143,7 +149,6 @@ private:
     bool checkDisk();
 
     void snapshotTrigger(std_msgs::Empty::ConstPtr trigger);
-    //    void doQueue(topic_tools::ShapeShifter::ConstPtr msg, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, std::string const& topic, boost::shared_ptr<ros::Subscriber> subscriber, boost::shared_ptr<int> count);
     void doRecord();
     void checkNumSplits();

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -138,6 +138,7 @@ public:
     boost::shared_ptr<ros::Subscriber> subscribe(std::string const& topic);
 
     int run();
+    void finish();
 
     void pauseTrigger(std_msgs::Bool::ConstPtr trigger);
     void snapshotTrigger(std_msgs::Empty::ConstPtr trigger);
@@ -178,6 +179,7 @@ private:
     std::set<std::string>         currently_recording_;  //!< set of currently recording topics
     int                           num_subscribers_;      //!< used for book-keeping of our number of subscribers
 
+    bool                          finish_;               //!< finish recording
     int                           exit_code_;            //!< eventual exit code
 
     std::map<std::pair<std::string, std::string>, OutgoingMessage> latched_msgs_;

--- a/tools/rosbag/include/rosbag/recorder.h
+++ b/tools/rosbag/include/rosbag/recorder.h
@@ -53,6 +53,7 @@
 
 #include <ros/ros.h>
 #include <ros/time.h>
+#include <ros/subscriber.h>
 
 #include <std_msgs/Bool.h>
 #include <std_msgs/Empty.h>
@@ -176,8 +177,9 @@ private:
     std::string                   write_filename_;
     std::list<std::string>        current_files_;
 
+    std::list<boost::shared_ptr<ros::Subscriber>> subscribers_;
     std::set<std::string>         currently_recording_;  //!< set of currently recording topics
-    int                           num_subscribers_;      //!< used for book-keeping of our number of subscribers
+    int                           num_subscribers_;      //!< number of active subscribers, used for automatic ros::shutdown
 
     bool                          finish_;               //!< finish recording
     int                           exit_code_;            //!< eventual exit code

--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -54,7 +54,7 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("regex,e", "match topics using regular expressions")
       ("exclude,x", po::value<std::string>(), "exclude topics matching regular expressions")
       ("quiet,q", "suppress console output")
-      ("publish,p", "Publish a msg when the record begin")
+      ("publish,p", "Publish a msg (with the actual bagfile name) when the recording begins")
       ("output-prefix,o", po::value<std::string>(), "prepend PREFIX to beginning of bag name")
       ("output-name,O", po::value<std::string>(), "record bagnamed NAME.bag")
       ("buffsize,b", po::value<int>()->default_value(256), "Use an internal buffer of SIZE MB (Default: 256)")

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -262,6 +262,9 @@ void Recorder::finish()
 {
   finish_ = true;
   queue_condition_.notify_all();
+  // unsubscribe from all topics
+  for (const auto& sub : subscribers_)
+    sub->shutdown();
 }
 
 void Recorder::pauseTrigger(std_msgs::Bool::ConstPtr trigger)
@@ -287,6 +290,7 @@ shared_ptr<ros::Subscriber> Recorder::subscribe(string const& topic) {
     ops.transport_hints = options_.transport_hints;
     *sub = nh.subscribe(ops);
 
+    subscribers_.push_back(sub);
     currently_recording_.insert(topic);
     num_subscribers_++;
 

--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -325,7 +325,6 @@ std::string Recorder::timeToStr(T ros_t)
 
 //! Callback to be invoked to save messages into a queue
 void Recorder::doQueue(const ros::MessageEvent<topic_tools::ShapeShifter const>& msg_event, string const& topic, shared_ptr<ros::Subscriber> subscriber, shared_ptr<int> count) {
-    //void Recorder::doQueue(topic_tools::ShapeShifter::ConstPtr msg, string const& topic, shared_ptr<ros::Subscriber> subscriber, shared_ptr<int> count) {
     Time rectime = Time::now();
     
     if (options_.verbose)


### PR DESCRIPTION
This is a rework of #1294 addressing [comments by @dirk-thomas](https://github.com/ros/ros_comm/pull/1294#issuecomment-363184836).
The primary goal is to provide an API to pause and continue message recording. As suggested by Dirk, this PR
- keeps pausing independent from snapshot triggering: while pausing stops message recording (into the memory queue), the latter triggers writing to a new file (but always continues recording)
- uses `std_msgs::Bool` to pause/continue recording

The new API is not exposed to the cmdline, because the snapshot API isn't either (and I don't need it to be exposed).