### PR TITLE
rosnode: Fix unclosed socket in rosnode_ping command

### DIFF
--- a/tools/rosnode/src/rosnode/__init__.py
+++ b/tools/rosnode/src/rosnode/__init__.py
@@ -359,6 +359,7 @@ def rosnode_ping(node_name, max_count=None, verbose=False, skip_cache=False):
                             if verbose:
                                 print("node url has changed from [%s] to [%s], retrying to ping"%(node_api, new_node_api))
                             node_api = new_node_api
+                            node.__exit__()
                             node = ServerProxy(node_api)
                             continue
                         print("ERROR: connection refused to [%s]"%(node_api), file=sys.stderr)
@@ -373,7 +374,9 @@ def rosnode_ping(node_name, max_count=None, verbose=False, skip_cache=False):
             time.sleep(1.0)
     except KeyboardInterrupt:
         pass
-            
+    finally:
+        node.__exit__()
+
     if verbose and count > 1:
         print("ping average: %fms"%(acc/count))
     return True


### PR DESCRIPTION
Fixes https://github.com/ros/ros_comm/issues/2176

Unfortunately due to the structure of the code and the fact that `ServerProxy` is not a mutable object, using the `with` context manager is not really feasible so this seems to be the feasible solution.