### PR TITLE
Fix for timer/srv-server finalization issue 2283

### DIFF
--- a/test/test_roscpp/test/test_callback_queue.cpp
+++ b/test/test_roscpp/test/test_callback_queue.cpp
@@ -177,7 +177,7 @@ TEST(CallbackQueue, removeSelf)
   queue.callOne();
 
   queue.addCallback(cb2, 1);
-  
+
   queue.callAvailable();
 
   EXPECT_EQ(cb1->count, 1U);
@@ -549,6 +549,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-
-
-


### PR DESCRIPTION
As explained in #2283, delivering #2121 opened a possibility for a race condition during ros::Timer and ros::ServiceServer finalization: https://github.com/aurzenligl/study/blob/master/ros-timer/src/race.cpp

In order to remedy the situation, but still allow the [scenario](https://gist.github.com/iwanders/ede48fb649fd47f9b1f9a52c527b463c) mentioned in #2121 to succeed, I propose to define post-condition of removeById this way: callback is not and will not be executed, unless removal happened in the context of callback (self-removal). It's compatible with user code prior to #2121, as then removeByID always blocked (even on self-removal, leading to deadlock).

This allows to satisfy both use cases:
- https://gist.github.com/iwanders/ede48fb649fd47f9b1f9a52c527b463c:
doesn't deadlock as long as timer stop is called w/o external mtx locked
(see: selfRemoveCallbackWhileExecuting testcase),
- https://github.com/aurzenligl/study/blob/master/ros-timer/src/race.cpp:
doesn't crash as ros::Timer::stop guarantees no spinner uses any cb-captured data anymore
(see: removeCallbackWhileExecuting testcase).

FYI: @iwanders, @jacobperron, @fujitatomoya