### PR TITLE
rosbag_main.py: fix calling uncallable signal handler object (#2235)

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -68,13 +68,13 @@ def handle_split(option, opt_str, value, parser):
 
 def _stop_process(signum, frame, old_handler, process):
     process.terminate()
-    if old_handler:
+    if callable(old_handler):
         old_handler(signum, frame)
 
 
 def _send_process_sigint(signum, frame, old_handler, process):
     process.send_signal(signal.SIGINT)
-    if old_handler:
+    if callable(old_handler):
         old_handler(signum, frame)
 
 


### PR DESCRIPTION
Fixes #2235 