### PR TITLE
[ROS-O] Fix rostest target names when build dir is inside source dir

### DIFF
--- a/tools/rostest/cmake/rostest-extras.cmake.em
+++ b/tools/rostest/cmake/rostest-extras.cmake.em
@@ -33,8 +33,8 @@ function(add_rostest file)
 
   # strip PROJECT_SOURCE_DIR and PROJECT_BINARY_DIR from absolute filename to get unique test name (as rostest does it internally)
   set(_testname ${_file_name})
-  rostest__strip_prefix(_testname "${PROJECT_SOURCE_DIR}/")
   rostest__strip_prefix(_testname "${PROJECT_BINARY_DIR}/")
+  rostest__strip_prefix(_testname "${PROJECT_SOURCE_DIR}/")
 
   # to support registering the same test with different ARGS
   # append the args to the test name


### PR DESCRIPTION
It's a common approach to build cmake projects in a `build` folder in the project root. It's just that `rosbuild`/`catkin` does not do it, so the changed name never mattered.

When you try, the target name includes another `build_` string and there is *exactly one* package in the whole ecosystem that relies on this not happening: https://github.com/ros/ros_comm/blob/845f74602c7464e08ef5ac6fd9e26c97d0fe42c9/test/test_rosbag/bag_migration_tests/CMakeLists.txt#L87-L103 