### PR TITLE
Fix EINTR handling in XmlRpcDispatch::work

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -176,12 +176,16 @@ XmlRpcDispatch::work(double timeout)
     {
 #if defined(_WINDOWS)
       XmlRpcUtil::error("Error in XmlRpcDispatch::work: error in poll (%d).", WSAGetLastError());
-#else
-      if(errno != EINTR)
-        XmlRpcUtil::error("Error in XmlRpcDispatch::work: error in poll (%d).", nEvents);
-#endif
       _inWork = false;
       return;
+#else
+      if(errno != EINTR)
+      {
+        XmlRpcUtil::error("Error in XmlRpcDispatch::work: error in poll (%d).", nEvents);
+        _inWork = false;
+        return;
+      }
+#endif
     }
 
     // Process events

--- a/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcDispatch.cpp
@@ -185,6 +185,8 @@ XmlRpcDispatch::work(double timeout)
         _inWork = false;
         return;
       }
+      // If we receive EINTR, the revents will be empty and no handleEvents will be called.
+      // It will loop back to the poll unless the timeout is reached.
 #endif
     }
 


### PR DESCRIPTION
Only leave XmlRpcDispatchwork if the `poll` error is **not** EINTR.

The EINTR check should probably be at every I/O syscalls, but I think this `poll` call is the only one supposed to block.

Closes #2275 