### PR TITLE
Fix #2249: Topic statistics do not handle well ROS time jumping back

### DIFF
--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -150,6 +150,7 @@ add_rostest(launch/search_param.xml)
 
 add_rostest(launch/stamped_topic_statistics_with_empty_timestamp.xml)
 add_rostest(launch/topic_statistic_frequency.xml DEPENDENCIES ${PROJECT_NAME}-publisher_rate ${PROJECT_NAME}-subscriber ${PROJECT_NAME}-topic_statistic_frequency)
+add_rostest(launch/topic_statistics.xml DEPENDENCIES ${PROJECT_NAME}-topic_statistics)
 
 # Test multiple latched publishers within the same process
 add_rostest(launch/multiple_latched_publishers.xml)

--- a/test/test_roscpp/test/launch/topic_statistics.xml
+++ b/test/test_roscpp/test/launch/topic_statistics.xml
@@ -1,0 +1,4 @@
+<launch>
+  <param name="/enable_statistics" value="true" />
+  <test test-name="roscpp_test_topic_statistics" pkg="test_roscpp" type="test_roscpp-topic_statistics" />
+</launch>

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -212,6 +212,9 @@ add_executable(${PROJECT_NAME}-multiple_latched_publishers EXCLUDE_FROM_ALL mult
 target_link_libraries(${PROJECT_NAME}-multiple_latched_publishers ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME}-multiple_latched_publishers ${std_msgs_EXPORTED_TARGETS})
 
+add_executable(${PROJECT_NAME}-topic_statistics EXCLUDE_FROM_ALL topic_statistics.cpp)
+target_link_libraries(${PROJECT_NAME}-topic_statistics ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+
 # The publishers and subscriber are compiled but not registered as a unit test
 # since the test execution requires a network connection which drops packages.
 # Call scripts/test_udp_with_dropped_packets.sh to run the test.
@@ -294,6 +297,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp
     ${PROJECT_NAME}-topic_statistic_frequency
     ${PROJECT_NAME}-multiple_latched_publishers
+    ${PROJECT_NAME}-topic_statistics
   )
 endif()
 
@@ -361,3 +365,4 @@ add_dependencies(${PROJECT_NAME}-stamped_topic_statistics_empty_timestamp
  ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-topic_statistic_frequency ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-multiple_latched_publishers ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}-topic_statistics ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/test/test_roscpp/test/src/topic_statistics.cpp
+++ b/test/test_roscpp/test/src/topic_statistics.cpp
@@ -1,0 +1,104 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2022, Open Source Robotics Foundation
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gtest/gtest.h>
+
+#include <boost/shared_ptr.hpp>
+
+#include <ros/duration.h>
+#include <ros/init.h>
+#include <ros/node_handle.h>
+#include <ros/statistics.h>
+#include <ros/subscription_callback_helper.h>
+#include <ros/time.h>
+#include <std_msgs/String.h>
+
+/**
+ * \brief Simulate receiving 10000 subscription callbacks of std_msgs/String messages with
+ *        increasing timestamp, starting from time 1.0.
+ * \param[in] logger The statistics logger to call when a simulated message is received.
+ */
+void lotsOfMessages(ros::StatisticsLogger& logger)
+{
+  ros::Time now(1, 0);
+  ros::Duration dt(0.1);
+  for (size_t i = 0; i < 10000; ++i)
+  {
+    ros::Time::setNow(now);
+    logger.callback(nullptr, "topic", "caller", {}, 100, now, false, 0);
+    now += dt;
+  }
+}
+
+/**
+ * \brief Unused.
+ */
+void fooCb(const std_msgs::String&)
+{
+}
+
+/**
+ * \brief Test that resetting ROS time while a lot of messages is published doesn't
+ *        congest the statistics (https://github.com/ros/ros_comm/issues/2249).
+ */
+TEST(TopicStatistics, TimeJumps)
+{
+  ros::StatisticsLogger logger;
+  auto h = boost::make_shared<ros::SubscriptionCallbackHelperT<std_msgs::String>>(&fooCb);
+  logger.init(h);
+  
+  // Make 4 repetitions of receiving 10000 messages. First repetition is okay. If the
+  // bug from doc-comment is not fixed, the following iterations will take considerably
+  // longer because the internal lists are never cleared.
+  
+  ros::WallDuration initialDuration;
+  for (size_t i = 0; i < 4; ++i)
+  {
+    auto start = ros::WallTime::now();
+    lotsOfMessages(logger);
+    auto duration = ros::WallTime::now() - start;
+    if (i == 0)
+      initialDuration = duration;
+    else
+      EXPECT_GT(initialDuration * 5, duration);
+  }
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "topic_statistics");
+  ros::NodeHandle nh;
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
First, I'm submitting a [failing test](https://build.ros.org/job/Npr__ros_comm__ubuntu_focal_amd64/520/testReport/).

It makes 4 repetitions of receiving 10000 messages, each time resetting ROS time from 1.0 onwards. First repetition is okay. If #2249 is not fixed, the following iterations will take considerably longer because the internal lists are never cleared.