### PR TITLE
Fix latched topic not latched in splitted rosbags

### DIFF
--- a/tools/rosbag/src/recorder.cpp
+++ b/tools/rosbag/src/recorder.cpp
@@ -457,7 +457,7 @@ void Recorder::startWriting() {
         {
             // Overwrite the original receipt time, otherwise the new bag will
             // have a gap before the new messages start.
-            bag_.write(out.second.topic, now, *out.second.msg);
+            bag_.write(out.second.topic, now, *out.second.msg, out.second.connection_header);
         }
     }
 


### PR DESCRIPTION
When writing latched topics in new rosbags splits, the header was not stored, which lost the "latching" flag. Store the header in new splits to avoid this.

Closes #2350