### PR TITLE
properly shutdown xml rpc server

### DIFF
--- a/tools/rosgraph/src/rosgraph/xmlrpc.py
+++ b/tools/rosgraph/src/rosgraph/xmlrpc.py
@@ -229,8 +229,8 @@ class XmlRpcNode(object):
             if handler:
                 handler._shutdown(reason)
             if server:
-                server.socket.close()
                 server.server_close()
+                server.shutdown()
                 
     def start(self):
         """


### PR DESCRIPTION
stop CPU usage spike when a rospy node receives a signals.SIGINT interrupt but before it terminates the process (e.g. pressing CTRL+C while the node is sleeping due to a rospy.sleep() call no longer sends CPU usage of a core to 100%)

should also fix https://github.com/ros/ros_comm/issues/2238