### PR TITLE
support `rosbag play --loop` in `rospy.Timer`

### DIFF
--- a/clients/rospy/src/rospy/timer.py
+++ b/clients/rospy/src/rospy/timer.py
@@ -226,6 +226,9 @@ class Timer(threading.Thread):
         while not rospy.core.is_shutdown() and not self._shutdown:
             try:
                 r.sleep()
+            except rospy.exceptions.ROSTimeMovedBackwardsException:
+                # avoid killing the timer just because a rosbag looped
+                pass
             except rospy.exceptions.ROSInterruptException as e:
                 if rospy.core.is_shutdown():
                     break


### PR DESCRIPTION
I fail to understand why this issue still exists after all these years, though I really should not be surprised...

Without the patch the Timer thread just dies on rosbag loop *with no way of detecting and restarting it* easily.
The patch changes the behavior to assume it slept enough and calls the callback again.
If the callback logic requires resets, this can be detected from the TimerEvent passed to the callback.

This addresses a use case that is currently fully broken, so there is no need to worry about incompatible behavior.