### PR TITLE
rosnode: allow rosrun & roslaunch to find script

### DIFF
--- a/tools/rosnode/CMakeLists.txt
+++ b/tools/rosnode/CMakeLists.txt
@@ -9,3 +9,6 @@ if(CATKIN_ENABLE_TESTING)
   find_package(rostest)
   add_rostest(test/rosnode.test)
 endif()
+
+catkin_install_python(PROGRAMS scripts/rosnode
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
As per subject.

See the commit comment for more info.

Inspired by what `rosservice` does:

https://github.com/ros/ros_comm/blob/dd78ac8af128bb8eb992d6431bb9f994658ea6ab/tools/rosservice/CMakeLists.txt#L8-L9

I'm not aware of any adverse side-effects, but haven't extensively tried to look for any either.
