### PR TITLE
Exposed record snapshot feature for command line.

### DIFF
--- a/tools/rosbag/src/record.cpp
+++ b/tools/rosbag/src/record.cpp
@@ -54,7 +54,8 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
       ("regex,e", "match topics using regular expressions")
       ("exclude,x", po::value<std::string>(), "exclude topics matching regular expressions")
       ("quiet,q", "suppress console output")
-      ("publish,p", "Publish a msg when the record begin")
+      ("snapshot,s", "Run in snapshot mode")
+      ("publish,p", "Publish a msg when the recording begins")
       ("output-prefix,o", po::value<std::string>(), "prepend PREFIX to beginning of bag name")
       ("output-name,O", po::value<std::string>(), "record bagnamed NAME.bag")
       ("buffsize,b", po::value<int>()->default_value(256), "Use an internal buffer of SIZE MB (Default: 256)")
@@ -106,6 +107,8 @@ rosbag::RecorderOptions parseOptions(int argc, char** argv) {
     }
     if (vm.count("quiet"))
       opts.quiet = true;
+    if (vm.count("snapshot"))
+      opts.snapshot = true;
     if (vm.count("publish"))
       opts.publish = true;
     if (vm.count("repeat-latched"))


### PR DESCRIPTION
I exposed the existing snapshot function of `rosbag::Recorder` in the command line options of the record verb.