### PR TITLE
Fix: rospy logger format %f microseconds

### DIFF
--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -284,6 +284,8 @@ class RosStreamHandler(logging.Handler):
             if self._get_time is not None and not self._is_wallclock():
                 time_str += ', %f' % self._get_time()
 
+            time_str = time_str.replace('%f', str(int(time.time() * 1000000) % 1000000).zfill(6))
+
             msg = msg.replace('${time:' + time_format + '}', time_str)
 
         msg += '\n'


### PR DESCRIPTION
With the following `ROSCONSOLE_FORMAT=[${severity}] [${time:%Y-%m-%d %H:%M:%S.%f}] ...` the console output from rospy info function:
```bash
[INFO] [2024-01-16 23:46:27.%f] ...
```

The problem here is, date class does't use "%f" to match microseconds [link](https://docs.python.org/3/library/time.html#time.strftime).

This issue can be addressed to way:
1. Calculate microseconds and replace each "%f" with calculated
2. Change time class to datetime class

This PR uses first aproach. Now output of python node is:
```bash
[INFO] [2024-01-16 23:46:27.920983] ...
```

Aditional info:
- [https://stackoverflow.com/questions/7479777/difference-between-python-datetime-vs-time-modules](https://stackoverflow.com/questions/7479777/difference-between-python-datetime-vs-time-modules)
- [https://stackoverflow.com/questions/7588511/format-a-datetime-into-a-string-with-milliseconds](https://stackoverflow.com/questions/7588511/format-a-datetime-into-a-string-with-milliseconds)
- [https://docs.python.org/3/library/time.html](https://docs.python.org/3/library/time.html)