### PR TITLE
Allow forwarding of working directory and launch file args to add_rostest from gtest wrapper functions

### DIFF
--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -64,7 +64,7 @@ endfunction()
 # The remaining arguments are the same as for add_rostest_gtest
 # and add_rostest_gmock
 #
-function(_add_rostest_google_test type target launch_file)
+function(_add_rostest_google_test type target launch_file working_directory args)
   if (NOT "${type}" STREQUAL "gtest" AND NOT "${type}" STREQUAL "gmock")
     message(FATAL_ERROR
       "Invalid use of _add_rostest_google_test function, "
@@ -82,7 +82,7 @@ function(_add_rostest_google_test type target launch_file)
     if(TARGET tests)
       add_dependencies(tests ${target})
     endif()
-    add_rostest(${launch_file} DEPENDENCIES ${target})
+    add_rostest(${launch_file} DEPENDENCIES ${target} WORKING_DIRECTORY ${working_directory} ARGS ${args})
   endif()
 endfunction()
 
@@ -102,7 +102,8 @@ endfunction()
 # :type ARGN: list of files
 #
 function(add_rostest_gtest target launch_file)
-  _add_rostest_google_test("gtest" ${target} ${launch_file} ${ARGN})
+  cmake_parse_arguments(_rostest_gtest "" "WORKING_DIRECTORY" "ARGS" ${ARGN})
+  _add_rostest_google_test("gtest" ${target} ${launch_file} ${_rostest_gtest_WORKING_DIRECTORY} ${_rostest_gtest_ARGS})
 endfunction()
 
 #

--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -64,7 +64,7 @@ endfunction()
 # The remaining arguments are the same as for add_rostest_gtest
 # and add_rostest_gmock
 #
-function(_add_rostest_google_test type target launch_file working_directory args)
+function(_add_rostest_google_test type target launch_file working_directory)
   if (NOT "${type}" STREQUAL "gtest" AND NOT "${type}" STREQUAL "gmock")
     message(FATAL_ERROR
       "Invalid use of _add_rostest_google_test function, "
@@ -82,7 +82,7 @@ function(_add_rostest_google_test type target launch_file working_directory args
     if(TARGET tests)
       add_dependencies(tests ${target})
     endif()
-    add_rostest(${launch_file} DEPENDENCIES ${target} WORKING_DIRECTORY ${working_directory} ARGS ${args})
+    add_rostest(${launch_file} DEPENDENCIES ${target} WORKING_DIRECTORY ${working_directory})
   endif()
 endfunction()
 
@@ -102,8 +102,8 @@ endfunction()
 # :type ARGN: list of files
 #
 function(add_rostest_gtest target launch_file)
-  cmake_parse_arguments(_rostest_gtest "" "WORKING_DIRECTORY" "ARGS" ${ARGN})
-  _add_rostest_google_test("gtest" ${target} ${launch_file} ${_rostest_gtest_WORKING_DIRECTORY} ${_rostest_gtest_ARGS})
+  cmake_parse_arguments(_rostest_gtest "" "WORKING_DIRECTORY" "" ${ARGN})
+  _add_rostest_google_test("gtest" ${target} ${launch_file} {_rostest_gtest_WORKING_DIRECTORY} ${ARGN})
 endfunction()
 
 #


### PR DESCRIPTION
I'm not great with cmake, so there very well may be a better way to do what I'm trying to do here. If this is acceptable, I'll add some unit tests and what not, but I wanted to go ahead and open the PR to get some feedback on whether or not there's a better way to do this.

This would have been more straightforward using a named argument for the sources, but I didn't want to break backwards compatibility.