### PR TITLE
[windows] Remove python2 specific hack

### DIFF
--- a/tools/roslaunch/env-hooks/10.roslaunch.bat
+++ b/tools/roslaunch/env-hooks/10.roslaunch.bat
@@ -1,15 +1,5 @@
 REM roslaunch/env-hooks/10.roslaunch.bat
 
-:: workaround Python 2 xmlrpc performance issue
-:: https://stackoverflow.com/questions/2617615/slow-python-http-server-on-localhost
-:: use IP address instead to avoid unnecessary DNS lookups.
 if "%ROS_MASTER_URI%" == "" (
-  set ROS_MASTER_URI=http://127.0.0.1:11311
-)
-
-:: it is discourage to set ROS_IP and ROS_HOSTNAME at the same time.
-if "%ROS_IP%" == "" (
-  if "%ROS_HOSTNAME%" == "" (
-    set ROS_IP=127.0.0.1
-  )
+  set ROS_MASTER_URI=http://localhost:11311
 )


### PR DESCRIPTION
This PR https://github.com/ros/ros_comm/pull/1872 made windows act differently than linux because of a specific python 2 delay doing unnecessary DNS checks for localhost.

The underlying code in python is different for python3, so the hack should no longer necessary. Given that, it's better to reunify the codebase.

Fixes 
https://github.com/RoboStack/ros-noetic/issues/430

Standard workflow is source workspace/catkin install and then export environment variables. The current hack makes that workflow not work on windows.