### PR TITLE
Fix bookkeeping of ongoing calls for recursive calls to CallbackQueue::callAvailable()

### DIFF
--- a/clients/roscpp/src/libros/callback_queue.cpp
+++ b/clients/roscpp/src/libros/callback_queue.cpp
@@ -334,9 +334,8 @@ void CallbackQueue::callAvailable(ros::WallDuration timeout)
     bool was_empty = tls->callbacks.empty();
 
     tls->callbacks.insert(tls->callbacks.end(), callbacks_.begin(), callbacks_.end());
+    calling_ += callbacks_.size();
     callbacks_.clear();
-
-    calling_ += tls->callbacks.size();
 
     if (was_empty)
     {


### PR DESCRIPTION
While investigating a segmentation fault in one of our applications, and while working on #2377 yesterday, I found another small possible bug in the implementation of `ros::CallbackQueue::callAvailable()` in the way it keeps track of how many callbacks are currently being executed in any spinner thread, namely the `calling_` variable.

When copying over pending calls to the thread-local callback queue held in `tls->callbacks`, the `calling_` member was not updated correctly with the number of added callbacks if `tls->callbacks` was not empty before. This may be the case if `callAvailable()` is called recursively, e.g. from within another callback.

The issue should only affect the `calling_` member and `empty()` and `isEmpty()` member functions, which apparently are unused within roscpp itself, but may be used by external code.