### PR TITLE
Improve polling for available file descriptors

### DIFF
--- a/utilities/xmlrpcpp/src/XmlRpcServer.cpp
+++ b/utilities/xmlrpcpp/src/XmlRpcServer.cpp
@@ -30,26 +30,6 @@ XmlRpcServer::XmlRpcServer()
     _accept_error(false),
     _accept_retry_time_sec(0.0)
 {
-#if !defined(_WINDOWS)
-  struct rlimit limit = { .rlim_cur = 0, .rlim_max = 0 };
-  unsigned int max_files = 1024;
-
-  if(getrlimit(RLIMIT_NOFILE, &limit) == 0) {
-    max_files = limit.rlim_max;
-    if( limit.rlim_max == RLIM_INFINITY ) {
-      max_files = 0;
-    }
-  } else {
-    XmlRpcUtil::error("Could not get open file limit: %s", strerror(errno));
-  }
-  pollfds.resize(max_files);
-  for(unsigned int i=0; i<max_files; i++) {
-    // Set up file descriptor query for all events.
-    pollfds[i].fd = i;
-    pollfds[i].events = POLLIN | POLLPRI | POLLOUT;
-  }
-#endif
-
   // Ask dispatch not to close this socket if it becomes unreadable.
   setKeepOpen(true);
 }
@@ -233,13 +213,31 @@ bool XmlRpcServer::enoughFreeFDs() {
     if( limit.rlim_max == RLIM_INFINITY ) {
       return true;
     }
+  } else {
+    // The man page for getrlimit says that it can fail if the requested
+    // resource is invalid or the second argument is invalid. I'm not sure
+    // either of these can actually fail in this code, but it's better to
+    // check.
+    XmlRpcUtil::error("XmlRpcServer::enoughFreeFDs: Could not get open file "
+                      "limit, getrlimit() failed: %s", strerror(errno));
+    return false;
+  }
 
-    // Poll the available file descriptors.
-    // The POSIX specification guarantees that rlim_cur will always be less or
-    // equal to the process's initial rlim_max, so we don't need an additional
-    // bounds check here.
-    if(poll(&pollfds[0], limit.rlim_cur, 1) >= 0) {
-      for(rlim_t i=0; i<limit.rlim_cur; i++) {
+  // List of all file descriptors, used for counting open files.
+  pollfds.resize(limit.rlim_cur > FREE_FD_BUFFER ? FREE_FD_BUFFER : limit.rlim_cur);
+
+  // Poll the available file descriptors.
+  // The POSIX specification guarantees that rlim_cur will always be less or
+  // equal to the process's initial rlim_max, so we don't need an additional
+  // bounds check here.
+  for(unsigned long long offset=0; offset<limit.rlim_cur; offset += FREE_FD_BUFFER) {
+    for(unsigned int i=0; i<pollfds.size(); i++) {
+      // Set up file descriptor query for all events.
+      pollfds[i].fd = i + offset;
+      pollfds[i].events = POLLIN | POLLPRI | POLLOUT;
+    }
+    if(poll(&pollfds[0], pollfds.size(), 1) >= 0) {
+      for(rlim_t i=0; i<pollfds.size(); i++) {
         if(pollfds[i].revents & POLLNVAL) {
           free_fds++;
         }
@@ -254,13 +252,6 @@ bool XmlRpcServer::enoughFreeFDs() {
       XmlRpcUtil::error("XmlRpcServer::enoughFreeFDs: poll() failed: %s",
                         strerror(errno));
     }
-  } else {
-    // The man page for getrlimit says that it can fail if the requested
-    // resource is invalid or the second argument is invalid. I'm not sure
-    // either of these can actually fail in this code, but it's better to
-    // check.
-    XmlRpcUtil::error("XmlRpcServer::enoughFreeFDs: Could not get open file "
-                      "limit, getrlimit() failed: %s", strerror(errno));
   }
 
   return false;


### PR DESCRIPTION
The polling of all file descriptors can take a lot of time especially on modern OSs where each process can open `1<<20` FDs.
This PR addresses this issue and stops polling for FDs once the desired number of available FDs has been found.
The heap memory needed for holding the FDs is also much smaller and no longer persistent throughout the lifetime of the XmlRpcServer.

TL;DR
 - Remove 8MB of memory for each socket created
 - Reduce available file descriptor polling to minimum necessary
   - roughly a 1000 times faster
   - old duration: 34'571'539 ns
   - new duration: 34'464 ns