### PR TITLE
[topic_tools/mux] add wait_publisher_initialization option in mux

### DIFF
--- a/tools/topic_tools/src/mux.cpp
+++ b/tools/topic_tools/src/mux.cpp
@@ -53,6 +53,7 @@ static bool g_lazy = false;
 static bool g_latch = false;
 static bool g_advertised = false;
 static bool g_wait_pub_init = false;
+static double g_wait_second = 0.1;
 static string g_output_topic;
 static ros::Publisher g_pub;
 static ros::Publisher g_pub_selected;
@@ -156,7 +157,7 @@ void in_cb(const boost::shared_ptr<ShapeShifter const>& msg,
     // we need sleep for publisher initialization
     // otherwise the first topic will drop.
     if (g_wait_pub_init) {
-      usleep(100000);
+      usleep(g_wait_second * 1000000);
     }
     g_advertised = true;
     
@@ -364,9 +365,10 @@ int main(int argc, char **argv)
     }
   }
 
-  // Wait publisher initialization for 0.1 seconds
+  // Wait publisher initialization for few second (default: 0.1s)
   // This option is to avoid dropping the first topic publishing.
   pnh.getParam("wait_publisher_initialization", g_wait_pub_init);
+  pnh.getParam("wait_publisher_second", g_wait_second);
   g_pub_selected.publish(t);
 
   // Backward compatibility


### PR DESCRIPTION
`mux` node does not have `sleep` between `advertise` and `publish`.
this causes dropping first message publication.
this does not matter when the topic's frequency is high.
but when the topic's frequency is low, dropping the first message causes huge time loss.

This PR add option to add `0.1ms` sleep between `advertise` and `publish`.
This change avoids dropping the first message.

## How to test

### Sample launch

Publish topic in 10 second.
without this PR, the first message of `/node_mux` will drop,
so we need to wait 20 seconds to get `/node_mux` topic.

```xml
<launch>
  <arg name="wait_publisher_initialization" default="false" />

  <node name="node1" pkg="rostopic" type="rostopic"
        args="pub -r 0.1 /node1 std_msgs/String node1" 
        output="screen" />
  <node name="node2" pkg="rostopic" type="rostopic"
        args="pub -r 0.1 /node2 std_msgs/String node2"
        output="screen" />
  <node name="mux" pkg="topic_tools" type="mux"
        args="/node_mux /node1 /node2"
        output="screen">
    <rosparam subst_value="true">
      wait_publisher_initialization: $(arg wait_publisher_initialization) 
    </rosparam>
  </node>
</launch>
```

## `wait_publisher_initialization`: true (this PR)

After 10 seconds, `/node1`, `/node2` and `/node_mux` arrived!

```
$ rostopic echo /node1
data: "node1"
---
```

```
$ rostopic echo /node2
data: "node2"
---
```

```
$ rostopic echo /node_mux
data: "node1"
---
```

## `wait_publisher_initialization`: false (current behavior)

After 10 seconds, `/node1` and `/node2` arrive, but `/node_mux` did not arrived.

```
$ rostopic echo /node1
data: "node1"
---
```

```
$ rostopic echo /node2
data: "node2"
---
```

```
$ rostopic echo /node_mux
```

