### PR TITLE
rosbag reindex bugfix - seek to truncated position after broken chunk

### DIFF
--- a/tools/rosbag/src/rosbag/bag.py
+++ b/tools/rosbag/src/rosbag/bag.py
@@ -2472,6 +2472,7 @@ class _BagReader200(_BagReader):
 
         if trunc_pos and trunc_pos < total_bytes:
             f.truncate(trunc_pos)
+            f.seek(trunc_pos)
 
     def _reindex_read_chunk(self, f, chunk_pos, total_bytes):
         # Read the chunk header


### PR DESCRIPTION
Fixes #2282

The truncate operation left the current `f.tell()` read head at the pre-truncated position, so the chunk infos that are written on closing the file started writing at this pre-truncated position, leaving dangling broken chunk data in between the last good chunk and the first file-end chunkinfo.