### PR TITLE
Fix segfault with default-constructed rosbag::ChunkedFile::swap

### DIFF
--- a/tools/rosbag_storage/src/chunked_file.cpp
+++ b/tools/rosbag_storage/src/chunked_file.cpp
@@ -248,12 +248,16 @@ void ChunkedFile::swap(ChunkedFile& other) {
     FileAccessor::setFile(*other.stream_factory_->getStream(compression::LZ4), &other);
 
     swap(read_stream_, other.read_stream_);
-    FileAccessor::setFile(*read_stream_, this);
-    FileAccessor::setFile(*other.read_stream_, &other);
+    if (read_stream_)
+      FileAccessor::setFile(*read_stream_, this);
+    if (other.read_stream_)
+      FileAccessor::setFile(*other.read_stream_, &other);
 
     swap(write_stream_, other.write_stream_);
-    FileAccessor::setFile(*write_stream_, this);
-    FileAccessor::setFile(*other.write_stream_, &other);
+    if (write_stream_)
+      FileAccessor::setFile(*write_stream_, this);
+    if (other.write_stream_)
+      FileAccessor::setFile(*other.write_stream_, &other);
 }
 
 } // namespace rosbag


### PR DESCRIPTION
Only update the read and write stream if their pointers are not null.

Closes #2362.