### PR TITLE
[roslaunch] add 'command' attribute to 'arg' tag

### DIFF
--- a/tools/roslaunch/src/roslaunch/depends.py
+++ b/tools/roslaunch/src/roslaunch/depends.py
@@ -45,7 +45,7 @@ from xml.dom import Node as DomNode
 
 import rospkg
 
-from .loader import convert_value, load_mappings
+from .loader import convert_value, load_mappings, exec_command
 from .substitution_args import resolve_args
 
 NAME="roslaunch-deps"
@@ -92,6 +92,8 @@ def _get_arg_value(tag, context):
         return context['arg'][name]
     elif 'default' in tag.attributes.keys():
         return resolve_args(tag.attributes['default'].value, context)
+    elif 'command' in tag.attributes.keys():
+        return exec_command(resolve_args(tag.attributes['command'].value, context))
     else:
         raise RoslaunchDepsException("No value for arg [%s]"%(name))
 

--- a/tools/roslaunch/src/roslaunch/xmlloader.py
+++ b/tools/roslaunch/src/roslaunch/xmlloader.py
@@ -285,7 +285,7 @@ class XmlLoader(loader.Loader):
             raise XmlParseException(
                 "Invalid <param> tag: %s. \n\nParam xml is %s"%(e, tag.toxml()))
 
-    ARG_ATTRS = ('name', 'value', 'default', 'doc')
+    ARG_ATTRS = ('name', 'value', 'default', 'command', 'doc')
     @ifunless
     def _arg_tag(self, tag, context, ros_config, verbose=True):
         """
@@ -294,12 +294,14 @@ class XmlLoader(loader.Loader):
         try:
             self._check_attrs(tag, context, ros_config, XmlLoader.ARG_ATTRS)
             (name,) = self.reqd_attrs(tag, context, ('name',))
-            value, default, doc = self.opt_attrs(tag, context, ('value', 'default', 'doc'))
+            value, default, command, doc = self.opt_attrs(tag, context, ('value', 'default', 'command', 'doc'))
             
-            if value is not None and default is not None:
+            if ((value is not None) + (default is not None) + (command is not None)) > 1:
                 raise XmlParseException(
-                    "<arg> tag must have one and only one of value/default.")
+                    "<arg> tag must have one and only one of value/default/command.")
             
+            if (command is not None):
+                value = loader.exec_command(name, self.resolve_args(command, context))
             context.add_arg(name, value=value, default=default, doc=doc)
 
         except substitution_args.ArgException as e:


### PR DESCRIPTION
There is very useful feature of setting parameter value from shell command output (attribute 'command' of 'param' tag). But the functionality is too limited: it is impossible to pass a command result to included launch or to node arguments. Extending this feature to arguments provides more ability for customization. It resolves #1767. Also, it can be used as a workaround for problem, described in #723 