### PR TITLE
Fix errors for multimachine communications: `paramiko.ssh_exception.SSHException: key cannot be used for signing` or `No existing session`

### DIFF
--- a/tools/roslaunch/src/roslaunch/remoteprocess.py
+++ b/tools/roslaunch/src/roslaunch/remoteprocess.py
@@ -192,7 +192,7 @@ class SSHChildROSLaunchProcess(roslaunch.server.ChildROSLaunchProcess):
                 if password is None: #use SSH agent
                     ssh.connect(address, port, username, timeout=TIMEOUT_SSH_CONNECT, key_filename=identity_file)
                 else: #use SSH with login/pass
-                    ssh.connect(address, port, username, password, timeout=TIMEOUT_SSH_CONNECT)
+                    ssh.connect(address, port, username, password, timeout=TIMEOUT_SSH_CONNECT, allow_agent=False)
             except paramiko.BadHostKeyException:
                 _logger.error(traceback.format_exc())
                 err_msg =  "Unable to verify host key for remote computer[%s:%s]"%(address, port)


### PR DESCRIPTION
Fix errors for multimachine communications: `paramiko.ssh_exception.SSHException: key cannot be used for signing` or `No existing session` . The latest `paramiko` change `allow_agent` to `True` as default, which will break the `roslaunch machine` using SSH with `login/pass`