### PR TITLE
Fix/Improve $(eval ...)

### DIFF
--- a/tools/roslaunch/src/roslaunch/substitution_args.py
+++ b/tools/roslaunch/src/roslaunch/substitution_args.py
@@ -343,7 +343,9 @@ def _eval(s, context):
 
     # ignore values containing double underscores (for safety)
     # http://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
-    if s.find('__') >= 0:
+    code = compile(s.strip(), "<expression>", "eval")
+    invalid_names = [n for n in code.co_names if n.startswith("__")]
+    if invalid_names:
         raise SubstitutionException("$(eval ...) may not contain double underscore expressions")
     return str(eval(s, _DictWrapper(context['arg'], functions)))
 

--- a/tools/roslaunch/test/unit/test_substitution_args.py
+++ b/tools/roslaunch/test/unit/test_substitution_args.py
@@ -95,7 +95,7 @@ def test_resolve_args():
     assert roslaunch_dir
 
     anon_context = {'foo': 'bar'}
-    arg_context = {'fuga': 'hoge', 'car': 'cdr', 'arg': 'foo', 'True': 'False'}
+    arg_context = {'fuga': 'hoge', 'car': 'cdr', 'arg': 'foo', 'True': 'False', 'dou__ble': '3.14'}
     context = {'anon': anon_context, 'arg': arg_context, 'filename': '/path/to/file.launch'}
         
     tests = [
@@ -145,6 +145,8 @@ def test_resolve_args():
         ('$(eval arg("True"))', 'False'),
         ('$(eval 1==1)', 'True'),
         ('$(eval [0,1,2][1])', '1'),
+        ('$(eval dou__ble)', '3.14'),
+        ('$(eval "dou__ble")', 'dou__ble'),
         # test implicit arg access
         ('$(eval fuga)', 'hoge'),
         ('$(eval True)', 'True'),
@@ -181,7 +183,8 @@ def test_resolve_args():
         '$(anon)',
         '$(anon foo bar)',            
         # Should fail without the supplied context.
-        '$(dirname)'
+        '$(dirname)',
+        '$(eval __import__("os"))',
         ]
     for f in failures:
         try:

--- a/tools/roslaunch/test/unit/test_substitution_args.py
+++ b/tools/roslaunch/test/unit/test_substitution_args.py
@@ -153,6 +153,8 @@ def test_resolve_args():
         ('$(eval cos(0))', '1.0'),
         # str, map
         ("$(eval ''.join(map(str, [4,2])))", '42'),
+        # global symbols in range context
+        ("$(eval [arg(var) for var in ['fuga', 'arg']])", "['hoge', 'foo']")
     ]
     for arg, val in tests:
         assert val == resolve_args(arg, context=context), arg


### PR DESCRIPTION
Evaluation of global symbols in list comprehension context (e.g. `$(eval [arg(var) for var in ['fuga', 'arg']])`) was failing:
`AttributeError: '_DictWrapper' object has no attribute 'get'`

Essentially, symbols need to be passed as the `globals` argument to `eval()` and this argument needs to inherit from `dict`.

Additionally, this PR improves the discarding of private symbols (starting with double underscore). Previously, any double underscores were considered offending, even those in the middle of a symbol or in literal text.
These are the same changes, I have implemented for `xacro`.