### PR TITLE
Fix occasional crash during shutdown when explicitly calling ros::start but not ros::shutdown

### DIFF
--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -304,9 +304,9 @@ struct InternalQueueJoiningThread
 
 void initInternalQueueJoiningThread()
 {
-  // Constructs the thread on first use, and joins it on shutdown.
-  // This is used to avoid the situation where the thread continues to run
-  // after singletons have been destroyed.
+  // This function must be called after the ROS singletons have been created
+  // via their respective getInstance() functions in order to ensure that
+  // the thread stops before the singletons are destroyed.
   // For more details, see: https://github.com/ros/ros_comm/pull/2355
   static InternalQueueJoiningThread internal_queue_joining_thread;
 }

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -622,6 +622,10 @@ void deInit()
   //ros::console::deregister_appender(g_rosout_appender);
   delete g_rosout_appender;
   g_rosout_appender = 0;
+
+  // preserve legacy behavior
+  g_shutting_down = true;
+  g_ok = false;
 }
 
 void shutdown()

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -608,10 +608,11 @@ bool ok()
 
 void deInit()
 {
-  boost::recursive_mutex::scoped_lock lock(g_shutting_down_mutex);
-  if (g_shutting_down)
+  static bool deinitialized = false;
+  if (deinitialized)
     return;
-
+  deinitialized = true;
+  
   ros::console::shutdown();
 
   g_global_queue->disable();

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -307,6 +307,7 @@ void initInternalQueueJoiningThread()
   // Constructs the thread on first use, and joins it on shutdown.
   // This is used to avoid the situation where the thread continues to run
   // after singletons have been destroyed.
+  // For more details, see: https://github.com/ros/ros_comm/pull/2355
   static InternalQueueJoiningThread internal_queue_joining_thread;
 }
 

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -410,8 +410,9 @@ void start()
 
   g_internal_queue_thread = boost::thread(internalCallbackQueueThreadFunc);
 
-  // Call shutdown() when the program exits, before singletons get destroyed,
-  // so that the internal queue thread is joined first.
+  // Ensure that shutdown() is always called when the program exits, 
+  // but before singletons get destroyed, so that the internal queue thread is joined first
+  // and cannot access destroyed singletons.
   if (!g_shutdown_registered)
   {
     g_shutdown_registered = true;

--- a/clients/roscpp/src/libros/init.cpp
+++ b/clients/roscpp/src/libros/init.cpp
@@ -410,6 +410,8 @@ void start()
 
   g_internal_queue_thread = boost::thread(internalCallbackQueueThreadFunc);
 
+  // Call shutdown() when the program exits, before singletons get destroyed,
+  // so that the internal queue thread is joined first.
   if (!g_shutdown_registered)
   {
     g_shutdown_registered = true;

--- a/test/test_roscpp/test/CMakeLists.txt
+++ b/test/test_roscpp/test/CMakeLists.txt
@@ -92,6 +92,10 @@ add_rostest(launch/service_call_zombie.xml)
 # Repeatedly call ros::init() and ros::fini()
 add_rostest(launch/multiple_init_fini.xml)
 
+# Check that ros::shutdown is automatically called
+# if ros::start has been called explcitly
+add_rostest(launch/missing_call_to_shutdown.xml)
+
 # Test node inspection functionality
 add_rostest(launch/inspection.xml)
 

--- a/test/test_roscpp/test/launch/missing_call_to_shutdown.xml
+++ b/test/test_roscpp/test/launch/missing_call_to_shutdown.xml
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="missing_call_to_shutdown" pkg="test_roscpp" type="test_roscpp-missing_call_to_shutdown"/>
+</launch>

--- a/test/test_roscpp/test/launch/missing_call_to_shutdown.xml
+++ b/test/test_roscpp/test/launch/missing_call_to_shutdown.xml
@@ -1,3 +1,4 @@
 <launch>
-  <test test-name="missing_call_to_shutdown" pkg="test_roscpp" type="test_roscpp-missing_call_to_shutdown"/>
+  <test test-name="missing_call_to_shutdown_init_only" pkg="test_roscpp" type="test_roscpp-missing_call_to_shutdown" args="0"/>
+  <test test-name="missing_call_to_shutdown_init_and_start" pkg="test_roscpp" type="test_roscpp-missing_call_to_shutdown" args="1"/>
 </launch>

--- a/test/test_roscpp/test/launch/missing_call_to_shutdown.xml
+++ b/test/test_roscpp/test/launch/missing_call_to_shutdown.xml
@@ -1,4 +1,3 @@
 <launch>
-  <test test-name="missing_call_to_shutdown_init_only" pkg="test_roscpp" type="test_roscpp-missing_call_to_shutdown" args="0"/>
-  <test test-name="missing_call_to_shutdown_init_and_start" pkg="test_roscpp" type="test_roscpp-missing_call_to_shutdown" args="1"/>
+  <test test-name="missing_call_to_shutdown" pkg="test_roscpp" type="test_roscpp-missing_call_to_shutdown"/>
 </launch>

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -89,8 +89,11 @@ add_dependencies(${PROJECT_NAME}-service_exception ${std_srvs_EXPORTED_TARGETS})
 add_executable(${PROJECT_NAME}-multiple_init_fini EXCLUDE_FROM_ALL multiple_init_fini.cpp)
 target_link_libraries(${PROJECT_NAME}-multiple_init_fini ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 
+add_executable(${PROJECT_NAME}-missing_call_to_shutdown_impl EXCLUDE_FROM_ALL missing_call_to_shutdown_impl.cpp)
+target_link_libraries(${PROJECT_NAME}-missing_call_to_shutdown_impl ${catkin_LIBRARIES})
+
 add_executable(${PROJECT_NAME}-missing_call_to_shutdown EXCLUDE_FROM_ALL missing_call_to_shutdown.cpp)
-target_link_libraries(${PROJECT_NAME}-missing_call_to_shutdown ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}-missing_call_to_shutdown ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 
 # Test node inspection functionality
 add_executable(${PROJECT_NAME}-inspection EXCLUDE_FROM_ALL inspection.cpp)
@@ -260,6 +263,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-service_call_repeatedly
     ${PROJECT_NAME}-multiple_init_fini
     ${PROJECT_NAME}-missing_call_to_shutdown
+    ${PROJECT_NAME}-missing_call_to_shutdown_impl
     ${PROJECT_NAME}-inspection
     ${PROJECT_NAME}-service_adv_multiple
     ${PROJECT_NAME}-service_adv_a
@@ -329,6 +333,7 @@ add_dependencies(${PROJECT_NAME}-service_exception ${${PROJECT_NAME}_EXPORTED_TA
 add_dependencies(${PROJECT_NAME}-service_call_repeatedly ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-multiple_init_fini ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-missing_call_to_shutdown ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}-missing_call_to_shutdown_impl ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-inspection ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-service_adv_multiple ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-service_adv_a ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/test/test_roscpp/test/src/CMakeLists.txt
+++ b/test/test_roscpp/test/src/CMakeLists.txt
@@ -89,6 +89,9 @@ add_dependencies(${PROJECT_NAME}-service_exception ${std_srvs_EXPORTED_TARGETS})
 add_executable(${PROJECT_NAME}-multiple_init_fini EXCLUDE_FROM_ALL multiple_init_fini.cpp)
 target_link_libraries(${PROJECT_NAME}-multiple_init_fini ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
 
+add_executable(${PROJECT_NAME}-missing_call_to_shutdown EXCLUDE_FROM_ALL missing_call_to_shutdown.cpp)
+target_link_libraries(${PROJECT_NAME}-missing_call_to_shutdown ${catkin_LIBRARIES})
+
 # Test node inspection functionality
 add_executable(${PROJECT_NAME}-inspection EXCLUDE_FROM_ALL inspection.cpp)
 target_link_libraries(${PROJECT_NAME}-inspection ${GTEST_LIBRARIES} ${catkin_LIBRARIES})
@@ -256,6 +259,7 @@ if(TARGET tests)
     ${PROJECT_NAME}-service_exception
     ${PROJECT_NAME}-service_call_repeatedly
     ${PROJECT_NAME}-multiple_init_fini
+    ${PROJECT_NAME}-missing_call_to_shutdown
     ${PROJECT_NAME}-inspection
     ${PROJECT_NAME}-service_adv_multiple
     ${PROJECT_NAME}-service_adv_a
@@ -324,6 +328,7 @@ add_dependencies(${PROJECT_NAME}-service_deadlock ${${PROJECT_NAME}_EXPORTED_TAR
 add_dependencies(${PROJECT_NAME}-service_exception ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-service_call_repeatedly ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-multiple_init_fini ${${PROJECT_NAME}_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}-missing_call_to_shutdown ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-inspection ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-service_adv_multiple ${${PROJECT_NAME}_EXPORTED_TARGETS})
 add_dependencies(${PROJECT_NAME}-service_adv_a ${${PROJECT_NAME}_EXPORTED_TARGETS})

--- a/test/test_roscpp/test/src/missing_call_to_shutdown.cpp
+++ b/test/test_roscpp/test/src/missing_call_to_shutdown.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Author: David Gossow */
+
+/*
+ * Call ros::start() explicitly, but never call ros::shutdown().
+ * ros::shutdown should be called automatically in this case.
+ */
+
+#include <cstdlib>
+#include <ros/ros.h>
+
+namespace
+{
+
+void atexitCallback()
+{
+  bool hasError = false;
+  if (ros::ok())
+  {
+    std::cerr << "ERROR: ros::ok() returned true after ROS has been de-initialized!" << std::endl;
+  }
+  if (ros::isStarted())
+  {
+    std::cerr << "ERROR: ros::isStarted() returned true after ROS has been de-initialized!" << std::endl;
+  }
+  if (!ros::isShuttingDown())
+  {
+    std::cerr << "ERROR: ros::isShuttingDown() returned false after ROS has been de-initialized!" << std::endl;
+  }
+
+  if (hasError)
+  {
+    std::_Exit(1);
+  }
+}
+}
+
+int
+main(int argc, char** argv)
+{
+  // Register atexit callbak which will be executed after ROS has been de-initialized.
+  if (atexit(atexitCallback) != 0)
+  {
+    std::cerr << "Failed to register atexit callback." << std::endl;
+    return 1;
+  }
+
+  ros::init(argc, argv, "missing_call_to_shutdown" );
+  ros::start();
+
+  if (!ros::ok())
+  {
+    std::cerr << "Failed to start ROS." << std::endl;
+    return 1;
+  }
+}

--- a/test/test_roscpp/test/src/missing_call_to_shutdown.cpp
+++ b/test/test_roscpp/test/src/missing_call_to_shutdown.cpp
@@ -37,25 +37,77 @@
 #include <cstdlib>
 #include <ros/ros.h>
 
+namespace ros
+{
+namespace console
+{
+extern bool g_shutting_down;
+}
+}
+
 namespace
 {
+
+enum TestId
+{
+  InitOnly = 0,
+  InitAndStart = 1
+};
+
+TestId test_id = InitOnly;
 
 void atexitCallback()
 {
   bool hasError = false;
-  if (ros::ok())
+
+  switch (test_id)
   {
-    std::cerr << "ERROR: ros::ok() returned true after ROS has been de-initialized!" << std::endl;
+    case InitOnly:
+      if (!ros::ok())
+      {
+        std::cerr << "ERROR: ros::ok() returned false, although ros::shutdown has not been called!" << std::endl;
+        hasError = true;
+      }
+      if (ros::isShuttingDown())
+      {
+        std::cerr << "ERROR: ros::isShuttingDown() returned true, although ros::shutdown has not been called!" << std::endl;
+        hasError = true;
+      }
+      if (ros::isStarted())
+      {
+        std::cerr << "ERROR: ros::isStarted() returned true, although ros::start has not been called!" << std::endl;
+        hasError = true;
+      }
+      break;
+    case InitAndStart:
+      if (ros::ok())
+      {
+        std::cerr << "ERROR: ros::ok() returned true after ros::shutdown should have been automatically called!" << std::endl;
+        hasError = true;
+      }
+      if (!ros::isShuttingDown())
+      {
+        std::cerr << "ERROR: ros::isShuttingDown() returned false after ros::shutdown should have been automatically called!" << std::endl;
+        hasError = true;
+      }
+      if (ros::isStarted())
+      {
+        std::cerr << "ERROR: ros::isStarted() returned true after ros::shutdown should have been automatically called!" << std::endl;
+        hasError = true;
+      }
+      break;
+  }
+
+  if (!ros::isInitialized())
+  {
+    std::cerr << "ERROR: ros::isInitialized() returned false, although ros::init was called!" << std::endl;
+    std::cerr << "Due to legacy reasons, it should return true, even after ROS has been de-initialized." << std::endl;
     hasError = true;
   }
-  if (ros::isStarted())
+
+  if (!ros::console::g_shutting_down)
   {
-    std::cerr << "ERROR: ros::isStarted() returned true after ROS has been de-initialized!" << std::endl;
-    hasError = true;
-  }
-  if (!ros::isShuttingDown())
-  {
-    std::cerr << "ERROR: ros::isShuttingDown() returned false after ROS has been de-initialized!" << std::endl;
+    std::cerr << "ERROR: ros::console::g_shutting_down returned false, but it should have been automatically shut down." << std::endl;
     hasError = true;
   }
 
@@ -69,6 +121,11 @@ void atexitCallback()
 int
 main(int argc, char** argv)
 {
+  if ( argc > 1 )
+  {
+    test_id = static_cast<TestId>(atoi(argv[1]));
+  }
+
   // Register atexit callbak which will be executed after ROS has been de-initialized.
   if (atexit(atexitCallback) != 0)
   {
@@ -76,12 +133,30 @@ main(int argc, char** argv)
     return 1;
   }
 
-  ros::init(argc, argv, "missing_call_to_shutdown" );
-  ros::start();
+  switch (test_id)
+  {
+    case InitOnly:
+      // Test case 0: Call ros::init() explicitly, but never call ros::shutdown().
+      // ros::deInit should be called automatically in this case.
+      ros::init(argc, argv, "missing_call_to_shutdown" );
+      break;
+    case InitAndStart:
+      // Test case 1: Call ros::init() and ros::start() explicitly, but never call ros::shutdown().
+      // ros::shutdown should be called automatically in this case.
+      ros::init(argc, argv, "missing_call_to_shutdown" );
+      ros::start();
+      break;
+    default:
+      std::cerr << "Invalid test id: " << test_id << std::endl;
+      return 1;
+      break;
+  }
 
   if (!ros::ok())
   {
     std::cerr << "Failed to start ROS." << std::endl;
     return 1;
   }
+  
+  return 0;
 }

--- a/test/test_roscpp/test/src/missing_call_to_shutdown.cpp
+++ b/test/test_roscpp/test/src/missing_call_to_shutdown.cpp
@@ -46,14 +46,17 @@ void atexitCallback()
   if (ros::ok())
   {
     std::cerr << "ERROR: ros::ok() returned true after ROS has been de-initialized!" << std::endl;
+    hasError = true;
   }
   if (ros::isStarted())
   {
     std::cerr << "ERROR: ros::isStarted() returned true after ROS has been de-initialized!" << std::endl;
+    hasError = true;
   }
   if (!ros::isShuttingDown())
   {
     std::cerr << "ERROR: ros::isShuttingDown() returned false after ROS has been de-initialized!" << std::endl;
+    hasError = true;
   }
 
   if (hasError)

--- a/test/test_roscpp/test/src/missing_call_to_shutdown.cpp
+++ b/test/test_roscpp/test/src/missing_call_to_shutdown.cpp
@@ -60,42 +60,20 @@ void atexitCallback()
 {
   bool hasError = false;
 
-  switch (test_id)
+  if (ros::ok())
   {
-    case InitOnly:
-      if (!ros::ok())
-      {
-        std::cerr << "ERROR: ros::ok() returned false, although ros::shutdown has not been called!" << std::endl;
-        hasError = true;
-      }
-      if (ros::isShuttingDown())
-      {
-        std::cerr << "ERROR: ros::isShuttingDown() returned true, although ros::shutdown has not been called!" << std::endl;
-        hasError = true;
-      }
-      if (ros::isStarted())
-      {
-        std::cerr << "ERROR: ros::isStarted() returned true, although ros::start has not been called!" << std::endl;
-        hasError = true;
-      }
-      break;
-    case InitAndStart:
-      if (ros::ok())
-      {
-        std::cerr << "ERROR: ros::ok() returned true after ros::shutdown should have been automatically called!" << std::endl;
-        hasError = true;
-      }
-      if (!ros::isShuttingDown())
-      {
-        std::cerr << "ERROR: ros::isShuttingDown() returned false after ros::shutdown should have been automatically called!" << std::endl;
-        hasError = true;
-      }
-      if (ros::isStarted())
-      {
-        std::cerr << "ERROR: ros::isStarted() returned true after ros::shutdown should have been automatically called!" << std::endl;
-        hasError = true;
-      }
-      break;
+    std::cerr << "ERROR: ros::ok() returned true!" << std::endl;
+    hasError = true;
+  }
+  if (!ros::isShuttingDown())
+  {
+    std::cerr << "ERROR: ros::isShuttingDown() returned false!" << std::endl;
+    hasError = true;
+  }
+  if (ros::isStarted())
+  {
+    std::cerr << "ERROR: ros::isStarted() returned true!" << std::endl;
+    hasError = true;
   }
 
   if (!ros::isInitialized())

--- a/test/test_roscpp/test/src/missing_call_to_shutdown_impl.cpp
+++ b/test/test_roscpp/test/src/missing_call_to_shutdown_impl.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* Author: David Gossow */
+
+/*
+ * Call ros::start() explicitly, but never call ros::shutdown().
+ * ros::shutdown should be called automatically in this case.
+ */
+
+#include <cstdlib>
+#include <ros/ros.h>
+
+namespace ros
+{
+namespace console
+{
+extern bool g_shutting_down;
+}
+}
+
+namespace
+{
+
+enum TestId
+{
+  InitOnly = 0,
+  InitAndStart = 1
+};
+
+TestId test_id = InitOnly;
+
+void atexitCallback()
+{
+  bool hasError = false;
+
+  if (ros::ok())
+  {
+    std::cerr << "ERROR: ros::ok() returned true!" << std::endl;
+    hasError = true;
+  }
+  if (!ros::isShuttingDown())
+  {
+    std::cerr << "ERROR: ros::isShuttingDown() returned false!" << std::endl;
+    hasError = true;
+  }
+  if (ros::isStarted())
+  {
+    std::cerr << "ERROR: ros::isStarted() returned true!" << std::endl;
+    hasError = true;
+  }
+
+  if (!ros::isInitialized())
+  {
+    std::cerr << "ERROR: ros::isInitialized() returned false, although ros::init was called!" << std::endl;
+    std::cerr << "Due to legacy reasons, it should return true, even after ROS has been de-initialized." << std::endl;
+    hasError = true;
+  }
+
+  if (!ros::console::g_shutting_down)
+  {
+    std::cerr << "ERROR: ros::console::g_shutting_down returned false, but it should have been automatically shut down." << std::endl;
+    hasError = true;
+  }
+
+  if (hasError)
+  {
+    std::_Exit(1);
+  }
+}
+}
+
+int
+main(int argc, char** argv)
+{
+  if ( argc > 1 )
+  {
+    test_id = static_cast<TestId>(atoi(argv[1]));
+  }
+
+  // Register atexit callbak which will be executed after ROS has been de-initialized.
+  if (atexit(atexitCallback) != 0)
+  {
+    std::cerr << "Failed to register atexit callback." << std::endl;
+    return 1;
+  }
+
+  switch (test_id)
+  {
+    case InitOnly:
+      // Test case 0: Call ros::init() explicitly, but never call ros::shutdown().
+      // ros::deInit should be called automatically in this case.
+      ros::init(argc, argv, "missing_call_to_shutdown" );
+      break;
+    case InitAndStart:
+      // Test case 1: Call ros::init() and ros::start() explicitly, but never call ros::shutdown().
+      // ros::shutdown should be called automatically in this case.
+      ros::init(argc, argv, "missing_call_to_shutdown" );
+      ros::start();
+      break;
+    default:
+      std::cerr << "Invalid test id: " << test_id << std::endl;
+      return 1;
+      break;
+  }
+
+  if (!ros::ok())
+  {
+    std::cerr << "Failed to start ROS." << std::endl;
+    return 1;
+  }
+  
+  return 0;
+}


### PR DESCRIPTION
## Summary

In the case that user code calls `ros::start` explicitly, the `ros::NodeHandle` class will not call `ros::shutdown` when the last instance is destroyed.

In order to make sure that the program can exit error-free nonetheless, currently `ros::init` registers the ``ros::atexitCallback`` callback to be executed after the user's `main` has finished, which performs clean-up of resources that were set up in `init`.

However, `atexitCallback` is registered _before_ the various ROS singletons are instantiated, which means that it is called _after_ the singletons have been destroyed.

[This PR](https://github.com/ros/ros_comm/pull/871) addressed most of the problem, however with one remaining issue: `ros::start` creates a thread, which will continue to execute after singletons have been destroyed and until `ros::atexitCallback` is called. So, in rare circumstances, this thread can access singleton objects after they have been destroyed.

This PR fixes the issue by ensuring that `ros::shutdown` is called after `main` has returned, but _before_ singletons are destroyed.

## Detailed Description

We came across a quite rare crash of ROS nodes during shutdown at my company with the following backtrace:

main thread:
```
#0  0x00007f0076baead3 in futex_wait_cancelable (private=<optimized out>, expected=0, futex_word=0x29708d8) at ../sysdeps/unix/sysv/linux/futex-internal.h:88
#1  0x00007f0076baead3 in __pthread_cond_wait_common (abstime=0x0, mutex=0x2970888, cond=0x29708b0) at pthread_cond_wait.c:502
#2  0x00007f0076baead3 in __pthread_cond_wait (cond=0x29708b0, mutex=0x2970888) at pthread_cond_wait.c:655
#3  0x00007f00773f1b5d in boost::condition_variable::wait(boost::unique_lock<boost::mutex>&) () at /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.65.1
#4  0x00007f00773e9d14 in boost::thread::join_noexcept() () at /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.65.1
#5  0x00007f00ae60784d in ros::shutdown() () at /opt/ros/melodic/lib/libroscpp.so
#6  0x00007f00ae607a49 in ros::atexitCallback() () at /opt/ros/melodic/lib/libroscpp.so
#7  0x00007f007362f031 in __run_exit_handlers (status=0, listp=0x7f00739d7718 <__exit_funcs>, run_list_atexit=run_list_atexit@entry=true, run_dtors=run_dtors@entry=true) at exit.c:108
#8  0x00007f007362f12a in __GI_exit (status=<optimized out>) at exit.c:139
#9  0x00007f007360dc8e in __libc_start_main (main=0x419a90 <main(int, char**)>, argc=27, argv=0x7ffdf94ccdc8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7ffdf94ccdb8) at ../csu/libc-start.c:344
#10 0x00000000004176ca in _start () at /usr/include/boost/asio/ssl/impl/error.ipp:89
```

second thread:
```
terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
  what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
Stack trace (most recent call last) in thread 245:
#18   Object "", at 0xffffffffffffffff, in 
#17   Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7fae78dc561e, in clone
#16   Object "/lib/x86_64-linux-gnu/libpthread.so.0", at 0x7fae7c25f6da, in start_thread
#15   Object "/usr/lib/x86_64-linux-gnu/libboost_thread.so.1.65.1", at 0x7fae7caa0bcc, in boost::this_thread::interruption_requested()
#14   Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3cbdef0, in ros::internalCallbackQueueThreadFunc()
#13   Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3c7e2fa, in ros::CallbackQueue::callAvailable(ros::WallDuration)
#12   Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3c7c558, in ros::CallbackQueue::callOneCB(ros::CallbackQueue::TLS*)
#11   Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3cb267a, in ros::TimerManager<ros::SteadyTime, ros::WallDuration, ros::SteadyTimerEvent>::TimerQueueCallback::call()
#10   Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3cad644, in ros::TransportPublisherLink::onRetryTimer(ros::SteadyTimerEvent const&)
#9    Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3ca32c2, in ros::TransportTCP::connect(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)
#8    Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3ca1e34, in ros::TransportTCP::initializeSocket()
#7    Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3cdbb31, in ros::PollSet::addSocket(int, boost::function<void (int)> const&, boost::shared_ptr<ros::Transport> const&)
#6    Object "/opt/ros/melodic/lib/libroscpp.so", at 0x7faeb3c2a368, in void boost::throw_exception<boost::lock_error>(boost::lock_error const&)
#5    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7fae796ddd53, in __cxa_throw
#4    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7fae796ddb20, in std::terminate()
#3    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7fae796ddae5, in std::rethrow_exception(std::__exception_ptr::exception_ptr)
#2    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7fae796d7956, in 
#1    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7fae78ce47f0, in abort
#0    Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7fae78ce2e87, in gsignal
Aborted (Signal sent by tkill() 231 0)
```

After digging through the source code, I found that this is indeed a bug in ROS itself, which happens in the following circumstances:
* The user code calls `ros::start`, but not `ros::shutdown`.
* There is some TCP transport publisher link which is dropped and happens to try to reconnect after the program's `main()` has ended

In this case, the sequence that leads to the crash is the following:
* [In `ros::init()`, the `ros::atexitCallback` is registered to be called after `main()` has ended.](https://github.com/boostorg/thread/blob/boost-1.71.0/include/boost/thread/detail/thread.hpp#L248-L259)
* In `ros::start()`, [Singletons are created](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/init.cpp#L321-L330) and [a thread which calls `internalCallbackQueueThreadFunc` is started](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/init.cpp#L410), [which calls callbacks from `ros::g_internal_callback_queue`](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/init.cpp#L276-L286).
* [TransportPublisherLink creates a timer which calls `TransportPublisherLink::onRetryTimer`](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/transport_publisher_link.cpp#L285-L287) and pushes this onto `ros::g_internal_callback_queue`, [accessed via ros::getInternalCallbackQueue()](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/transport_publisher_link.cpp#L255).

Once the user's `main()` function exits:
* g_internal_queue_thread is destructed, [which results in the underlying thread being detached](https://www.boost.org/doc/libs/1_79_0/doc/html/thread/thread_management.html#thread.thread_management.thread.destructor), i.e. `internalCallbackQueueThreadFunc` continues to run
* all singletons are destructed, including PollManager.
* `atexitCallback` is called and calls `ros::shutdown`, which sets `g_shutting_down` to true, signaling the `internalCallbackQueueThreadFunc` to exit, and waits for the thread to join.
* The `internalCallbackQueueThreadFunc` thread however [has already entered the call to `queue->callAvailable`](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/init.cpp#L284), which in turn calls `TransportPublisherLink::onRetryTimer`.
* [`TransportPublisherLink::onRetryTimer` calls `PollManager::instance()`](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/transport_publisher_link.cpp#L233), which returns the address of the destructed singleton object
* [The following call to `TransportTCP::connect`](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/transport_publisher_link.cpp#L234) results in an exception, since it tries to lock an already-destructed mutex.

The fix in this PR works around this problem by making sure that the `internalCallbackQueueThreadFunc` thread is ended before singletons are destroyed.

It does this by stopping the thread in the destructor of a `InternalQueueJoiningThread` instance which is declared as a static variable inside of the `initInternalQueueJoiningThread` function.

This function is called after the singleton instances (which are also static function-scope variables) are created, which means that the compiler must generate code that destroys the `InternalQueueJoiningThread` object, and thus joins the thread, before the other Singletons are destroyed.

Note that, as mentioned above, init.cpp registers [`atexitCallback`](https://github.com/ros/ros_comm/blob/noetic-devel/clients/roscpp/src/libros/init.cpp#L146-L154) specifically for the case that `ros::shutdown` was not called by the user code. However, it fails to address the issue described above since it is called after singletons have been destroyed but before the `internalCallbackQueueThreadFunc` thread has ended.

This was meant to be addressed by [this PR,](https://github.com/ros/ros_comm/pull/871), but the fix was incomplete.