### PR TITLE
Added feature to enable or disable logs through service call

### DIFF
--- a/clients/rospy/src/rospy/client.py
+++ b/clients/rospy/src/rospy/client.py
@@ -157,14 +157,23 @@ _names_to_logging_levels = {
       'ERROR':    logging.ERROR,
       'FATAL':    logging.CRITICAL,
       }
+_level_to_change_logs = {
+      "ENABLE":    logging.NOTSET,
+      "DISABLE":   logging.CRITICAL
+}
 
 def _set_logger_level(request):
     """
     ROS service handler to set the logging level for a particular logger
     """
     level = request.level.upper()
-    if level in _names_to_logging_levels:
-        logger = logging.getLogger(request.logger)
+    logger_request = request.logger
+    if logger_request.upper() in _level_to_change_logs:
+        logging.disable(_level_to_change_logs[logger_request.upper()])
+    elif level in _names_to_logging_levels:
+        logger = logging.getLogger(logger_request)
+        if(not logger.isEnabledFor(logging.CRITICAL)):
+            logging.disable(_level_to_change_logs["ENABLE"])
         logger.setLevel(_names_to_logging_levels[level])
     else:
        logging.getLogger('rospy').error("Bad logging level: %s"%level)


### PR DESCRIPTION
**Issue aimed**
Basically right now there is no way to stop logging during the runtime of rospy node ,event though using service call one cannot disable logs, they can only change the log level of the node.
So to overcome this issue I have basically added a feature to enable/disable logs for any rospy node using base service `set_logger_level`.

**Approach**
To enable/disable logs, one has to pass enable/disable parameter in logger, part of service request.
_Sample Service call to disable logging_
`rosservice call /node_name/set_logger_level "logger: 'disable' level: 'info'" `
This will make sure no logs will get dump.

Moreover the logs will automatically get enable if any other logger is set in service request.
Example:
`rosservice call /node_name/set_logger_level "logger: 'rospy' level: 'info'" `
or using enable parameter
`rosservice call /node_name/set_logger_level "logger: 'enable' level: 'info'" `

**Future**
Once this PR is approved I will raise a PR for roscpp part (already tested & created), so that any node can be disable using service call.