### PR TITLE
Fix get_type_and_topic_info() exception in Python3

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -857,7 +857,7 @@ class Bag(object):
         # load our list of topics and optionally filter
         if topic_filters is not None:
             if not isinstance(topic_filters, list):
-                topic_filters = [topic_filters]
+                topic_filters = list(topic_filters)
                 
             topics = topic_filters
         else:


### PR DESCRIPTION
Calling this function in Python 3 can produce the exception "TypeError: unhashable type: 'dict_keys'", we should use proper conversion to list to fix this exception