### PR TITLE
Update topic_tools relay_field to Python 3

### DIFF
--- a/tools/topic_tools/scripts/relay_field
+++ b/tools/topic_tools/scripts/relay_field
@@ -16,7 +16,6 @@ Example:
          frame_id: m.data"
 """
 
-from __future__ import print_function
 import argparse
 import sys
 import copy

--- a/tools/topic_tools/scripts/relay_field
+++ b/tools/topic_tools/scripts/relay_field
@@ -38,7 +38,7 @@ def _eval_in_dict_impl(dict_, globals_, locals_):
         type_ = type(v)
         if type_ is dict:
             res[k] = _eval_in_dict_impl(v, globals_, locals_)
-        elif (type_ is str) or (type_ is unicode):
+        elif (type_ is str) or (type_ is bytes):
             try:
                 res[k] = eval(v, globals_, locals_)
             except NameError:


### PR DESCRIPTION
### Solves
[Issue 2167](https://github.com/ros/ros_comm/issues/2167)

### Content
Implementing the "unicode" to "bytes" migration the author of [Issue 2167](https://github.com/ros/ros_comm/issues/2167) describes.

After this change, Python's 2to3 only suggests 
 - using list() to encase the result of a dictionary's items() before iterating over it (which is not useful) and 
 - deleting the import of print_function from future (which we might as well do).

### Explanation
To address the second half of [issue #2167](https://github.com/ros/ros_comm/pull/639#issuecomment-121757055), it is the OP's example which is at fault, not relay_field. The example attempts to write a string to a field ("data") whose type has changed from "unicode" to "bytes" in Noetic. Replacing the empty string with empty brackets [] fixes that example. The example in the file's help looks intact.

### Testing
On my copy of Noetic the attached example launch files run when the edit in this PR is made. Both show the frame_id being transferred but the timestamp changed to one second.

[test_relay_field.tar.gz](https://github.com/ros/ros_comm/files/8995956/test_relay_field.tar.gz)

I have not tested beyond these two examples.