### PR TITLE
More robust Linux release parsing

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -89,7 +89,7 @@ def _support_http_1_1():
     if platform.system() != 'Linux':
         return True
     minimum_supported_major, minimum_supported_minor = (4, 16)
-    release = platform.release().split('.')
+    release = platform.release().split('-')[0].split('.')
     platform_major = int(release[0])
     platform_minor = int(release[1])
     if platform_major < minimum_supported_major:


### PR DESCRIPTION
This more robust than the current code.

The current code leaves all the remaining release info into the patch version number of the version. When the version doesn't include a patch version number. The minor version number is polluted. Which causes the error of #2289.

By splitting on the dash. Only the major, minor(, patch) is used. And the remaining release info is ignored.

Fixes #2289