### PR TITLE
Add missing repeat_latched initialization

### DIFF
--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -97,6 +97,7 @@ RecorderOptions::RecorderOptions() :
     snapshot(false),
     verbose(false),
     publish(false),
+    repeat_latched(false),
     compression(compression::Uncompressed),
     prefix(""),
     name(""),


### PR DESCRIPTION
The repeat_latched member variable bool was left in an uninitialized/random state.
On my machine, even without specifying "--repeat_latched", it was sometimes activated.