### PR TITLE
Add a workaround for a race condition while closing the socket (#2212)

### DIFF
--- a/clients/rospy/src/rospy/impl/tcpros_base.py
+++ b/clients/rospy/src/rospy/impl/tcpros_base.py
@@ -856,6 +856,13 @@ class TCPROSTransport(Transport):
                         pass
                     finally:
                         self.socket.close()
+            except AttributeError:
+                # this is a workaround to avoid a race condition: thread A
+                # checks the self.socket to be not None (above in
+                # this function), thread B sets it to None (below in this
+                # function) and then thread A executes self.socket.close()
+                # (above in this function)
+                pass
             finally:
                 self.socket = self.read_buff = self.write_buff = self.protocol = None
                 super(TCPROSTransport, self).close()


### PR DESCRIPTION
This is not a fix but rather a workaround to avoid the exception when the socket is closed from two different threads (race condition). A proper fix would require to redesign the whole class to be thread safe. See https://github.com/ros/ros_comm/issues/2212.