### PR TITLE
Update: #include <boost/bind.hpp> -> <boost/bind/bind.hpp> for boost 1.73

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -47,7 +47,7 @@
 #include "ros/init.h"
 #include "common.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <xmlrpcpp/XmlRpcValue.h>
 

--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -47,8 +47,6 @@
 #include "ros/init.h"
 #include "common.h"
 
-#include <boost/bind/bind.hpp>
-
 #include <xmlrpcpp/XmlRpcValue.h>
 
 namespace ros

--- a/clients/roscpp/include/ros/publisher.h
+++ b/clients/roscpp/include/ros/publisher.h
@@ -32,7 +32,7 @@
 #include "ros/common.h"
 #include "ros/message.h"
 #include "ros/serialization.h"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 
 namespace ros
@@ -216,4 +216,3 @@ namespace ros
 }
 
 #endif // ROSCPP_PUBLISHER_HANDLE_H
-

--- a/clients/roscpp/include/ros/publisher.h
+++ b/clients/roscpp/include/ros/publisher.h
@@ -35,6 +35,9 @@
 #include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 
+// For backward compatibility, pull placeholders into global namespace
+using namespace boost::placeholders;
+
 namespace ros
 {
   /**

--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -39,7 +39,7 @@
 #include <ros/assert.h>
 
 #include <boost/shared_array.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {

--- a/clients/roscpp/src/libros/intraprocess_publisher_link.cpp
+++ b/clients/roscpp/src/libros/intraprocess_publisher_link.cpp
@@ -42,7 +42,7 @@
 #include "ros/connection_manager.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 
@@ -156,4 +156,3 @@ void IntraProcessPublisherLink::getPublishTypes(bool& ser, bool& nocopy, const s
 }
 
 } // namespace ros
-

--- a/clients/roscpp/src/libros/intraprocess_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/intraprocess_subscriber_link.cpp
@@ -37,7 +37,7 @@
 #include "ros/topic_manager.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {

--- a/clients/roscpp/src/libros/poll_set.cpp
+++ b/clients/roscpp/src/libros/poll_set.cpp
@@ -39,7 +39,7 @@
 
 #include <ros/assert.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <fcntl.h>
 

--- a/clients/roscpp/src/libros/publisher_link.cpp
+++ b/clients/roscpp/src/libros/publisher_link.cpp
@@ -41,7 +41,7 @@
 #include "ros/connection_manager.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 
@@ -111,4 +111,3 @@ const std::string& PublisherLink::getMD5Sum()
 }
 
 } // namespace ros
-

--- a/clients/roscpp/src/libros/service_client_link.cpp
+++ b/clients/roscpp/src/libros/service_client_link.cpp
@@ -41,7 +41,7 @@
 #include "ros/this_node.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {
@@ -242,4 +242,3 @@ void ServiceClientLink::processResponse(bool ok, const SerializedMessage& res)
 
 
 } // namespace ros
-

--- a/clients/roscpp/src/libros/service_publication.cpp
+++ b/clients/roscpp/src/libros/service_publication.cpp
@@ -37,7 +37,7 @@
 #include "ros/connection.h"
 #include "ros/callback_queue_interface.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <std_msgs/String.h>
 

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -40,7 +40,7 @@
 #include "ros/this_node.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 
@@ -388,4 +388,3 @@ bool ServiceServerLink::isValid() const
 }
 
 } // namespace ros
-

--- a/clients/roscpp/src/libros/subscriber_link.cpp
+++ b/clients/roscpp/src/libros/subscriber_link.cpp
@@ -28,7 +28,7 @@
 #include "ros/subscriber_link.h"
 #include "ros/publication.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -39,7 +39,7 @@
 #include "ros/file_log.h"
 #include <ros/assert.h>
 #include <sstream>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <fcntl.h>
 #include <errno.h>
 #ifndef _WIN32

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -37,7 +37,7 @@
 #include "ros/file_log.h"
 
 #include <ros/assert.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #ifndef _WIN32
   #include <sys/socket.h>  // explicit include required for FreeBSD
 #endif

--- a/clients/roscpp/src/libros/transport_publisher_link.cpp
+++ b/clients/roscpp/src/libros/transport_publisher_link.cpp
@@ -48,7 +48,7 @@
 #include "ros/callback_queue.h"
 #include "ros/internal_timer_manager.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 
@@ -321,4 +321,3 @@ std::string TransportPublisherLink::getTransportInfo()
 }
 
 } // namespace ros
-

--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -36,7 +36,7 @@
 #include "ros/topic_manager.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {

--- a/test/test_rosbag_storage/src/bag_player.cpp
+++ b/test/test_rosbag_storage/src/bag_player.cpp
@@ -4,7 +4,7 @@
 #include <std_msgs/UInt64.h>
 
 #include <gtest/gtest.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 /**
  * @brief Helper function to create std_msgs::* messages.

--- a/test/test_roscpp/test/src/sim_time_test.cpp
+++ b/test/test_roscpp/test/src/sim_time_test.cpp
@@ -46,7 +46,7 @@
 #include <rosgraph_msgs/Clock.h>
 
 #include <boost/thread.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 int g_argc;
 char** g_argv;
@@ -168,4 +168,3 @@ int main(int argc, char** argv)
   g_argv = argv;
   return RUN_ALL_TESTS();
 }
-

--- a/test/test_roscpp/test/test_callback_queue.cpp
+++ b/test/test_roscpp/test/test_callback_queue.cpp
@@ -40,7 +40,7 @@
 
 #include <boost/atomic.hpp>
 #include <boost/shared_ptr.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 #include <boost/function.hpp>
 
@@ -549,6 +549,3 @@ int main(int argc, char** argv)
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
-
-
-

--- a/test/test_roscpp/test/test_poll_set.cpp
+++ b/test/test_roscpp/test/test_poll_set.cpp
@@ -41,7 +41,7 @@
 
 #include <fcntl.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 
 using namespace ros;
@@ -529,4 +529,3 @@ int main(int argc, char** argv)
 
   return RUN_ALL_TESTS();
 }
-

--- a/test/test_roscpp/test/test_subscription_queue.cpp
+++ b/test/test_roscpp/test/test_subscription_queue.cpp
@@ -41,7 +41,7 @@
 #include "ros/init.h"
 
 #include <boost/shared_array.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 
 using namespace ros;
@@ -287,5 +287,3 @@ int main(int argc, char** argv)
   ros::init(argc, argv, "blah");
   return RUN_ALL_TESTS();
 }
-
-

--- a/test/test_roscpp/test/test_transport_tcp.cpp
+++ b/test/test_roscpp/test/test_transport_tcp.cpp
@@ -37,7 +37,7 @@
 #include "ros/poll_set.h"
 #include "ros/transport/transport_tcp.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 
 using namespace ros;

--- a/utilities/message_filters/include/message_filters/signal1.h
+++ b/utilities/message_filters/include/message_filters/signal1.h
@@ -41,7 +41,7 @@
 #include <ros/message_event.h>
 #include <ros/parameter_adapter.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 
 namespace message_filters
@@ -128,5 +128,3 @@ private:
 } // message_filters
 
 #endif // MESSAGE_FILTERS_SIGNAL1_H
-
-

--- a/utilities/message_filters/include/message_filters/signal9.h
+++ b/utilities/message_filters/include/message_filters/signal9.h
@@ -42,7 +42,7 @@
 #include <ros/message_event.h>
 #include <ros/parameter_adapter.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 
 namespace message_filters
@@ -313,5 +313,3 @@ private:
 } // message_filters
 
 #endif // MESSAGE_FILTERS_SIGNAL9_H
-
-

--- a/utilities/message_filters/include/message_filters/simple_filter.h
+++ b/utilities/message_filters/include/message_filters/simple_filter.h
@@ -42,7 +42,7 @@
 #include <ros/message_event.h>
 #include <ros/subscription_callback_helper.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <string>
 
@@ -147,4 +147,3 @@ private:
 }
 
 #endif
-

--- a/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/approximate_time.h
@@ -45,7 +45,7 @@
 #include <boost/function.hpp>
 #include <boost/thread/mutex.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/mpl/or.hpp>
@@ -926,4 +926,3 @@ private:
 } // namespace message_filters
 
 #endif // MESSAGE_FILTERS_SYNC_APPROXIMATE_TIME_H
-

--- a/utilities/message_filters/include/message_filters/sync_policies/exact_time.h
+++ b/utilities/message_filters/include/message_filters/sync_policies/exact_time.h
@@ -45,7 +45,7 @@
 #include <boost/function.hpp>
 #include <boost/thread/mutex.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/mpl/or.hpp>
@@ -278,4 +278,3 @@ private:
 } // namespace message_filters
 
 #endif // MESSAGE_FILTERS_SYNC_EXACT_TIME_H
-

--- a/utilities/message_filters/include/message_filters/synchronizer.h
+++ b/utilities/message_filters/include/message_filters/synchronizer.h
@@ -40,7 +40,7 @@
 #include <boost/function.hpp>
 #include <boost/thread/mutex.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/mpl/or.hpp>


### PR DESCRIPTION
Since boost 1.73, i.e. on Ubuntu 22.04, the old header issues a deprecation warning:
```
/usr/include/boost/bind.hpp:36:1: note: ‘#pragma message:
The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated.
Please use <boost/bind/bind.hpp> + using namespace boost::placeholders,
or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.’
```

While the new header <boost/bind/bind.hpp> is available for a long time (on 18.04 already) and the source has been updated to use boost::placeholders in #2023, the header was not yet updated.