### PR TITLE
Fixed ROSCONSOLE_FORMAT with microseconds

### DIFF
--- a/tools/rosgraph/src/rosgraph/roslogging.py
+++ b/tools/rosgraph/src/rosgraph/roslogging.py
@@ -255,7 +255,7 @@ class RosStreamHandler(logging.Handler):
         while '${walltime:' in msg:
             tag_end_index = msg.index('${walltime:') + len('${walltime:')
             time_format = msg[tag_end_index: msg.index('}', tag_end_index)]
-            time_str = time.strftime(time_format)
+            time_str = datetime.datetime.now().strftime(time_format)
             msg = msg.replace('${walltime:' + time_format + '}', time_str)
 
         msg = msg.replace('${thread}', str(record.thread))
@@ -279,7 +279,7 @@ class RosStreamHandler(logging.Handler):
         while '${time:' in msg:
             tag_end_index = msg.index('${time:') + len('${time:')
             time_format = msg[tag_end_index: msg.index('}', tag_end_index)]
-            time_str = time.strftime(time_format)
+            time_str = datetime.datetime.now().strftime(time_format)
 
             if self._get_time is not None and not self._is_wallclock():
                 time_str += ', %f' % self._get_time()

--- a/tools/rosgraph/test/test_roslogging.py
+++ b/tools/rosgraph/test/test_roslogging.py
@@ -47,7 +47,7 @@ os.environ['ROSCONSOLE_FORMAT'] = ' '.join([
     '${severity}',
     '${message}',
     '${walltime}',
-    '${walltime:%Y-%m-%d %H:%M:%S}',
+    '${walltime:%Y-%m-%d %H:%M:%S.%f}',
     '${thread}',
     '${logger}',
     '${file}',
@@ -55,7 +55,7 @@ os.environ['ROSCONSOLE_FORMAT'] = ' '.join([
     '${function}',
     '${node}',
     '${time}',
-    '${time:%Y-%m-%d %H:%M:%S}',
+    '${time:%Y-%m-%d %H:%M:%S.%f}',
 ])
 rosgraph.roslogging.configure_logging('test_rosgraph', logging.INFO)
 loginfo = logging.getLogger('rosout').info
@@ -113,7 +113,7 @@ try:
                 'INFO',
                 'on ' + loc,
                 r'[0-9]*\.[0-9]*',
-                r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
+                r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}',
                 '[0-9]*',
                 'rosout',
                 re.escape(this_file),
@@ -122,7 +122,7 @@ try:
                 # depending if rospy.get_name() is available
                 '(/unnamed|<unknown_node_name>)',
                 r'[0-9]*\.[0-9]*',
-                r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}',
+                r'[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}',
             ])
             assert_regexp_matches(lout.getvalue().splitlines()[i], log_out)
 


### PR DESCRIPTION
Currently, using the `%f` modifier for microseconds in `ROSCONSOLE_FORMAT` only works for C++ nodes. Python nodes do not interpret it:

```
$ export ROSCONSOLE_FORMAT='[${severity}] [${time:%d/%m/%Y %T.%f}] [${node}]: ${message}'

$ rosrun joint_state_publisher_gui joint_state_publisher_gui  # Python node
[INFO] [20/02/2024 15:19:57.%f, 0.000000] [/joint_state_publisher_gui]: Centering

$ rosrun tf2_ros static_transform_publisher 0 0 0 0 0 0 a b  # C++ node
[ INFO] [20/02/2024 14:41:05.796267] [/static_transform_publisher_1708440065774087215]: Spinning until killed publishing a to b
```

That is because the Python part calls `time.strftime()`, which uses the integer seconds. If, on the other hand, `datetime` is used, it uses a fractional seconds representation and is this [capable of printing the microseconds](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).

This PR fixes the issue by switching to `datetime` objects. It also updates the unit test to test the feature.