### PR TITLE
Expose is_shutdown_requested in rospy namespace.

### DIFF
--- a/clients/rospy/src/rospy/__init__.py
+++ b/clients/rospy/src/rospy/__init__.py
@@ -54,7 +54,7 @@ from .client import spin, myargv, init_node, \
     get_param, get_param_cached, get_param_names, set_param, delete_param, has_param, search_param,\
     DEBUG, INFO, WARN, ERROR, FATAL
 from .timer import sleep, Rate, Timer
-from .core import is_shutdown, signal_shutdown, \
+from .core import is_shutdown, signal_shutdown, is_shutdown_requested, \
     get_node_uri, get_ros_root, \
     logdebug, logwarn, loginfo, logout, logerr, logfatal, \
     logdebug_throttle, logwarn_throttle, loginfo_throttle, logerr_throttle, logfatal_throttle, \
@@ -99,6 +99,7 @@ __all__ = [
     'ERROR',
     'FATAL',
     'is_shutdown',
+    'is_shutdown_requested',
     'signal_shutdown',
     'get_node_uri',
     'get_ros_root',


### PR DESCRIPTION
Just like the C++ `ros::isShuttingDown()`, this can be useful in certain
cases where shutdown needs to be checked before all shutdown handlers
finished.

The difference to `is_shutdown()` is already clearly described in the
docstring of `is_shutdown_requested()` (see [here](https://github.com/ros/ros_comm/blob/dd78ac8af128bb8eb992d6431bb9f994658ea6ab/clients/rospy/src/rospy/core.py#L465)).