### PR TITLE
Use atomic bool instead of volatile uint32_t

### DIFF
--- a/clients/roscpp/include/ros/connection.h
+++ b/clients/roscpp/include/ros/connection.h
@@ -40,10 +40,11 @@
 
 #include <boost/signals2.hpp>
 
-#include <boost/function.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/shared_array.hpp>
+#include <boost/atomic.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <boost/function.hpp>
+#include <boost/shared_array.hpp>
+#include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 
@@ -230,9 +231,7 @@ private:
   /// Flag telling us if we're in the middle of a read (mostly to avoid recursive deadlocking)
   bool reading_;
   /// flag telling us if there is a read callback
-  /// 32-bit loads and stores are atomic on x86 and PPC... TODO: use a cross-platform atomic operations library
-  /// to ensure this is done atomically
-  volatile uint32_t has_read_callback_;
+  boost::atomic<bool> has_read_callback_;
 
   /// Buffer to write from
   boost::shared_array<uint8_t> write_buffer_;
@@ -248,9 +247,7 @@ private:
   /// Flag telling us if we're in the middle of a write (mostly used to avoid recursive deadlocking)
   bool writing_;
   /// flag telling us if there is a write callback
-  /// 32-bit loads and stores are atomic on x86 and PPC... TODO: use a cross-platform atomic operations library
-  /// to ensure this is done atomically
-  volatile uint32_t has_write_callback_;
+  boost::atomic<bool> has_write_callback_;
 
   /// Function to call when the outgoing header has finished writing
   WriteFinishedFunc header_written_callback_;

--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -50,11 +50,11 @@ Connection::Connection()
 , read_filled_(0)
 , read_size_(0)
 , reading_(false)
-, has_read_callback_(0)
+, has_read_callback_(false)
 , write_sent_(0)
 , write_size_(0)
 , writing_(false)
-, has_write_callback_(0)
+, has_write_callback_(false)
 , sending_header_error_(false)
 {
 }
@@ -137,7 +137,7 @@ void Connection::readTransport()
         uint32_t size = read_size_;
         read_size_ = 0;
         read_filled_ = 0;
-        has_read_callback_ = 0;
+        has_read_callback_ = false;
 
         if (callback)
         {
@@ -170,7 +170,7 @@ void Connection::readTransport()
       read_buffer_.reset();
       read_size_ = 0;
       read_filled_ = 0;
-      has_read_callback_ = 0;
+      has_read_callback_ = false;
 
       ROS_DEBUG_NAMED("superdebug", "Calling read callback");
       callback(shared_from_this(), buffer, size, true);
@@ -234,7 +234,7 @@ void Connection::writeTransport()
         write_buffer_ = boost::shared_array<uint8_t>();
         write_sent_ = 0;
         write_size_ = 0;
-        has_write_callback_ = 0;
+        has_write_callback_ = false;
       }
 
       ROS_DEBUG_NAMED("superdebug", "Calling write callback");
@@ -277,7 +277,7 @@ void Connection::read(uint32_t size, const ReadFinishedFunc& callback)
     read_buffer_ = boost::shared_array<uint8_t>(new uint8_t[size]);
     read_size_ = size;
     read_filled_ = 0;
-    has_read_callback_ = 1;
+    has_read_callback_ = true;
   }
 
   transport_->enableRead();
@@ -302,7 +302,7 @@ void Connection::write(const boost::shared_array<uint8_t>& buffer, uint32_t size
     write_buffer_ = buffer;
     write_size_ = size;
     write_sent_ = 0;
-    has_write_callback_ = 1;
+    has_write_callback_ = true;
   }
 
   transport_->enableWrite();


### PR DESCRIPTION
- Use `boost::atomic<bool>` instead of `volatile uint32_t`
- Replaced int literals with bool literals
- Fixed `#include` order