### PR TITLE
Added init_options::NoSimTime to forcefully disable subscribing to /clock

### DIFF
--- a/clients/roscpp/include/ros/init.h
+++ b/clients/roscpp/include/ros/init.h
@@ -65,7 +65,7 @@ enum InitOption
    * \brief Don't consider /use_sim_time parameter and always use system time.
    * Don't create the /clock subscriber.
    */
-  NoSimTime = 1 << 2,
+  NoSimTime = 1 << 3,
 };
 }
 typedef init_options::InitOption InitOption;

--- a/clients/roscpp/include/ros/init.h
+++ b/clients/roscpp/include/ros/init.h
@@ -61,6 +61,11 @@ enum InitOption
    * \brief Don't broadcast rosconsole output to the /rosout topic
    */
   NoRosout = 1 << 2,
+  /**
+   * \brief Don't consider /use_sim_time parameter and always use system time.
+   * Don't create the /clock subscriber.
+   */
+  NoSimTime = 1 << 2,
 };
 }
 typedef init_options::InitOption InitOption;

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -387,7 +387,10 @@ void start()
 
   {
     bool use_sim_time = false;
-    param::param("/use_sim_time", use_sim_time, use_sim_time);
+    if (!(g_init_options & init_options::NoSimTime))
+    {
+      param::param("/use_sim_time", use_sim_time, use_sim_time);
+    }
 
     if (use_sim_time)
     {

--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 add_rostest(launch/real_time_test.xml)
 add_rostest(launch/sim_time_test.xml)
-add_rostest(launch/init_no_sim_time.xml)
+add_rostest(launch/init_no_sim_time.xml DEPENDENCIES ${PROJECT_NAME}-init_no_sim_time_test)
 
 # Publish one message
 add_rostest(launch/pubsub_once.xml)

--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 
 add_rostest(launch/real_time_test.xml)
 add_rostest(launch/sim_time_test.xml)
+add_rostest(launch/init_no_sim_time.xml)
 
 # Publish one message
 add_rostest(launch/pubsub_once.xml)

--- a/test/test_roscpp/test/launch/init_no_sim_time.xml
+++ b/test/test_roscpp/test/launch/init_no_sim_time.xml
@@ -1,0 +1,5 @@
+<launch>
+  <param name="/use_sim_time" type="bool" value="true"/>
+  <test test-name="init_no_sim_time_test" pkg="test_roscpp" type="test_roscpp-init_no_sim_time_test" args=""/>
+</launch>
+

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -61,6 +61,9 @@ add_executable(${PROJECT_NAME}-sim_time_test EXCLUDE_FROM_ALL sim_time_test.cpp)
 target_link_libraries(${PROJECT_NAME}-sim_time_test ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 add_dependencies(${PROJECT_NAME}-sim_time_test ${rosgraph_msgs_EXPORTED_TARGETS})
 
+add_executable(${PROJECT_NAME}-init_no_sim_time_test EXCLUDE_FROM_ALL init_no_sim_time_test.cpp)
+target_link_libraries(${PROJECT_NAME}-init_no_sim_time_test ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
+
 # Call a service
 add_executable(${PROJECT_NAME}-service_adv EXCLUDE_FROM_ALL service_adv.cpp)
 target_link_libraries(${PROJECT_NAME}-service_adv ${catkin_LIBRARIES})

--- a/test/test_roscpp/test/src/init_no_sim_time_test.cpp
+++ b/test/test_roscpp/test/src/init_no_sim_time_test.cpp
@@ -1,0 +1,66 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2023, Open Robotics
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Willow Garage, Inc. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Author: Martin Pecka */
+
+/*
+ * Test ros::init_options::NoSimTime.
+ */
+
+#include <gtest/gtest.h>
+#include "ros/ros.h"
+#include "ros/topic_manager.h"
+
+TEST(NoSimTime, isTimeValid)
+{
+  // We should be using the system time, so time should be valid right away
+  ASSERT_TRUE(ros::Time::isValid());
+
+  // Check that the use_sim_time parameter is set to true
+  bool use_sim_time = false;
+  ros::param::param("/use_sim_time", use_sim_time, use_sim_time);
+  EXPECT_TRUE(use_sim_time);
+  EXPECT_TRUE(ros::Time::isSystemTime());
+
+  EXPECT_EQ(0u, ros::TopicManager::instance()->getNumSubscribers("/clock"));
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "sim_time_test", ros::init_options::NoSimTime);
+  ros::NodeHandle nh;
+  return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
Browsing through the list of migrated ARO questions, I stumbled upon https://robotics.stackexchange.com/questions/96165/nodelet-load-process-does-message-deserialization .

It shows that a simple `nodelet load` process can take significant CPU cycles when running with a fast simulated clock (e.g. gazebo on 1 kHz).

This option would allow `nodelet load` to disable the `/clock` topic subscription which it doesn't need for anything (PR pending: https://github.com/ros/nodelet_core/pull/120).