### PR TITLE
Add an environment variable to disable rosout

### DIFF
--- a/tools/roslaunch/resources/roscore.xml
+++ b/tools/roslaunch/resources/roscore.xml
@@ -8,6 +8,6 @@
   <group ns="/">
     <param name="rosversion" command="rosversion roslaunch" />
     <param name="rosdistro" command="rosversion -d" />
-    <node pkg="rosout" type="rosout" name="rosout" respawn="true"/>
+    <node pkg="rosout" type="rosout" name="rosout" respawn="true" unless="$(optenv ROS_ROSOUT_DISABLE false)"/>
   </group>
 </launch>


### PR DESCRIPTION
There are a lot of questions around asking about how to disable logging in ROS. One of the more difficult things to do is to turn off rosout. Our solution was to patch all of our ROS installs and set an environment variable to disable logging.

ROSOUT_DISABLE_FILE_LOGGING exists but rosout still runs which is unnecessary for our deployed systems.

https://github.com/ros/ros_comm/issues/139
https://answers.ros.org/question/9627/how-can-i-completely-disable-writing-logs-to-filesystem/