### PR TITLE
Add --min-space option to rosbag record Python cli (#1951)

### DIFF
--- a/tools/rosbag/src/rosbag/rosbag_main.py
+++ b/tools/rosbag/src/rosbag/rosbag_main.py
@@ -97,6 +97,7 @@ def record_cmd(argv):
     parser.add_option("-b", "--buffsize",      dest="buffsize",      default=256,   type='int',   action="store", help="use an internal buffer of SIZE MB (Default: %default, 0 = infinite)", metavar="SIZE")
     parser.add_option("--chunksize",           dest="chunksize",     default=768,   type='int',   action="store", help="Advanced. Record to chunks of SIZE KB (Default: %default)", metavar="SIZE")
     parser.add_option("-l", "--limit",         dest="num",           default=0,     type='int',   action="store", help="only record NUM messages on each topic")
+    parser.add_option("-L", "--min-space",     dest="min_space",     default="1G",  type='string',action="store", help="Minimum allowed space on recording device (use G,M,k multipliers)")
     parser.add_option(      "--node",          dest="node",          default=None,  type='string',action="store", help="record all topics subscribed to by a specific node")
     parser.add_option("-j", "--bz2",           dest="compression",   default=None,  action="store_const", const='bz2', help="use BZ2 compression")
     parser.add_option("--lz4",                 dest="compression",                  action="store_const", const='lz4', help="use LZ4 compression")
@@ -137,6 +138,7 @@ def record_cmd(argv):
             cmd.extend(["--max-splits", str(options.max_splits)])
     if options.duration:    cmd.extend(["--duration", options.duration])
     if options.size:        cmd.extend(["--size", str(options.size)])
+    if options.min_space:   cmd.extend(["--min-space", str(options.min_space)])
     if options.node:
         cmd.extend(["--node", options.node])
     if options.tcpnodelay:  cmd.extend(["--tcpnodelay"])


### PR DESCRIPTION
The "--min-space" option is missed in the Python rosbag record cli. This fix issue #1951. 