### PR TITLE
Option to set TCP_NODELAY in imu_tools transform.

### DIFF
--- a/tools/topic_tools/scripts/transform
+++ b/tools/topic_tools/scripts/transform
@@ -63,6 +63,10 @@ class TopicOp:
             '--latch', action='store_true',
             help='Set publisher to latched.'
         )
+        parser.add_argument(
+            '--tcpnodelay', dest='tcp_nodelay', action='store_true',
+            help='Set TCP_NODELAY transport hint when subscribing to topics.'
+        )
 
         # get and strip out ros args first
         argv = rospy.myargv()
@@ -92,7 +96,7 @@ class TopicOp:
         self.output_class = roslib.message.get_message_class(args.output_type)
 
         self.pub = rospy.Publisher(args.output_topic, self.output_class, queue_size=1, latch=args.latch)
-        self.sub = rospy.Subscriber(input_topic, input_class, self.callback)
+        self.sub = rospy.Subscriber(input_topic, input_class, self.callback, tcp_nodelay=args.tcp_nodelay)
 
     def callback(self, m):
         if self.input_fn is not None:


### PR DESCRIPTION
Similar to https://github.com/ros/ros_comm/pull/1682 gives you the option to have `tcpnodelay` subscriptions in `imu_tools transform`. For example is a quick solution to transport high rate messages via the `transform` node.

Tested on hardware.