### PR TITLE
Statistics deadlock fix

### DIFF
--- a/clients/roscpp/CMakeLists.txt
+++ b/clients/roscpp/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(roscpp
   src/libros/poll_manager.cpp
   src/libros/publication.cpp
   src/libros/statistics.cpp
+  src/libros/statistics_manager.cpp
   src/libros/intraprocess_subscriber_link.cpp
   src/libros/intraprocess_publisher_link.cpp
   src/libros/callback_queue.cpp

--- a/clients/roscpp/include/ros/statistics.h
+++ b/clients/roscpp/include/ros/statistics.h
@@ -31,7 +31,6 @@
 #include "forwards.h"
 #include "poll_set.h"
 #include "common.h"
-#include "publisher.h"
 #include <ros/time.h>
 #include "ros/subscription_callback_helper.h"
 #include <map>
@@ -84,10 +83,7 @@ private:
 
   // frequency to publish statistics
   double pub_frequency_;
-
-  // publisher for statistics data
-  ros::Publisher pub_;
-
+  
   struct StatData {
     // last time, we published /statistics data
     ros::Time last_publish;

--- a/clients/roscpp/include/ros/statistics_manager.h
+++ b/clients/roscpp/include/ros/statistics_manager.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022, Torc Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Torc Robotics, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef ROSCPP_STATISTICS_MANAGER_H
+#define ROSCPP_STATISTICS_MANAGER_H
+
+#include "forwards.h"
+#include "common.h"
+#include "advertise_service_options.h"
+#include "service_client_options.h"
+#include "publisher.h"
+#include <boost/thread/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/recursive_mutex.hpp>
+#include <rosgraph_msgs/TopicStatistics.h>
+namespace ros
+{
+
+class StatisticsManager;
+typedef boost::shared_ptr<StatisticsManager> StatisticsManagerPtr;
+
+class ROSCPP_DECL StatisticsManager
+{
+public:
+  static const StatisticsManagerPtr& instance();
+
+  StatisticsManager();
+  ~StatisticsManager();
+
+
+  /** @brief Adds topic statistics to the publishing queue
+   *
+   * @param msg The TopicStatistics msg to addeded to queue.
+   */
+  void addToQueue(rosgraph_msgs::TopicStatistics msg);
+  void threadFunc();
+  void start();
+  void shutdown();
+
+private:
+  std::deque<rosgraph_msgs::TopicStatistics> statistics_queue_;
+  boost::mutex statistics_queue_mutex_;
+  volatile bool shutting_down_;
+  ros::Publisher pub_;
+  boost::thread thread_;
+};
+
+} // namespace ros
+
+#endif // ROSCPP_STATISTICS_MANAGER_H
+

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -39,6 +39,7 @@
 #include "ros/connection_manager.h"
 #include "ros/topic_manager.h"
 #include "ros/service_manager.h"
+#include "ros/statistics_manager.h"
 #include "ros/this_node.h"
 #include "ros/network.h"
 #include "ros/file_log.h"
@@ -328,6 +329,7 @@ void start()
   ConnectionManager::instance()->start();
   PollManager::instance()->start();
   XMLRPCManager::instance()->start();
+  StatisticsManager::instance()->start();
 
   if (!(g_init_options & init_options::NoSigintHandler))
   {

--- a/clients/roscpp/src/libros/statistics.cpp
+++ b/clients/roscpp/src/libros/statistics.cpp
@@ -27,6 +27,7 @@
 
 #include "ros/statistics.h"
 #include "ros/node_handle.h"
+#include "ros/statistics_manager.h"
 #include <rosgraph_msgs/TopicStatistics.h>
 #include "ros/this_node.h"
 #include "ros/message_traits.h"
@@ -227,14 +228,7 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
       msg.period_max = ros::Duration(0);
     }
 
-    if (!pub_.getTopic().length())
-    {
-      ros::NodeHandle n("~");
-      // creating the publisher in the constructor results in a deadlock. so do it here.
-      pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics", 1);
-    }
-
-    pub_.publish(msg);
+    StatisticsManager::instance()->addToQueue(msg);
 
     // dynamic window resizing
     if (stats.arrival_time_list.size() > static_cast<size_t>(max_elements) && pub_period / 2.0 >= min_window)
@@ -256,6 +250,5 @@ void StatisticsLogger::callback(const boost::shared_ptr<M_string>& connection_he
   // store the stats for this connection
   map_[callerid] = stats;
 }
-
 
 } // namespace ros

--- a/clients/roscpp/src/libros/statistics_manager.cpp
+++ b/clients/roscpp/src/libros/statistics_manager.cpp
@@ -77,6 +77,7 @@ void StatisticsManager::threadFunc()
       pub_.publish(msg);
       statistics_queue_.pop_front();
     }
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(1));
   }
 }
 

--- a/clients/roscpp/src/libros/statistics_manager.cpp
+++ b/clients/roscpp/src/libros/statistics_manager.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2022, Torc Robotics, Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the names of Torc Robotics, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <cstdio>
+#include "ros/statistics_manager.h"
+#include "ros/node_handle.h"
+#include "ros/this_node.h"
+
+using namespace std; // sigh
+
+namespace ros
+{
+
+const StatisticsManagerPtr& StatisticsManager::instance()
+{
+  static StatisticsManagerPtr statistics_manager = boost::make_shared<StatisticsManager>();
+  return statistics_manager;
+}
+
+StatisticsManager::StatisticsManager()
+{
+
+}
+
+StatisticsManager::~StatisticsManager()
+{
+  shutdown();
+}
+
+void StatisticsManager::addToQueue(rosgraph_msgs::TopicStatistics msg)
+{
+  if(!shutting_down_)
+  {
+    boost::mutex::scoped_lock lock(statistics_queue_mutex_);
+    statistics_queue_.push_back(msg);
+  }
+}
+
+void StatisticsManager::threadFunc()
+{
+  while(!shutting_down_)
+  {
+    if (!statistics_queue_.empty() && !pub_.getTopic().length())
+    {
+      ros::NodeHandle n("~");
+      // We do not want to advertise in the constructor because that will advertise even if enable_statistics is unset or set to false. 
+      pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics", 1);
+    }
+    boost::mutex::scoped_lock lock(statistics_queue_mutex_);
+    while(!statistics_queue_.empty())
+    {
+      auto msg = statistics_queue_.front();
+      pub_.publish(msg);
+      statistics_queue_.pop_front();
+    }
+  }
+}
+
+void StatisticsManager::start()
+{
+  shutting_down_ = false;
+  thread_ = boost::thread(&StatisticsManager::threadFunc, this);
+}
+
+void StatisticsManager::shutdown()
+{
+  shutting_down_ = true;
+  thread_.join();
+}
+
+} // namespace ros
+

--- a/clients/roscpp/src/libros/statistics_manager.cpp
+++ b/clients/roscpp/src/libros/statistics_manager.cpp
@@ -70,12 +70,15 @@ void StatisticsManager::threadFunc()
       // We do not want to advertise in the constructor because that will advertise even if enable_statistics is unset or set to false. 
       pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics", 1);
     }
-    boost::mutex::scoped_lock lock(statistics_queue_mutex_);
-    while(!statistics_queue_.empty() && pub_.getTopic().length())
     {
-      auto msg = statistics_queue_.front();
-      pub_.publish(msg);
-      statistics_queue_.pop_front();
+      // Put scoped_lock within brackets to leave its scope and unlock mutex prior to sleep
+      boost::mutex::scoped_lock lock(statistics_queue_mutex_);
+      while(!statistics_queue_.empty() && pub_.getTopic().length())
+      {
+        auto msg = statistics_queue_.front();
+        pub_.publish(msg);
+        statistics_queue_.pop_front();
+      }
     }
     boost::this_thread::sleep_for(boost::chrono::milliseconds(1));
   }

--- a/clients/roscpp/src/libros/statistics_manager.cpp
+++ b/clients/roscpp/src/libros/statistics_manager.cpp
@@ -71,7 +71,7 @@ void StatisticsManager::threadFunc()
       pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics", 1);
     }
     boost::mutex::scoped_lock lock(statistics_queue_mutex_);
-    while(!statistics_queue_.empty())
+    while(!statistics_queue_.empty() && pub_.getTopic().length())
     {
       auto msg = statistics_queue_.front();
       pub_.publish(msg);


### PR DESCRIPTION
Credit to Jacob White @ Torc Robotics for the thorough research on development of this fix.

ROS_COMM Problem and Solution

There are two deadlocks that can occur when the rosparam enable_statistics is set to true. Both stem from this block of code from statistics.cpp in the ros_comm package (line 230):

 ```
    if (!pub_.getTopic().length())
    {
      ros::NodeHandle n("~");
      // creating the publisher in the constructor results in a deadlock. so do it here.
      pub_ = n.advertise<rosgraph_msgs::TopicStatistics>("/statistics", 1);
    }    

    pub_.publish(msg)
```
 

Note: The comment describing the publisher deadlock is original ros content.

Deadlock 1:
During the advertisement of the /statistics msg, a deadlock can occur if the same topic is adveritised twice. The StatisticsLogger calls the advertise function after a second of statistics data is accumulated on the topic of interest.   Thus in order to produce the deadlock, we must be in the middle of subscribing to something exactly 1 second after the 1st subscriber was created. A deadlock occurs between callbacks_mutex_ in Subscription class and the subs_mutex_ in the TopicManager class. Stack trace with mutex ownership described below.  This will occur only on startup during the second subscription to the same topic. In our case this was the tf topic. 
Because the statistics logger requests 5 ros parameters, and init is called every time there is a new subscription, the network delay becomes a factor and is required to demonstrate this.  

Thread 1
- 3 Subscription::addCallback              <-- Waiting on callbacks_mutex_
StatisticsLogger::init
callbacks_mutex_
- 4 TopicManager::addSubCallback
- 5 TopicManager::subscribe                <-- Has subs_mutex_ 
- 6 NodeHandle::subscribe
- 7 TransformListener::initWithThread
- 8 TransformListener::TransformListener
- 9 ObjStreamGroup::ObjStreamGroup

Thread 2
- 3 TopicManager::advertise                <-- Waiting on subs_mutex_
- 4 NodeHandle::advertise
- 5 NodeHandle::advertise<TopicStatistics>
- 6 StatisticsLogger::callback
- 7 Subscription::handleMessage            <-- Has callbacks_mutex_
- 8 TransportPublisherLink::handleMessage
- 9 TransportPublisherLink::onMessage
- 10 Connection::readTransport
- 11 TransportTCP::socketUpdate
- 12 PollSet::update
- 13 PollManager::threadFunc

Deadlock 2:
The second deadlock occurs because there is a deadlock between 4 separate threads running that become locked due to a direct call to publish within subscription.cpp via StatisticsLogger::publish. This happens on the thread within PollManager which is listening for incoming subscribed topics. When Subscription::handleMessage is called, the callbacks_mutex_ is locked which prevents call to StatisticsLogger::publish from creating the publisher for /statistics. This also occurs on startup. The topic that appears to drive this is the bond topic that occurs between nodelet components.

A summary of the lock is provided below.

Threads are waiting on these mutexes:
Thread 1: Bond::isBroken()
- Waiting on Bond mutex_

Thread 2: TopicManager::publish
- Waiting on advertised_topics_mutex_
- Has callbacks_mutex_
- Likely has close_mutex_

Thread 3: TransportTCP::close()
- Waiting on close_mutex_

Thread 7: Subscription::getPublishTypes((bool&, bool&, std::type_info const&)
- Waiting on callbacks_mutex_
- Has Bond mutex_
- Has advertised_topics_mutex_

 
Solution:

Based on Jacob White's suggestion, another class was created to handle the accumulation of /statistics msg data with it's own thread to handle publishing of queued statistics data. It was constructed using a similar pattern used in the other classes called in init.cpp and is initialized in the same location.

```
  TopicManager::instance()->start();
  ServiceManager::instance()->start();
  ConnectionManager::instance()->start();
  PollManager::instance()->start();
  XMLRPCManager::instance()->start();
  StatisticsManager::instance()->start(); <------  new class 
```

Instead of publishing directly, now the StatisticsLogger class calls StatisticsManager::addToQueue to add the msg to a mutex protected deque and the threadFunc handed off to the new thread consumes and publishes the msgs.
This change moves the initialization of the publisher and publishing of the messages off of the PollManager thread.

Attached in a subsequent comment is a small set of code that can be used to recreate the deadlock. 
You'll need to clone `ros_comm` where is says to to provide an overlay and after building the package, these steps are required to recreate it locally: 

1. Start roscore and set enable_statistics to true. This can be done via the launch file in the zip file.

2. Introduce a network delay to simulate a highly loaded network. 
This can be done via the instructions in this link. The same instructions exist inside the package inside minimal_deadlock_node.cpp. Target your loopback connection if testing on a local machine. 
https://www.pico.net/kb/how-can-i-simulate-delayed-and-dropped-packets-in-linux/

3. Playback a rosbag with tf topics or have some node consistently broadcast tf data. 

4. Run the node via 'rosrun minimal_deadlock minimal_deadlock_node`
     The terminal will output the timing of specific locks and unlocks. Depending on the computer performance adjusting the timing of the delay and the timing of the sleep call in minimal_deadlock.cpp.

After switching to the updated branch and rebuilding, the deadlock is no longer possible to recreate with the same steps.